### PR TITLE
Proper ssh key file modes and callback usage

### DIFF
--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -194,6 +194,7 @@ parser.command('key')
   .callback(function(opts) {
     key(opts)
       .then(function() {
+        logs.info('Key successfully generated.');
         process.exit(0);
       })
       .catch(function(err) {

--- a/lib/key.js
+++ b/lib/key.js
@@ -3,9 +3,9 @@ var provision = require('./tessel/provision'),
 
 module.exports = function() {
   return new Promise(function(resolve, reject) {
-    provision.setupLocal(function(err, created) {
-      if (!created) {
-        reject(new Error('Key already exists. No new key created.'));
+    provision.setupLocal(function(err) {
+      if (err) {
+        reject(err);
       } else {
         resolve();
       }

--- a/lib/tessel/provision.js
+++ b/lib/tessel/provision.js
@@ -15,9 +15,14 @@ Tessel.prototype.provisionTessel = function() {
   var self = this;
   if (self.connection.connectionType === 'USB') {
     // Check if local .tessel file has keypair, if not, put it there
-    setupLocal(function() {
-      // Authorize Tessel for SSH
-      authTessel(self);
+    setupLocal(function(err) {
+      if (err) {
+        logs.err(err);
+        return;
+      } else {
+        // Authorize Tessel for SSH
+        authTessel(self);
+      }
     });
   } else {
     logs.warn('Tessel must be connected with USB to use this command.');
@@ -75,7 +80,7 @@ function setupLocal(callback) {
               return;
             } else {
               if (typeof callback === 'function') {
-                callback(null, true);
+                callback();
               }
             }
           });
@@ -83,7 +88,7 @@ function setupLocal(callback) {
     });
   } else {
     if (typeof callback === 'function') {
-      callback(null, false);
+      callback(new Error('Keys already exist. Refusing to overwrite them.'));
     }
   }
 }

--- a/lib/tessel/provision.js
+++ b/lib/tessel/provision.js
@@ -50,16 +50,17 @@ function setupLocal(callback) {
 
         function createKeyFile(filepath, key, successString, callback) {
           // Put SSH keys for Tessel in that folder
-          fs.writeFile(filepath, key, function(err) {
+          fs.writeFile(filepath, key, {
+            mode: '0600'
+          }, function(err) {
             // Handle any errors that may have occurred
-            if (Tessel._commonErrorHandler(err)) {
+            if (Tessel._commonErrorHandler(err, callback)) {
               return;
+            } else {
+              if (typeof callback === 'function') {
+                callback();
+              }
             }
-
-            fs.chmod(filepath + '.pub', '600', function() {
-              logs.info(successString);
-              callback();
-            });
           });
         }
 
@@ -70,7 +71,7 @@ function setupLocal(callback) {
           ],
           function(err) {
             // Handle any errors that may have occurred
-            if (Tessel._commonErrorHandler(err)) {
+            if (Tessel._commonErrorHandler(err, callback)) {
               return;
             } else {
               if (typeof callback === 'function') {


### PR DESCRIPTION
This tiny PR does three things:
1. Creates both SSH keys with a 0600 file mode
2. Adds a log that the `key generate` function worked (if it did)
3. Properly executes callbacks in the key generation function (which was preventing 2 from working)
4. Changes the `setupLocal` function to call callbacks with `function(err)` where 'Keys already exist` can be an error instead of `function(err, createdBool)`. This method is more consistent with Node.