### PR TITLE
Adds another provision test

### DIFF
--- a/test/unit/provision.js
+++ b/test/unit/provision.js
@@ -85,6 +85,8 @@ exports['controller.provisionTessel'] = {
 
     this.provisionSpy = sinon.spy(Tessel.prototype, 'provisionTessel');
 
+    this.writeSpy = sinon.spy(fs, 'writeFile');
+
     this.getTessel = sinon.stub(Tessel, 'get', function() {
       return new Promise(function(resolve) {
         resolve(self.tessel);
@@ -102,6 +104,7 @@ exports['controller.provisionTessel'] = {
     this.isProvisioned.restore();
     this.provisionTessel.restore();
     this.provisionSpy.restore();
+    this.writeSpy.restore();
     this.exec.restore();
     this.getTessel.restore();
     this.logsWarn.restore();
@@ -109,6 +112,24 @@ exports['controller.provisionTessel'] = {
 
     deleteKeyTestFolder();
     done();
+  },
+
+  completeProvisioned: function(test) {
+    var self = this;
+    test.expect(3);
+
+    this.provisionTessel().catch(function(error) {
+      test.ifError(error);
+    }.bind(this))
+    .then(function() {
+      // It should call into tessel provision
+      test.equal(self.provisionSpy.callCount, 1);
+      // It should not attempt to delete the folder
+      test.equal(self.exec.callCount, 0);
+      // It should not attempt to rewrite the keys
+      test.equal(self.writeSpy.callCount, 0);
+      test.done();
+    });
   },
 
   completeForced: function(test) {


### PR DESCRIPTION
@rwaldron This adds a test for the case where the SSH keys already exist and we want to provision another Tessel.