### PR TITLE
Stops renaming if newName and oldName are the same

### DIFF
--- a/lib/tessel/name.js
+++ b/lib/tessel/name.js
@@ -104,7 +104,7 @@ Tessel.prototype.rename = function(opts, callback) {
       if (err) return callback && callback(err);
       // Don't set the new name if it's the same as the old name
       if (oldName == opts.newName) {
-        tessel.logs.info("Name of device is already", oldName);
+        tessel.logs.warn("Name of device is already", oldName);
         callback && callback();
       }
       // Set the name with the provided arg

--- a/lib/tessel/name.js
+++ b/lib/tessel/name.js
@@ -102,6 +102,11 @@ Tessel.prototype.rename = function(opts, callback) {
   else {
     self.getName(function(err, oldName) {
       if (err) return callback && callback(err);
+      // Don't set the new name if it's the same as the old name
+      if (oldName == opts.newName) {
+        tessel.logs.info("Name of device is already", oldName);
+        callback && callback();
+      }
       // Set the name with the provided arg
       self.setName(opts.newName, function(err) {
         if (err) return callback && callback(err);


### PR DESCRIPTION
This was simply to reduce the number of times mdns has to be reset. It's not like this is going to happen all the time, but is something worth avoiding.