### PR TITLE
[WIP] Properly closes Tessel connections after each use (Order: 3)

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -1,20 +1,21 @@
-var Tessel = require('./tessel/tessel'),
-  logs = require('./logs'),
-  Promise = require('bluebird'),
-  _ = require('lodash'),
-  discover = require('./discover'),
-  sprintf = require('sprintf-js').sprintf,
-  cp = require('child_process'),
-  async = require('async');
+var Tessel = require('./tessel/tessel');
+var logs = require('./logs');
+var Promise = require('bluebird');
+var _ = require('lodash');
+var discover = require('./discover');
+var sprintf = require('sprintf-js').sprintf;
+var cp = require('child_process');
+var async = require('async');
+var controller = {};
 
 Tessel.list = function(opts) {
+
   return new Promise(function(resolve, reject) {
     // Grab all attached Tessels
     logs.info('Searching for nearby Tessels...');
 
     // Keep a list of all the Tessels we discovered
     var foundTessels = [];
-
     // Start looking for Tessels
     var seeker = new discover.TesselSeeker().start();
 
@@ -31,7 +32,7 @@ Tessel.list = function(opts) {
       }
 
       // Print out details...
-      console.log(sprintf('\t%s\t%s\t%s', tessel.name, tessel.connection.connectionType, note));
+      logs.basic(sprintf('\t%s\t%s\t%s', tessel.name, tessel.connection.connectionType, note));
     });
 
     // Called after CTRL+C or timeout
@@ -48,20 +49,20 @@ Tessel.list = function(opts) {
         reject('No Tessels Found');
       } else if (foundTessels.length === 1) {
         // Close all opened connections and resolve
-        closeTesselConnections(foundTessels)
+        controller.closeTesselConnections(foundTessels)
           .then(resolve);
       }
       // If we have only one Tessel or two Tessels with the same name (just USB and LAN)
       else if (foundTessels.length === 1 ||
         (foundTessels.length === 2 && foundTessels[0].name === foundTessels[1].name)) {
         // Close all opened connections and resolve
-        closeTesselConnections(foundTessels)
+        controller.closeTesselConnections(foundTessels)
           .then(resolve);
       }
       // Otherwise
       else {
         // Figure out which Tessel will be selected
-        runHeuristics(opts, foundTessels)
+        controller.runHeuristics(opts, foundTessels)
           .then(function logSelected(tessel) {
             // Report that selected Tessel to the user
             logs.info('Multiple Tessels found.');
@@ -72,7 +73,7 @@ Tessel.list = function(opts) {
             logs.info('Set default Tessel with environment variable (e.g. \'export TESSEL=bulbasaur\') or use the --name flag.');
 
             // Close all opened connections and resolve
-            closeTesselConnections(foundTessels)
+            controller.closeTesselConnections(foundTessels)
               .then(resolve);
           });
       }
@@ -138,16 +139,17 @@ Tessel.get = function(opts) {
       // Otherwise
       else {
         // Combine the same Tessels into one object
-        reconcileTessels(tessels)
+        controller.reconcileTessels(tessels)
           .then(function(reconciledTessels) {
             tessels = reconciledTessels;
             // Run the heuristics to pick which Tessel to use
-            runHeuristics(opts, tessels)
+            return controller.runHeuristics(opts, tessels)
               .then(logAndFinish);
           });
       }
     }, timeout * 1000);
 
+    // Accesses `tessels` in closure
     function logAndFinish(tessel) {
       // The Tessels that we won't be using should have their connections closed
       var connectionsToClose = tessels;
@@ -155,17 +157,15 @@ Tessel.get = function(opts) {
       if (tessel) {
         logs.info(sprintf('Connected to %s over %s', tessel.name, tessel.connection.connectionType));
         connectionsToClose.splice(tessels.indexOf(tessel), 1);
-        closeTesselConnections(connectionsToClose)
-          .then(function othersClosed() {
+
+        controller.closeTesselConnections(connectionsToClose)
+          .then(function() {
             return resolve(tessel);
           });
-
       } else {
         logs.info('Please specify a Tessel by name');
-        closeTesselConnections(connectionsToClose)
-          .then(function othersClosed() {
-            reject();
-          });
+        controller.closeTesselConnections(connectionsToClose)
+          .then(reject);
       }
     }
   });
@@ -176,7 +176,9 @@ Takes a list of Tessels with connections that
 may or may not be open and closes them
 
 */
-function closeTesselConnections(tessels) {
+
+
+controller.closeTesselConnections = function(tessels) {
   return new Promise(function(resolve, reject) {
     async.each(tessels, function closeThem(tessel, done) {
         // If not an unauthorized LAN Tessel, it's connected
@@ -197,7 +199,7 @@ function closeTesselConnections(tessels) {
         }
       });
   });
-}
+};
 
 /*
 Takes list of USB and LAN Tessels and merges
@@ -206,7 +208,7 @@ connection methods.
 
 Assumes tessel.getName has already been called for each.
 */
-function reconcileTessels(tessels) {
+controller.reconcileTessels = function(tessels) {
   return new Promise(function(resolve) {
     // If there is only one, just return
     if (tessels.length <= 1) {
@@ -227,7 +229,7 @@ function reconcileTessels(tessels) {
 
     resolve(reconciled);
   });
-}
+};
 
 /*
 0. using the --name flag
@@ -238,7 +240,7 @@ function reconcileTessels(tessels) {
 */
 // Called when multiple tessels are found are we need to figure out
 // Which one the user should act upon
-function runHeuristics(opts, tessels) {
+controller.runHeuristics = function(opts, tessels) {
   var NAME_OPTION_PRIORITY = 0;
   var ENV_OPTION_PRIORITY = 1;
   var USB_CONN_PRIORITY = 2;
@@ -338,9 +340,9 @@ function runHeuristics(opts, tessels) {
       // We'll return the highest priority available
       return collector[0].tessel;
     });
-}
+};
 
-function provisionTessel(opts) {
+controller.provisionTessel = function(opts) {
   opts = opts || {};
   return new Promise(function(resolve, reject) {
       if (Tessel.isProvisioned()) {
@@ -364,36 +366,36 @@ function provisionTessel(opts) {
     .then(function(tessel) {
       return tessel.provisionTessel(opts)
         .then(function() {
-          return closeTesselConnections(tessel);
+          return controller.closeTesselConnections(tessel);
         });
     });
-}
+};
 
-function deployScript(opts, push) {
+controller.deployScript = function(opts, push) {
   // Grab the preferred Tessel
   return Tessel.get(opts)
     .then(function(tessel) {
       // Run the script on Tessel
       return tessel.deployScript(opts, push)
         .then(function() {
-          return closeTesselConnections(tessel);
+          return controller.closeTesselConnections(tessel);
         });
     });
-}
+};
 
-function eraseScript(opts) {
+controller.eraseScript = function(opts) {
   // Grab the preferred Tessel
   return Tessel.get(opts)
     .then(function(tessel) {
       // Run the script on Tessel
       return tessel.eraseScript(opts, false)
         .then(function() {
-          return closeTesselConnections(tessel);
+          return controller.closeTesselConnections(tessel);
         });
     });
-}
+};
 
-function renameTessel(opts) {
+controller.renameTessel = function(opts) {
   opts = opts || {};
 
   // Grab the preferred tessel
@@ -412,12 +414,12 @@ function renameTessel(opts) {
     .then(function(tessel) {
       return tessel.rename(opts)
         .then(function() {
-          return closeTesselConnections(tessel);
+          return controller.closeTesselConnections(tessel);
         });
     });
-}
+};
 
-function printAvailableNetworks(opts) {
+controller.printAvailableNetworks = function(opts) {
   // Grab the preferred Tessel
   return Tessel.get(opts)
     .then(function(selectedTessel) {
@@ -432,28 +434,25 @@ function printAvailableNetworks(opts) {
           });
         })
         .then(function() {
-          return closeTesselConnections(selectedTessel);
+          return controller.closeTesselConnections(selectedTessel);
         });
     });
-}
+};
 
-function connectToNetwork(opts) {
+controller.connectToNetwork = function(opts) {
   // Grab the preferred Tessel
   return Tessel.get(opts)
     .then(function(selectedTessel) {
       // Connect to the network with provided options
       return selectedTessel.connectToNetwork(opts)
         .then(function() {
-          return closeTesselConnections(selectedTessel);
+          return controller.closeTesselConnections(selectedTessel);
         });
     });
-}
+};
 
+module.exports = controller;
+
+// Shared exports
 module.exports.listTessels = Tessel.list;
 module.exports.getTessel = Tessel.get;
-module.exports.provisionTessel = provisionTessel;
-module.exports.deployScript = deployScript;
-module.exports.eraseScript = eraseScript;
-module.exports.renameTessel = renameTessel;
-module.exports.printAvailableNetworks = printAvailableNetworks;
-module.exports.connectToNetwork = connectToNetwork;

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -4,7 +4,8 @@ var Tessel = require('./tessel/tessel'),
   _ = require('lodash'),
   discover = require('./discover'),
   sprintf = require('sprintf-js').sprintf,
-  cp = require('child_process');
+  cp = require('child_process'),
+  async = require('async');
 
 Tessel.list = function(opts) {
   return new Promise(function(resolve, reject) {
@@ -46,13 +47,16 @@ Tessel.list = function(opts) {
         // Report the sadness
         reject('No Tessels Found');
       } else if (foundTessels.length === 1) {
-        resolve();
+        // Close all opened connections and resolve
+        closeTesselConnections(foundTessels)
+          .then(resolve);
       }
       // If we have only one Tessel or two Tessels with the same name (just USB and LAN)
       else if (foundTessels.length === 1 ||
         (foundTessels.length === 2 && foundTessels[0].name === foundTessels[1].name)) {
-        // Resolve
-        resolve();
+        // Close all opened connections and resolve
+        closeTesselConnections(foundTessels)
+          .then(resolve);
       }
       // Otherwise
       else {
@@ -66,8 +70,10 @@ Tessel.list = function(opts) {
             }
             // Helpful instructions on how to switch
             logs.info('Set default Tessel with environment variable (e.g. \'export TESSEL=bulbasaur\') or use the --name flag.');
-            // Finish this function
-            resolve();
+
+            // Close all opened connections and resolve
+            closeTesselConnections(foundTessels)
+              .then(resolve);
           });
       }
     }
@@ -133,7 +139,8 @@ Tessel.get = function(opts) {
       else {
         // Combine the same Tessels into one object
         reconcileTessels(tessels)
-          .then(function(tessels) {
+          .then(function(reconciledTessels) {
+            tessels = reconciledTessels;
             // Run the heuristics to pick which Tessel to use
             runHeuristics(opts, tessels)
               .then(logAndFinish);
@@ -142,16 +149,55 @@ Tessel.get = function(opts) {
     }, timeout * 1000);
 
     function logAndFinish(tessel) {
+      // The Tessels that we won't be using should have their connections closed
+      var connectionsToClose = tessels;
+
       if (tessel) {
         logs.info(sprintf('Connected to %s over %s', tessel.name, tessel.connection.connectionType));
-        resolve(tessel);
+        connectionsToClose.splice(tessels.indexOf(tessel), 1);
+        closeTesselConnections(connectionsToClose)
+          .then(function othersClosed() {
+            return resolve(tessel);
+          });
+
       } else {
         logs.info('Please specify a Tessel by name');
-        reject();
+        closeTesselConnections(connectionsToClose)
+          .then(function othersClosed() {
+            reject();
+          });
       }
     }
   });
 };
+
+/*
+Takes a list of Tessels with connections that
+may or may not be open and closes them
+
+*/
+function closeTesselConnections(tessels) {
+  return new Promise(function(resolve, reject) {
+    async.each(tessels, function closeThem(tessel, done) {
+        // If not an unauthorized LAN Tessel, it's connected
+        if (!(tessel.connection.connectionType === 'LAN' &&
+            !tessel.connection.authorized)) {
+          // Close the connection
+          return tessel.close()
+            .then(done, done);
+        } else {
+          done();
+        }
+      },
+      function closed(err) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+  });
+}
 
 /*
 Takes list of USB and LAN Tessels and merges
@@ -318,7 +364,7 @@ function provisionTessel(opts) {
     .then(function(tessel) {
       return tessel.provisionTessel(opts)
         .then(function() {
-          tessel.connection.end();
+          return closeTesselConnections(tessel);
         });
     });
 }
@@ -329,7 +375,9 @@ function deployScript(opts, push) {
     .then(function(tessel) {
       // Run the script on Tessel
       return tessel.deployScript(opts, push)
-        .then(tessel.close);
+        .then(function() {
+          return closeTesselConnections(tessel);
+        });
     });
 }
 
@@ -338,7 +386,10 @@ function eraseScript(opts) {
   return Tessel.get(opts)
     .then(function(tessel) {
       // Run the script on Tessel
-      return tessel.eraseScript(opts, false);
+      return tessel.eraseScript(opts, false)
+        .then(function() {
+          return closeTesselConnections(tessel);
+        });
     });
 }
 
@@ -359,7 +410,10 @@ function renameTessel(opts) {
     })
     .then(Tessel.get.bind(null, opts))
     .then(function(tessel) {
-      return tessel.rename(opts);
+      return tessel.rename(opts)
+        .then(function() {
+          return closeTesselConnections(tessel);
+        });
     });
 }
 
@@ -376,7 +430,9 @@ function printAvailableNetworks(opts) {
           networks.forEach(function(network) {
             logs.info('\t', network.ssid, '(' + network.quality + '/' + network.quality_max + ')');
           });
-          return;
+        })
+        .then(function() {
+          return closeTesselConnections(selectedTessel);
         });
     });
 }
@@ -386,7 +442,10 @@ function connectToNetwork(opts) {
   return Tessel.get(opts)
     .then(function(selectedTessel) {
       // Connect to the network with provided options
-      return selectedTessel.connectToNetwork(opts);
+      return selectedTessel.connectToNetwork(opts)
+        .then(function() {
+          return closeTesselConnections(selectedTessel);
+        });
     });
 }
 

--- a/lib/logs.js
+++ b/lib/logs.js
@@ -13,6 +13,11 @@ function info() {
   console.error(colors.grey('INFO'), util.format.apply(util, arguments));
 }
 
+function basic() {
+  console.log(util.format.apply(util, arguments));
+}
+
 exports.warn = warn;
 exports.err = err;
 exports.info = info;
+exports.basic = basic;

--- a/lib/usb_connection.js
+++ b/lib/usb_connection.js
@@ -153,7 +153,7 @@ USB.Connection.prototype.end = function() {
   return new Promise(function(resolve, reject) {
     // Tell the USB daemon to end all processes active
     // on account of this connection
-    Daemon.deregister(this, function(err) {
+    Daemon.deregister(self, function(err) {
       self._close();
       if (err) {
         reject(err);

--- a/test/unit/controller.js
+++ b/test/unit/controller.js
@@ -1,0 +1,383 @@
+var sinon = require('sinon');
+var _ = require('lodash');
+var controller = require('../../lib/controller');
+var Tessel = require('../../lib/tessel/tessel');
+var Seeker = require('../../lib/discover.js');
+var util = require('util');
+var EventEmitter = require('events').EventEmitter;
+var logs = require('../../lib/logs');
+
+
+function newTessel(options) {
+  var tessel = new Tessel({
+    connectionType: options.type || 'LAN',
+    authorized: options.authorized !== undefined ? options.authorized : true,
+    end: function() {
+      return Promise.resolve();
+    }
+  });
+
+  tessel.name = options.name || 'a';
+
+  options.sandbox.stub(tessel, 'close', function() {
+    return Promise.resolve();
+  });
+
+  return tessel;
+}
+
+exports['controller.closeTesselConnections'] = {
+
+  setUp: function(done) {
+    this.sandbox = sinon.sandbox.create();
+    this.logsWarn = this.sandbox.stub(logs, 'warn', function() {});
+    this.logsInfo = this.sandbox.stub(logs, 'info', function() {});
+    this.logsBasic = this.sandbox.stub(logs, 'basic', function() {});
+
+    done();
+  },
+
+  tearDown: function(done) {
+    this.sandbox.restore();
+    done();
+  },
+
+  callsCloseOnAllAuthorizedLANConnections: function(test) {
+    test.expect(3);
+
+    var a = newTessel({
+      sandbox: this.sandbox,
+      authorized: true,
+      type: 'LAN'
+    });
+
+    var b = newTessel({
+      sandbox: this.sandbox,
+      authorized: true,
+      type: 'LAN'
+    });
+
+    var c = newTessel({
+      sandbox: this.sandbox,
+      authorized: false,
+      type: 'LAN'
+    });
+
+    controller.closeTesselConnections([a, b, c])
+      .then(function() {
+        test.equal(a.close.callCount, 1);
+        test.equal(b.close.callCount, 1);
+        test.equal(c.close.callCount, 0);
+        test.done();
+      }.bind(this));
+  },
+
+  callsCloseOnAllUSBConnections: function(test) {
+    test.expect(3);
+
+    var a = newTessel({
+      sandbox: this.sandbox,
+      type: 'USB'
+    });
+
+    var b = newTessel({
+      sandbox: this.sandbox,
+      type: 'USB'
+    });
+
+    var c = newTessel({
+      sandbox: this.sandbox,
+      authorized: true,
+      type: 'LAN'
+    });
+
+    controller.closeTesselConnections([a, b, c])
+      .then(function() {
+        test.equal(a.close.callCount, 1);
+        test.equal(b.close.callCount, 1);
+        test.equal(c.close.callCount, 1);
+        test.done();
+      }.bind(this));
+  },
+
+  resolvesForUnauthorizedLANConnections: function(test) {
+    test.expect(1);
+
+    var a = newTessel({
+      sandbox: this.sandbox,
+      authorized: false,
+      type: 'LAN'
+    });
+
+    controller.closeTesselConnections([a])
+      .then(function() {
+        test.equal(a.close.callCount, 0);
+        test.done();
+      }.bind(this));
+  },
+};
+
+
+exports['Tessel.list'] = {
+
+  setUp: function(done) {
+    var self = this;
+    this.sandbox = sinon.sandbox.create();
+    this.processOn = this.sandbox.stub(process, 'on');
+    this.activeSeeker = undefined;
+    this.seeker = this.sandbox.stub(Seeker, 'TesselSeeker', function Seeker() {
+      this.start = function() {
+        self.activeSeeker = this;
+        return this;
+      };
+      this.stop = function() {
+        return this;
+      };
+    });
+    util.inherits(this.seeker, EventEmitter);
+
+    this.logsWarn = this.sandbox.stub(logs, 'warn', function() {});
+    this.logsInfo = this.sandbox.stub(logs, 'info', function() {});
+    this.logsBasic = this.sandbox.stub(logs, 'basic', function() {});
+
+    this.closeTesselConnections = this.sandbox.spy(controller, 'closeTesselConnections');
+    this.runHeuristics = this.sandbox.spy(controller, 'runHeuristics');
+
+    done();
+  },
+
+  tearDown: function(done) {
+    this.sandbox.restore();
+    done();
+  },
+
+  oneUSBTessel: function(test) {
+    test.expect(3);
+
+    var a = newTessel({
+      sandbox: this.sandbox,
+      authorized: true,
+      type: 'USB'
+    });
+
+    Tessel.list({
+        timeout: 1
+      })
+      .then(function() {
+        test.equal(this.runHeuristics.callCount, 0);
+        test.equal(this.closeTesselConnections.callCount, 1);
+        test.equal(a.close.callCount, 1);
+        test.done();
+      }.bind(this));
+
+    this.activeSeeker.emit('tessel', a);
+  },
+
+  oneLANTessel: function(test) {
+    test.expect(3);
+
+    var a = newTessel({
+      sandbox: this.sandbox,
+      authorized: true,
+      type: 'LAN'
+    });
+
+    Tessel.list({
+        timeout: 1
+      })
+      .then(function() {
+        test.equal(this.runHeuristics.callCount, 0);
+        test.equal(this.closeTesselConnections.callCount, 1);
+        test.equal(a.close.callCount, 1);
+        test.done();
+      }.bind(this));
+
+    this.activeSeeker.emit('tessel', a);
+  },
+
+  oneTesselTwoConnections: function(test) {
+    test.expect(4);
+
+    var usb = newTessel({
+      sandbox: this.sandbox,
+      type: 'USB',
+      name: 'samesies'
+    });
+
+    var lan = newTessel({
+      sandbox: this.sandbox,
+      authorized: true,
+      type: 'LAN',
+      name: 'samesies'
+    });
+
+    Tessel.list({
+        timeout: 1
+      })
+      .then(function() {
+        test.equal(this.runHeuristics.callCount, 0);
+        test.equal(this.closeTesselConnections.callCount, 1);
+        test.equal(usb.close.callCount, 1);
+        test.equal(lan.close.callCount, 1);
+        test.done();
+      }.bind(this));
+
+    this.activeSeeker.emit('tessel', usb);
+    this.activeSeeker.emit('tessel', lan);
+  },
+
+  multipleDifferentTessels: function(test) {
+    test.expect(4);
+
+    var usb = newTessel({
+      sandbox: this.sandbox,
+      type: 'USB',
+      name: 'foo'
+    });
+
+    var lan = newTessel({
+      sandbox: this.sandbox,
+      authorized: true,
+      type: 'LAN',
+      name: 'bar'
+    });
+
+    Tessel.list({
+        timeout: 1
+      })
+      .then(function() {
+        test.equal(this.runHeuristics.callCount, 1);
+        test.equal(this.closeTesselConnections.callCount, 1);
+        test.equal(usb.close.callCount, 1);
+        test.equal(lan.close.callCount, 1);
+        test.done();
+      }.bind(this));
+
+    this.activeSeeker.emit('tessel', usb);
+    this.activeSeeker.emit('tessel', lan);
+  },
+};
+
+exports['Tessel.get'] = {
+
+  setUp: function(done) {
+    var self = this;
+    this.sandbox = sinon.sandbox.create();
+    this.processOn = this.sandbox.stub(process, 'on');
+    this.activeSeeker = undefined;
+    this.seeker = this.sandbox.stub(Seeker, 'TesselSeeker', function Seeker() {
+      this.start = function() {
+        self.activeSeeker = this;
+        return this;
+      };
+      this.stop = function() {
+        return this;
+      };
+    });
+    util.inherits(this.seeker, EventEmitter);
+
+    this.logsWarn = this.sandbox.stub(logs, 'warn', function() {});
+    this.logsInfo = this.sandbox.stub(logs, 'info', function() {});
+    this.logsBasic = this.sandbox.stub(logs, 'basic', function() {});
+
+    this.closeTesselConnections = this.sandbox.stub(controller, 'closeTesselConnections');
+    this.reconcileTessels = this.sandbox.spy(controller, 'reconcileTessels');
+    this.runHeuristics = this.sandbox.spy(controller, 'runHeuristics');
+
+    done();
+  },
+
+  tearDown: function(done) {
+    this.sandbox.restore();
+    done();
+  },
+
+  oneNamedTessel: function(test) {
+    test.expect(5);
+
+    controller.closeTesselConnections.returns(Promise.resolve());
+
+    var a = newTessel({
+      sandbox: this.sandbox,
+      authorized: true,
+      type: 'LAN',
+      name: 'the_name'
+    });
+
+    Tessel.get({
+        timeout: 1,
+        name: 'the_name'
+      })
+      .then(function() {
+        test.equal(this.reconcileTessels.callCount, 0);
+        test.equal(this.runHeuristics.callCount, 0);
+        test.equal(this.closeTesselConnections.callCount, 1);
+        test.equal(this.logsInfo.callCount, 2);
+        test.equal(_.contains(this.logsInfo.lastCall.args[0], 'the_name'), true);
+        test.done();
+      }.bind(this));
+
+    this.activeSeeker.emit('tessel', a);
+  },
+
+  oneUnNamedTessel: function(test) {
+    test.expect(5);
+
+    controller.closeTesselConnections.returns(Promise.resolve());
+
+    var a = newTessel({
+      sandbox: this.sandbox,
+      authorized: true,
+      type: 'LAN',
+      name: 'the_name'
+    });
+
+    Tessel.get({
+        timeout: 1
+      })
+      .then(function() {
+        test.equal(this.reconcileTessels.callCount, 0);
+        test.equal(this.runHeuristics.callCount, 0);
+        test.equal(this.closeTesselConnections.callCount, 1);
+        test.equal(this.logsInfo.callCount, 2);
+        test.equal(_.contains(this.logsInfo.lastCall.args[0], 'the_name'), true);
+        test.done();
+      }.bind(this));
+
+    this.activeSeeker.emit('tessel', a);
+  },
+
+  oneUnamedTesselTwoConnections: function(test) {
+    test.expect(5);
+
+    controller.closeTesselConnections.returns(Promise.resolve());
+
+    var usb = newTessel({
+      sandbox: this.sandbox,
+      type: 'USB',
+      name: 'samesies'
+    });
+
+    var lan = newTessel({
+      sandbox: this.sandbox,
+      authorized: true,
+      type: 'LAN',
+      name: 'samesies'
+    });
+
+    Tessel.get({
+        timeout: 1
+      })
+      .then(function() {
+        test.equal(this.reconcileTessels.callCount, 1);
+        test.equal(this.runHeuristics.callCount, 1);
+        test.equal(this.closeTesselConnections.callCount, 1);
+        test.equal(this.logsInfo.callCount, 2);
+        test.equal(_.contains(this.logsInfo.lastCall.args[0], 'samesies'), true);
+        test.done();
+      }.bind(this));
+
+    this.activeSeeker.emit('tessel', usb);
+    this.activeSeeker.emit('tessel', lan);
+  },
+};

--- a/test/unit/tessel.js
+++ b/test/unit/tessel.js
@@ -140,10 +140,16 @@ exports['Tessel (get)'] = {
       }.bind(this));
 
     var a = new Tessel({
-      connectionType: 'USB'
+      connectionType: 'USB',
+      end: function() {
+        return Promise.resolve();
+      }
     });
     var b = new Tessel({
-      connectionType: 'USB'
+      connectionType: 'USB',
+      end: function() {
+        return Promise.resolve();
+      }
     });
 
     a.name = 'a';
@@ -171,10 +177,16 @@ exports['Tessel (get)'] = {
       });
 
     var a = new Tessel({
-      connectionType: 'USB'
+      connectionType: 'USB',
+      end: function() {
+        return Promise.resolve();
+      }
     });
     var b = new Tessel({
-      connectionType: 'USB'
+      connectionType: 'USB',
+      end: function() {
+        return Promise.resolve();
+      }
     });
 
     a.name = 'a';
@@ -204,10 +216,17 @@ exports['Tessel (get)'] = {
       });
 
     var usb = new Tessel({
-      connectionType: 'USB'
+      connectionType: 'USB',
+      end: function() {
+        return Promise.resolve();
+      }
     });
     var lan = new Tessel({
-      connectionType: 'LAN'
+      connectionType: 'LAN',
+      authorized: false,
+      end: function() {
+        return Promise.resolve();
+      }
     });
 
     usb.name = 'a';
@@ -219,7 +238,6 @@ exports['Tessel (get)'] = {
 
   usbAndNonAuthorizedLANSameTesselLANFirst: function(test) {
     test.expect(2);
-
     // Try to get Tessels but return none
     Tessel.get({
         timeout: 0.5,
@@ -234,10 +252,17 @@ exports['Tessel (get)'] = {
       });
 
     var usb = new Tessel({
-      connectionType: 'USB'
+      connectionType: 'USB',
+      end: function() {
+        return Promise.resolve();
+      }
     });
     var lan = new Tessel({
-      connectionType: 'LAN'
+      connectionType: 'LAN',
+      authorized: false,
+      end: function() {
+        return Promise.resolve();
+      }
     });
 
     usb.name = 'a';
@@ -267,10 +292,17 @@ exports['Tessel (get)'] = {
       });
 
     var usb = new Tessel({
-      connectionType: 'USB'
+      connectionType: 'USB',
+      end: function() {
+        return Promise.resolve();
+      }
     });
     var lan = new Tessel({
-      connectionType: 'LAN'
+      connectionType: 'LAN',
+      authorized: true,
+      end: function() {
+        return Promise.resolve();
+      }
     });
 
     usb.name = 'a';
@@ -299,10 +331,18 @@ exports['Tessel (get)'] = {
       }.bind(this));
 
     var a = new Tessel({
-      connectionType: 'LAN'
+      connectionType: 'LAN',
+      authorized: true,
+      end: function() {
+        return Promise.resolve();
+      }
     });
     var b = new Tessel({
-      connectionType: 'LAN'
+      connectionType: 'LAN',
+      authorized: true,
+      end: function() {
+        return Promise.resolve();
+      }
     });
 
     a.name = 'a';
@@ -330,10 +370,18 @@ exports['Tessel (get)'] = {
       });
 
     var a = new Tessel({
-      connectionType: 'LAN'
+      connectionType: 'LAN',
+      authorized: true,
+      end: function() {
+        return Promise.resolve();
+      }
     });
     var b = new Tessel({
-      connectionType: 'LAN'
+      connectionType: 'LAN',
+      authorized: true,
+      end: function() {
+        return Promise.resolve();
+      }
     });
 
     a.name = 'a';

--- a/test/unit/tessel.js
+++ b/test/unit/tessel.js
@@ -62,6 +62,8 @@ exports['Tessel (get)'] = {
     var self = this;
     this.sandbox = sinon.sandbox.create();
     this.activeSeeker = undefined;
+    // This is necessary to prevent an EventEmitter memory leak warning
+    this.processOn = this.sandbox.stub(process, 'on');
     this.seeker = this.sandbox.stub(Seeker, 'TesselSeeker', function Seeker() {
       this.start = function() {
         self.activeSeeker = this;


### PR DESCRIPTION
This is less of an issue for SSH connections, but the USB Daemon needs to be notified when connections are completed so it can remove that entry from its table. It can currently run 256 processes currently but if we aren't consistent about closing them, they can eventually crash the daemon with a fair amount of use.

- [x] Close discovered Tessels
- [x] Close Tessels used for each command
- [x] Write tests to confirm that they are closed