### PR TITLE
Fixes #66

### DIFF
--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -31,7 +31,7 @@ parser.command('run')
         if(err instanceof Error){
           throw err;
         }
-        tessel.logs.warn(err);
+        tessel.logs.err(err);
         process.exit(1);
       });
   })

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -149,7 +149,9 @@ function getTessel(opts) {
           connection = connections.selected;
         }
 
+        // If this is a remote device and the user isn't authorized
         if (connection.connectionType === "LAN" && !connection.authorized) {
+          // Reject the request and provide a helpful error message
           return reject("Not authorized to deploy to this device. If you're connecting to Tessel 2 hardware, physically connect via USB and run 'tessel provision'. If you're connecting to a VM, run `tessel key generate` prior to launching the VM.");
         }
 

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -149,6 +149,10 @@ function getTessel(opts) {
           connection = connections.selected;
         }
 
+        if (connection.connectionType === "LAN" && !connection.authorized) {
+          return reject("Not authorized to deploy to this device. If you're connecting to Tessel 2 hardware, physically connect via USB and run 'tessel provision'. If you're connecting to a VM, run `tessel key generate` prior to launching the VM.");
+        }
+
         // Log connection info
         var message = "Connected over " + connection.connectionType + "."
         if (connection.connectionType === 'LAN'){


### PR DESCRIPTION
Previously, you'd get a log telling you that you are connected to a remote device and then a long winded error message telling you that you are actually *not* connected to a remote device:

```
➜  demo  t2 run index.js
INFO Connecting to Tessel...
INFO Connected over LAN. IP ADDRESS: 192.168.1.1
Unhandled rejection Error: Not connected
    at Client.exec (/Users/Jon/Work/technical/t2-cli/node_modules/ssh2/lib/client.js:544:11)
    at LANConnection.exec (/Users/Jon/Work/technical/t2-cli/lib/lan_connection.js:40:12)
...
```

This PR fixes that:
```
# I'm not authorized on the device with this IP address
➜  t2-cli git:(jon-fix-conn) t2 run test/test-deploy-script.js --ip 192.168.128.149
INFO Connecting to Tessel...
ERR! Not authorized to deploy to this device. If you're connecting to Tessel 2 hardware, physically connect via USB and run 'tessel provision'. If you're connecting to a VM, run `tessel key generate` prior to launching the VM.
```