### PR TITLE
lib: fixed exit codes

### DIFF
--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -127,7 +127,7 @@ parser.command('list')
   .callback(function(opts) {
     controller.listTessels(opts)
       .then(function() {
-        process.exit(1);
+        process.exit(0);
       })
       .catch(function(err) {
         if (err instanceof Error) {
@@ -155,7 +155,7 @@ parser.command('wifi')
     if (opts.list) {
       controller.printAvailableNetworks(opts)
         .then(function() {
-          process.exit(1);
+          process.exit(0);
         })
         .catch(function(err) {
           if (err instanceof Error) {
@@ -167,7 +167,7 @@ parser.command('wifi')
     } else if (opts.ssid && opts.password) {
       controller.connectToNetwork(opts)
         .then(function() {
-          process.exit(1);
+          process.exit(0);
         })
         .catch(function(err) {
           if (err instanceof Error) {

--- a/lib/tessel/deploy.js
+++ b/lib/tessel/deploy.js
@@ -144,7 +144,7 @@ function runScript(t, filepath, ret, entryPoint) {
       // End the connection
       t.connection.end(function() {
         // Exit the process
-        process.exit(1);
+        process.exit(0);
       });
     });
 
@@ -196,7 +196,7 @@ function startPushedScript(t, entryPoint) {
     remoteProcess.once('close', function() {
       logs.info('Running %s...', entryPoint);
       t.connection.end(function() {
-        process.exit(1);
+        process.exit(0);
       });
     });
   });


### PR DESCRIPTION
*fixes #174*

A number of places exited with a faulty code when really nothing went wrong. This should fix that.

I'm a tiny bit uncertain on the two in `lib/tessel/deploy.js`, would be cool if someone could review :sunglasses: 