### PR TITLE
Changes stopRunningScript to do the correct thing.

### DIFF
--- a/lib/tessel/commands.js
+++ b/lib/tessel/commands.js
@@ -5,7 +5,7 @@ module.exports.scanWiFi = function() {
   return ['ubus', 'call', 'iwinfo', 'scan', '{"device":"wlan0"}'];
 };
 module.exports.stopRunningScript = function() {
-  return ['/etc/init.d/tessel-app', 'stop'];
+  return ['killall', 'node'];
 };
 module.exports.deleteFolder = function(filepath) {
   return ['rm', '-rf', filepath];


### PR DESCRIPTION
`stopRunningScript` will not actually kill the node script that is running, since it's not launched through `/etc/init.d/tessel-app`. So killing it will let the node script continue to run, eating memory, hogging up ports, causing havoc.

This is a weak solution but will do the correct thing always.