### PR TITLE
[WIP] Prefer LAN connections

### DIFF
--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -15,7 +15,7 @@ var timeoutOption = {
   abbr: 't',
   metavar: 'TIMEOUT',
   help: 'Set timeout in seconds for scanning for networked tessels',
-  default: 3
+  default: 5
 };
 
 parser.command('provision')
@@ -39,6 +39,9 @@ parser.command('provision')
 parser.command('run')
   .callback(function(opts) {
     controller.deployScript(opts, false)
+      .then(function() {
+        process.exit(0);
+      })
       .catch(function(err) {
         if (err instanceof Error) {
           throw err;

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -128,9 +128,13 @@ Tessel.get = function(opts) {
       }
       // Otherwise
       else {
-        // Run the heuristics to pick which Tessel to use
-        runHeuristics(opts, tessels)
-          .then(logAndFinish);
+        // Combine the same Tessels into one object
+        reconcileTessels(tessels)
+          .then(function(tessels) {
+            // Run the heuristics to pick which Tessel to use
+            runHeuristics(opts, tessels)
+              .then(logAndFinish);
+          });
       }
     }, timeout * 1000);
 
@@ -140,6 +144,48 @@ Tessel.get = function(opts) {
     }
   });
 };
+
+/*
+Takes list of USB and LAN Tessels and merges
+and Tessels that are the same origin with difference
+connection methods.
+
+Assumes tessel.getName has already been called for each.
+*/
+function reconcileTessels(tessels) {
+  return new Promise(function(resolve) {
+    // If there is only one, just return
+    if (tessels.length <= 1) {
+      return resolve(tessels);
+    }
+    // Sort the Tessels by name
+    tessels = _.sortBy(tessels, function(entry) {
+      return entry.name;
+    });
+    // Iterate through all of the Tessels
+    for (var i = 0; i < tessels.length; i++) {
+      var cur = tessels[i];
+      var next = tessels[i + 1];
+      // If this tessel and the next exist
+      if (cur && next) {
+        // If the next Tessel as the same name
+        if (cur.name === next.name) {
+          // Adds the next Tessel's connection to the currents connections
+          cur.connection = next.connection;
+          tessels.splice(i, 1);
+        }
+      }
+      // We are at the end of the array
+      else {
+        // Return the Tessels
+        resolve(tessels);
+      }
+    }
+    // We made it through the entire array because the last item
+    // was spliced out
+    resolve(tessels);
+  });
+}
 
 /*
 0. using the --name flag
@@ -286,9 +332,7 @@ function deployScript(opts, push) {
     .then(function(tessel) {
       // Run the script on Tessel
       return tessel.deployScript(opts, push)
-        .then(function() {
-          tessel.connection.end();
-        });
+        .then(tessel.close);
     });
 }
 

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -67,7 +67,6 @@ Tessel.list = function(opts) {
             resolve();
           });
       }
-
     }
 
     // If a timeout was provided and it's a number
@@ -140,8 +139,13 @@ Tessel.get = function(opts) {
     }, timeout * 1000);
 
     function logAndFinish(tessel) {
-      logs.info(sprintf('Connected to %s over %s', tessel.name, tessel.connection.connectionType));
-      resolve(tessel);
+      if (tessel) {
+        logs.info(sprintf('Connected to %s over %s', tessel.name, tessel.connection.connectionType));
+        resolve(tessel);
+      } else {
+        logs.info('Please specify a Tessel by name');
+        reject();
+      }
     }
   });
 };
@@ -159,32 +163,20 @@ function reconcileTessels(tessels) {
     if (tessels.length <= 1) {
       return resolve(tessels);
     }
-    // Sort the Tessels by name
-    tessels = _.sortBy(tessels, function(entry) {
-      return entry.name;
-    });
-    // Iterate through all of the Tessels
-    for (var i = 0; i < tessels.length; i++) {
-      var cur = tessels[i];
-      var next = tessels[i + 1];
-      // If this tessel and the next exist
-      if (cur && next) {
-        // If the next Tessel as the same name
-        if (cur.name === next.name) {
-          // Adds the next Tessel's connection to the currents connections
-          cur.connection = next.connection;
-          tessels.splice(i, 1);
-        }
+
+    var accounts = {};
+    var reconciled = tessels.reduce(function(accum, tessel) {
+      if (accounts[tessel.name]) {
+        // Updates tessels in accum by reference
+        accounts[tessel.name].connections.push(tessel.connection);
+      } else {
+        accounts[tessel.name] = tessel;
+        accum.push(tessel);
       }
-      // We are at the end of the array
-      else {
-        // Return the Tessels
-        resolve(tessels);
-      }
-    }
-    // We made it through the entire array because the last item
-    // was spliced out
-    resolve(tessels);
+      return accum;
+    }, []);
+
+    resolve(reconciled);
   });
 }
 
@@ -259,7 +251,8 @@ function runHeuristics(opts, tessels) {
       for (var i = 0; i < collector.length; i++) {
         var collectorEntry = collector[i];
         // If this is a name option or environment variable option
-        if (collectorEntry.priority === NAME_OPTION_PRIORITY || collectorEntry.priority === ENV_OPTION_PRIORITY) {
+        if (collectorEntry.priority === NAME_OPTION_PRIORITY ||
+          collectorEntry.priority === ENV_OPTION_PRIORITY) {
           // Return the Tessel and stop searching
           return collectorEntry.tessel;
         }

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -120,6 +120,7 @@ Tessel.get = function(opts) {
       if (tessels.length === 0) {
         // Report it
         reject('No Tessels Found.');
+        return;
       }
       // If there was only one Tessel
       else if (tessels.length === 1) {

--- a/lib/tessel/deploy.js
+++ b/lib/tessel/deploy.js
@@ -45,7 +45,9 @@ Tessel.prototype.deployScript = function(opts, push) {
         else {
           // Push the code into ram
           runScript(self, filepath, ret, opts.entryPoint)
-            .then(resolve);
+            .then(function() {
+              resolve();
+            });
         }
       })
       .catch(reject);

--- a/lib/tessel/deploy.js
+++ b/lib/tessel/deploy.js
@@ -45,9 +45,7 @@ Tessel.prototype.deployScript = function(opts, push) {
         else {
           // Push the code into ram
           runScript(self, filepath, ret, opts.entryPoint)
-            .then(function() {
-              resolve();
-            });
+            .then(resolve);
         }
       })
       .catch(reject);

--- a/lib/tessel/tessel.js
+++ b/lib/tessel/tessel.js
@@ -3,30 +3,61 @@
     param connection: the Connection object that represents the physical comm bus
 */
 function Tessel(connection) {
+  var self = this;
+
+  if (connection === undefined) {
+    throw new Error('Cannot create a Tessel with an undefined connection type');
+  }
   // Set the connection var so we have an abstract interface to relay comms
-  this.connection = connection;
+  self.connections = [connection];
   // The human readable name of the device
-  this.name = undefined;
+  self.name = undefined;
   // The unique serial number of the device
-  this.serialNumber = undefined;
+  self.serialNumber = undefined;
 
   var endConnection = function() {
-    // Kill all of this Tessel's remote processes
-    this.connection.end(function() {
-      // Exit the process
-      process.on('exit', function() {
-        process.exit(1);
+    return new Promise(function(resolve, reject) {
+      // Kill all of this Tessel's remote processes
+      self.connection.end(function(err) {
+        // Exit the process
+        process.on('exit', function(code) {
+          process.exit(code);
+        });
+
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
       });
     });
-  }.bind(this);
+  };
 
   // Once we get a SIGINT from the console
   process.once('SIGINT', endConnection);
 
-  this.close = function() {
+  self.close = function() {
+    // Remove the SIGINT listener because it's not needed anymore
     process.removeListener('SIGINT', endConnection);
+    // End the connection
+    return endConnection();
   };
 }
+
+Object.defineProperty(Tessel.prototype, 'connection', {
+  get: function() {
+    for (var i = 0; i < this.connections.length; i++) {
+      if (this.connections[i].connectionType === 'LAN') {
+        return this.connections[i];
+      }
+    }
+
+    return this.connections[0];
+  },
+  set: function(connection) {
+    this.connections.push(connection);
+  }
+});
 
 // Temporary function until we fully switch over to Promises
 Tessel._commonErrorHandler = function(err, callback) {

--- a/lib/tessel/tessel.js
+++ b/lib/tessel/tessel.js
@@ -20,8 +20,7 @@ function Tessel(connection) {
   var endConnection = function() {
     if (self.closed) {
       return;
-    }
-    else {
+    } else {
       self.closed = true;
     }
     return new Promise(function(resolve, reject) {
@@ -48,7 +47,7 @@ function Tessel(connection) {
     // Remove the SIGINT listener because it's not needed anymore
     if (!self.closed) {
       process.removeListener('SIGINT', endConnection);
-    } 
+    }
     // End the connection
     return endConnection();
   };

--- a/lib/tessel/tessel.js
+++ b/lib/tessel/tessel.js
@@ -14,8 +14,16 @@ function Tessel(connection) {
   self.name = undefined;
   // The unique serial number of the device
   self.serialNumber = undefined;
+  // Whether or not this connection has been ended
+  self.closed = false;
 
   var endConnection = function() {
+    if (self.closed) {
+      return;
+    }
+    else {
+      self.closed = true;
+    }
     return new Promise(function(resolve, reject) {
       // Kill all of this Tessel's remote processes
       self.connection.end(function(err) {
@@ -38,7 +46,9 @@ function Tessel(connection) {
 
   self.close = function() {
     // Remove the SIGINT listener because it's not needed anymore
-    process.removeListener('SIGINT', endConnection);
+    if (!self.closed) {
+      process.removeListener('SIGINT', endConnection);
+    } 
     // End the connection
     return endConnection();
   };

--- a/lib/tessel/tessel.js
+++ b/lib/tessel/tessel.js
@@ -55,16 +55,24 @@ function Tessel(connection) {
 
 Object.defineProperty(Tessel.prototype, 'connection', {
   get: function() {
+    var index = -1;
+
     for (var i = 0; i < this.connections.length; i++) {
-      if (this.connections[i].connectionType === 'LAN') {
-        return this.connections[i];
+      if (index === -1 && this.connections[i].connectionType === 'USB') {
+        index = i;
+      }
+      if (this.connections[i].connectionType === 'LAN' &&
+        this.connections[i].authorized) {
+        index = i;
       }
     }
 
-    return this.connections[0];
-  },
-  set: function(connection) {
-    this.connections.push(connection);
+    // There were no connections to filter, default
+    // the index to 0, which will return `undefined`
+    if (index === -1) {
+      index = 0;
+    }
+    return this.connections[index];
   }
 });
 

--- a/test/common/tessel-simulator.js
+++ b/test/common/tessel-simulator.js
@@ -30,6 +30,7 @@ function TesselSimulator() {
 Tessel.prototype.mockClose = function() {
   this.close();
   process.removeAllListeners('exit');
+  process.removeAllListeners('SIGINT');
 };
 
 module.exports = TesselSimulator;

--- a/test/common/tessel-simulator.js
+++ b/test/common/tessel-simulator.js
@@ -2,10 +2,7 @@ var RemoteProcessSimulator = require('./remote-process-simulator');
 var Tessel = require('../../lib/tessel/tessel');
 
 function TesselSimulator() {
-  var tessel = new Tessel();
-  tessel._rps = new RemoteProcessSimulator();
-
-  tessel.connection = {
+  var simConnection = {
     exec: function(command, callback) {
 
       if (!Array.isArray(command)) {
@@ -24,7 +21,15 @@ function TesselSimulator() {
     }
   };
 
+  var tessel = new Tessel(simConnection);
+  tessel._rps = new RemoteProcessSimulator();
+
   return tessel;
 }
+
+Tessel.prototype.mockClose = function() {
+  this.close();
+  process.removeAllListeners('exit');
+};
 
 module.exports = TesselSimulator;

--- a/test/unit/deploy.js
+++ b/test/unit/deploy.js
@@ -14,7 +14,6 @@ var rimraf = require('rimraf');
 
 exports['Tessel.prototype.deployScript'] = {
   setUp: function(done) {
-
     this.deployScript = sinon.spy(Tessel.prototype, 'deployScript');
     this.stopRunningScript = sinon.spy(commands, 'stopRunningScript');
     this.deleteFolder = sinon.spy(commands, 'deleteFolder');
@@ -38,7 +37,7 @@ exports['Tessel.prototype.deployScript'] = {
   },
 
   tearDown: function(done) {
-    this.tessel.close();
+    this.tessel.mockClose();
     this.deployScript.restore();
     this.stopRunningScript.restore();
     this.deleteFolder.restore();

--- a/test/unit/erase.js
+++ b/test/unit/erase.js
@@ -17,7 +17,7 @@ exports['Tessel.prototype.erase'] = {
   },
 
   tearDown: function(done) {
-    this.tessel.close();
+    this.tessel.mockClose();
     this.erase.restore();
     this.logsWarn.restore();
     this.logsInfo.restore();

--- a/test/unit/name.js
+++ b/test/unit/name.js
@@ -3,6 +3,7 @@ var Tessel = require('../../lib/tessel/tessel');
 var commands = require('../../lib/tessel/commands');
 var logs = require('../../lib/logs');
 var controller = require('../../lib/controller');
+var TesselSimulator = require('../common/tessel-simulator');
 
 exports['Tessel.prototype.rename'] = {
   setUp: function(done) {
@@ -21,17 +22,14 @@ exports['Tessel.prototype.rename'] = {
     this.getHostname = sinon.spy(commands, 'getHostname');
     this.logsWarn = sinon.stub(logs, 'warn', function() {});
     this.logsInfo = sinon.stub(logs, 'info', function() {});
-
-    this.tessel = new Tessel();
-    this.tessel.connection = {
-      exec: sinon.spy()
-    };
+    this.tessel = TesselSimulator();
+    this.tessel.connection.exec = sinon.spy();
 
     done();
   },
 
   tearDown: function(done) {
-    this.tessel.close();
+    this.tessel.mockClose();
     this.isValidName.restore();
     this.renameTessel.restore();
     this.getName.restore();

--- a/test/unit/provision.js
+++ b/test/unit/provision.js
@@ -97,7 +97,7 @@ exports['controller.provisionTessel'] = {
   },
 
   tearDown: function(done) {
-    this.tessel.close();
+    this.tessel.mockClose();
     this.tessel._rps.removeAllListeners();
     this.isProvisioned.restore();
     this.provisionTessel.restore();
@@ -210,7 +210,7 @@ exports['Tessel.prototype.provision'] = {
   },
 
   tearDown: function(done) {
-    this.tessel.close();
+    this.tessel.mockClose();
     this.provision.restore();
     this.setupLocal.restore();
     this.writeFileSpy.restore();

--- a/test/unit/tessel.js
+++ b/test/unit/tessel.js
@@ -86,33 +86,39 @@ exports['Tessel (get)'] = {
 
   noTessels: function(test) {
     // Try to get Tessels but return none
-    Tessel.get({timeout:1})
-    // If 
-    .then(function(tessels) {
-      test.equal(tessels, false, 'Somehow Tessels were returned');
-    })
-    .catch(function(err) {
-      test.equal(typeof err, 'string', 'No error thrown');
-      test.done()
-    })
+    Tessel.get({
+        timeout: 1
+      })
+      // If
+      .then(function(tessels) {
+        test.equal(tessels, false, 'Somehow Tessels were returned');
+      })
+      .catch(function(err) {
+        test.equal(typeof err, 'string', 'No error thrown');
+        test.done();
+      });
   },
 
   oneUSB: function(test) {
     var testConnectionType = 'USB';
     var testName = 'testTessel';
     // Try to get Tessels but return none
-    Tessel.get({timeout:1})
-    // If 
-    .then(function(tessel) {
-      test.equal(tessel.name, testName);
-      test.equal(tessel.connection.connectionType, testConnectionType);
-      test.done()
-    })
-    .catch(function(err) {
-      test.equal(err, undefined, 'A valid USB Tessel was reject upon get.');
-    })
+    Tessel.get({
+        timeout: 1
+      })
+      // If
+      .then(function(tessel) {
+        test.equal(tessel.name, testName);
+        test.equal(tessel.connection.connectionType, testConnectionType);
+        test.done();
+      })
+      .catch(function(err) {
+        test.equal(err, undefined, 'A valid USB Tessel was reject upon get.');
+      });
 
-    var tessel = new Tessel({connectionType: testConnectionType});
+    var tessel = new Tessel({
+      connectionType: testConnectionType
+    });
     tessel.name = testName;
     this.activeSeeker.emit('tessel', tessel);
   },

--- a/test/unit/tessel.js
+++ b/test/unit/tessel.js
@@ -5,7 +5,8 @@ exports['Tessel (endConnection)'] = {
   setUp: function(done) {
 
     this.mockConnection = {
-      end: function() {}
+      end: function() {},
+      close: function() {}
     };
 
     this.end = sinon.spy(this.mockConnection, 'end');
@@ -44,9 +45,57 @@ exports['Tessel (endConnection)'] = {
     tessel.close();
 
     test.equal(processremoveListener.callCount, 1);
-    test.equal(this.end.callCount, 0);
+    test.equal(this.end.callCount, 1);
 
     processremoveListener.restore();
+    test.done();
+  },
+};
+
+exports['Tessel (get)'] = {
+
+  setUp: function(done) {
+    // TODO
+    done();
+  },
+
+  tearDown: function(done) {
+    // TODO
+    done();
+  },
+
+  noTessels: function(test) {
+    // TODO
+    test.done();
+  },
+
+  oneUSB: function(test) {
+    // TODO
+    test.done();
+  },
+
+  multipleUSB: function(test) {
+    // TODO
+    test.done();
+  },
+
+  usbAndNonAuthorizedLANSameTessel: function(test) {
+    // TODO
+    test.done();
+  },
+
+  usbAndAuthorizedLANSameTessel: function(test) {
+    // TODO
+    test.done();
+  },
+
+  manyLAN: function(test) {
+    // TODO
+    test.done();
+  },
+
+  oneUSBManyLAN: function(test) {
+    // TODO
     test.done();
   },
 };

--- a/test/unit/wifi.js
+++ b/test/unit/wifi.js
@@ -17,7 +17,7 @@ exports['Tessel.prototype.findAvailableNetworks'] = {
   },
 
   tearDown: function(done) {
-    this.tessel.close();
+    this.tessel.mockClose();
     this.findAvailableNetworks.restore();
     this.logsWarn.restore();
     this.logsInfo.restore();
@@ -134,7 +134,7 @@ module.exports['Tessel.prototype.connectToNetwork'] = {
     done();
   },
   tearDown: function(done) {
-    this.tessel.close();
+    this.tessel.mockClose();
     this.connectToNetwork.restore();
     this.logsWarn.restore();
     this.logsInfo.restore();


### PR DESCRIPTION
LAN connections are generally faster than USB connections. This PR does a couple of things:

- [x] After collecting available Tessels, combines USB and LAN connections into the same Tessel rather than treating them as distinct.
- [x] When `tessel.connection` is called on a Tessel with both USB and LAN connections, it returns the LAN connection. 
- [x] Fixes process completion and connection closing once deployment completes.
- [x] Adds tests for all of these functionalities.

Fixes #162.