### PR TITLE
lib: work around bug in mdns library

### DIFF
--- a/lib/lan_connection.js
+++ b/lib/lan_connection.js
@@ -130,21 +130,29 @@ Scanner.prototype.start = function() {
       try {
         // Start discovering Tessels
         self.browser.discover();
-      } catch (error) {
-        self.emit('error', error);
+      } catch (err) {
+        process.nextTick(function() {
+          self.emit('error', err);
+        });
       }
     });
 
     // When the browser finds a new device
     self.browser.on('update', function(data) {
-      // Check if it's a Tessel
-      if (_.findIndex(self.discovered, data) > -1) {
-        return;
+      try {
+        // Check if it's a Tessel
+        if (_.findIndex(self.discovered, data) > -1) {
+          return;
+        }
+
+        var connection = new LANConnection(data);
+
+        self.emit('connection', connection);
+      } catch (err) {
+        process.nextTick(function() {
+          self.emit('error', err);
+        });
       }
-
-      var connection = new LANConnection(data);
-
-      self.emit('connection', connection);
     });
   });
 };


### PR DESCRIPTION
This works around kmpm/node-mdns-js#40 which otherwise swallows our errors making debugging a pain. :bug: 