### PR TITLE
lib: provisioning error handling

### DIFF
--- a/lib/tessel/provision.js
+++ b/lib/tessel/provision.js
@@ -56,14 +56,15 @@ function setupLocal(keyPath) {
     logs.info('Creating public and private keys for Tessel authentication...');
     // Generate SSH key
     keygen({}, function(err, out) {
-
+      if (err) {
+        return reject(err);
+      }
 
       var privateKey = out.key;
       var publicKey = out.pubKey;
 
       // Make sure dir exists
       fs.ensureDir(path.dirname(keyPath), function(err) {
-        // Handle any errors that may have occurred
         if (err) {
           return reject(err);
         }
@@ -84,10 +85,10 @@ function setupLocal(keyPath) {
           function(err) {
             if (err) {
               return reject(err);
-            } else {
-              logs.info('SSH Keys written.');
-              resolve();
             }
+
+            logs.info('SSH Keys written.');
+            resolve();
           });
       });
     });
@@ -105,6 +106,10 @@ function authTessel(tessel, filepath) {
         fs.readFile(filepath + '.pub', {
           encoding: 'utf-8'
         }, function(err, pubKey) {
+          if (err) {
+            return reject(err);
+          }
+
           // See if the public key is already in the authFile
           return checkIfKeyInFile(tessel, remoteAuthFile, pubKey)
             .then(function keyNotInFile() {
@@ -122,6 +127,10 @@ function checkAuthFileExists(tessel, authFile) {
   return new Promise(function(resolve, reject) {
     // Ensure that the remote authorized_keys file exists
     tessel.connection.exec(commands.ensureFileExists(authFile), function(err, remoteProc) {
+      if (err) {
+        return reject(err);
+      }
+
       // Var to store incoming error data
       var errBuf = '';
 
@@ -151,7 +160,6 @@ function checkIfKeyInFile(tessel, authFile, pubKey) {
   return new Promise(function(resolve, reject) {
     // Read the public keys from the auth file
     tessel.connection.exec(commands.readFile(authFile), function(err, remoteProc) {
-      // Handle any errors that may have occurred
       if (err) {
         return reject(err);
       }
@@ -200,7 +208,6 @@ function copyKey(tessel, authFile, pubKey) {
   return new Promise(function(resolve, reject) {
     // Open up stdin to the authorized_keys file
     tessel.connection.exec(commands.appendStdinToFile(authFile), function(err, remoteProc) {
-      // Handle any errors that may have occurred
       if (err) {
         return reject(err);
       }


### PR DESCRIPTION
Error handling in provisioning was missing some errors which caused problems in https://github.com/tessel/t2-vm/issues/24#issuecomment-122308893.

[feross/standard](https://github.com/feross/standard) has a rule that detects when you are not handling the `err` parameter in a callback. It's plenty useful, we should have something similar (or maybe switch to standard :+1:).