### PR TITLE
Fix this-binding issue.

### DIFF
--- a/lib/tessel/tessel.js
+++ b/lib/tessel/tessel.js
@@ -10,14 +10,7 @@ function Tessel(connection) {
   // The unique serial number of the device
   this.serialNumber = undefined;
 
-  // Once we get a SIGINT from the console
-  process.once('SIGINT', endConnection);
-
-  this.close = function() {
-    process.removeListener('SIGINT', endConnection);
-  };
-
-  function endConnection() {
+  var endConnection = function() {
     // Kill all of this Tessel's remote processes
     this.connection.end(function() {
       // Exit the process
@@ -25,7 +18,14 @@ function Tessel(connection) {
         process.exit(1);
       });
     });
-  }
+  }.bind(this);
+
+  // Once we get a SIGINT from the console
+  process.once('SIGINT', endConnection);
+
+  this.close = function() {
+    process.removeListener('SIGINT', endConnection);
+  };
 }
 
 // Temporary function until we fully switch over to Promises

--- a/test/unit/tessel.js
+++ b/test/unit/tessel.js
@@ -1,0 +1,51 @@
+var sinon = require('sinon');
+var Tessel = require('../../lib/tessel/tessel');
+
+exports['Tessel (endConnection)'] = {
+  setUp: function(done) {
+
+    this.mockConnection = {
+      end: function() {}
+    };
+
+    this.end = sinon.spy(this.mockConnection, 'end');
+
+    done();
+  },
+
+  tearDown: function(done) {
+    this.end.restore();
+    done();
+  },
+
+  sigintConnection: function(test) {
+    test.expect(1);
+
+    var processOnce = sinon.stub(process, 'once');
+
+    new Tessel(this.mockConnection);
+
+    var endConnection = processOnce.lastCall.args[1];
+
+    endConnection();
+
+    test.equal(this.end.callCount, 1);
+
+    processOnce.restore();
+    test.done();
+  },
+
+  closeConnection: function(test) {
+    test.expect(3);
+
+    var length = process._events.SIGINT.length;
+    var tessel = new Tessel(this.mockConnection);
+
+    test.equal(process._events.SIGINT.length, length + 1);
+    tessel.close();
+
+    test.equal(process._events.SIGINT.length, length);
+    test.equal(this.end.callCount, 0);
+    test.done();
+  },
+};


### PR DESCRIPTION
When either `tessel.close()` is called or `SIGINT` from console, the following error occurs:


```
 t2 run index.js
INFO Connecting to Tessel...
INFO Connected over USB.
INFO Writing index.js to RAM on arnold (14286.336 kB)...
ERR! Unable to deploy code: tar: index.js: time stamp 2015-06-17 20:25:35 is 100537.87948 s in the future

^C/Users/rwaldron/clonez/t2-cli/lib/tessel/tessel.js:22
    this.connection.end(function() {
                   ^
TypeError: Cannot read property 'end' of undefined
    at process.endConnection (/Users/rwaldron/clonez/t2-cli/lib/tessel/tessel.js:22:20)
    at process.g (events.js:199:16)
    at process.emit (events.js:104:17)
    at Signal.wrap.onsignal (node.js:655:46)
```

The issue is caused by `this` being `undefined` inside of the `endConnection`