### PR TITLE
Removing ip address functionality which isn't used by anything

### DIFF
--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -154,19 +154,6 @@ parser.command('wifi')
           process.exit(1);
       });
     }
-    else if (opts.ip) {
-      controller.printIPAddress(opts)
-        .then(function(info){
-          process.exit(1);
-        })
-        .catch(function (err) {
-          if(err instanceof Error){
-            throw err;
-          }
-          logs.warn(err);
-          process.exit(1);
-      });
-    }
     else if (opts.ssid && opts.password) {
       controller.connectToNetwork(opts)
         .then(function(info){

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -253,24 +253,6 @@ function printAvailableNetworks(opts) {
     });
 }
 
-
-function printIPAddress(opts) {
- // Grab the preferred Tessel
-  return getTessel(opts)
-    .then(function(selectedTessel) {
-    // Fetch it's IP Address
-    // Return to propagate promise
-    return selectedTessel
-      .getIPAddress()
-      // Print the fetched IP
-      .then(printIP)
-    });
-
-  function printIP(ip) {
-    logs.info("IP ADDRESS: ", ip);
-  }
-}
-
 function connectToNetwork(opts) {
   // Grab the preferred Tessel
   return getTessel(opts)
@@ -301,23 +283,6 @@ function printAvailableNetworks(opts) {
 }
 
 
-function printIPAddress(opts) {
- // Grab the preferred Tessel
-  return getTessel(opts)
-    .then(function(selectedTessel) {
-      // Fetch it's IP Address
-      // Return to propagate promise
-      return selectedTessel
-        .getIPAddress()
-        // Print the fetched IP
-        .then(printIP)
-    });
-
-  function printIP(ip) {
-    logs.info("IP ADDRESS: ", ip);
-  }
-}
-
 function connectToNetwork(opts) {
   // Grab the preferred Tessel
   return getTessel(opts)
@@ -334,5 +299,4 @@ module.exports.deployScript = deployScript;
 module.exports.eraseScript = eraseScript;
 module.exports.renameTessel = renameTessel;
 module.exports.printAvailableNetworks = printAvailableNetworks;
-module.exports.printIPAddress = printIPAddress;
 module.exports.connectToNetwork = connectToNetwork;

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -262,27 +262,6 @@ function connectToNetwork(opts) {
   });
 }
 
-function printAvailableNetworks(opts) {
-  // Grab the preferred Tessel
-  return getTessel(opts)
-    .then(function(selectedTessel) {
-    // Run the script on Tessel
-    // Return to propagate promise
-    return selectedTessel.findAvailableNetworks()
-      .then(function(networks) {
-
-        logs.info("Currently visible networks (" + networks.length + "):");
-
-        // Print out networks
-        networks.forEach(function(network) {
-          logs.info("\t", network.ssid, "(" + network.quality + "/" + network.quality_max + ")");
-        });
-        return;
-    });
-  });
-}
-
-
 function connectToNetwork(opts) {
   // Grab the preferred Tessel
   return getTessel(opts)

--- a/lib/tessel/wifi.js
+++ b/lib/tessel/wifi.js
@@ -64,49 +64,6 @@ function compareBySignal(a,b) {
   return 0;
 }
 
-Tessel.prototype.getIPAddress = function() {
-  var self = this;
-  return new Promise(function(resolve, reject) {
-    if (self.connection.connectionType === "LAN") {
-      // Return the IP Address
-      resolve(self.connection.ip)
-    }
-
-    self.connection.exec(commands.connectedNetworkStatus(), function (err, streams) {
-      if (err) reject(err);
-
-      var resultsJSON = '';
-
-      // Gather the results
-      streams.stdout.on('data', function(d) {
-        resultsJSON += d;
-      });
-
-      // Wait for the transfer to finish...
-      streams.stdout.once('end', function() {
-        var status;
-        var someFound = false;
-
-        // Parse the response
-        try {
-          status = JSON.parse(resultsJSON);
-        }
-        catch(err) {
-          self.connection.end(function() {
-            callback && callback(err);
-          });
-        }
-
-        // We've finished, close the connection
-        self.connection.end(function() {
-          // Resolve with address
-          resolve(status['ipv4-address'][0].address);
-        });
-      });
-    });
-  });
-}
-
 Tessel.prototype.connectToNetwork = function(opts) {
   var self = this;
   var ssid = opts.ssid;


### PR DESCRIPTION
This has been bothering me for a while. The `ip` flag to `t2 wifi` (originally to print out the IP Address) is no longer available but the underlying functionality was still sitting in the library. This PR removes it.

It also removes duplicated functionality for the `wifi list` and `print IP` options.