### PR TITLE
Connects to LAN via IP, not hostname.local

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -44,7 +44,7 @@ function listTessels(opts) {
             .reduce(function(validConnections, lan_connection){
               return new Promise(function(resolve) {
                 // Pass connections through for consistency
-                logs.info('LAN CONNECTION ip: ', lan_connection.ip, ', name: ', lan_connection.auth.host.slice(0,-6), ', Authorized: ', lan_connection.authorized);
+                logs.info('LAN CONNECTION ip: ', lan_connection.ip, ', name: ', lan_connection.host.slice(0,-6), ', Authorized: ', lan_connection.authorized);
                 // Add valid connection
                 validConnections.push(lan_connection);
                 // Pass connections through for consistency
@@ -116,13 +116,13 @@ function getTessel(opts) {
       var match;
       // Start with tessel selected by the command `tessel select`
       // TODO: Remove slice and use .name once USB is implemented
-      if(process.env.SELECTED_TESSEL && process.env.SELECTED_TESSEL === connection.auth.host.slice(0,-6) ){
+      if(process.env.SELECTED_TESSEL && process.env.SELECTED_TESSEL === connection.host.slice(0,-6) ){
         match = connection;
       }
 
       // Over ride with command line options
       // Match name
-      if(opts.name && opts.name === connection.auth.host.slice(0,-6)){
+      if(opts.name && opts.name === connection.host.slice(0,-6)){
         match = connection;
       }
 
@@ -140,7 +140,7 @@ function getTessel(opts) {
 
       // Default with no option flags will be taken from environment variable if it exists
       // TODO: Remove slice and use .name once USB is implemented
-      if(process.env.SELECTED_TESSEL && process.env.SELECTED_TESSEL === connection.auth.host.slice(0,-6)){
+      if(process.env.SELECTED_TESSEL && process.env.SELECTED_TESSEL === connection.host.slice(0,-6)){
         collector.default = connection;
       }
 

--- a/lib/lan_connection.js
+++ b/lib/lan_connection.js
@@ -12,7 +12,8 @@ mdns.excludeInterface('0.0.0.0');
 function LANConnection(opts) {
   this.auth = {};
   this.ip = Array.isArray(opts.addresses) ? opts.addresses[0] : opts.host;
-  this.auth.host = opts.host || '';
+  this.host = opts.host || '';
+  this.auth.host = this.ip;
   this.auth.port = opts.port || 22;
   this.auth.username = opts.username || 'root';
   this.auth.privateKey = opts.privateKey || fs.readFileSync(osenv.home() + '/.tessel/id_rsa');


### PR DESCRIPTION
OSes lacking mDNS will also lack the ability to look up Tessels by hostname.local, which is how the SSH connection currently works. Accidentally, we were relying on the host mDNS implementation rather than the JS one.