### PR TITLE
move update instructions back to here

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ See docs on T2 CLI usage [on the t2-docs repo](https://github.com/tessel/t2-docs
 ## Contents
 
 * [Installation for development](#installation-for-development)
+* [Updating Tessel](#updating-tessel-2-on-board-osfirmware)
 * [Development milestones](#development-milestones)
 
 ## Installation for development
@@ -34,6 +35,22 @@ You may encounter the following error when executing `npm link` on windows:
 19804 error Failed at the tessel@0.3.23 postinstall script 'tessel install-drivers || true; tessel trademark || true'.
 ```
 This error occurs because of windows folder permissions. To resolve this make sure you are running cmd or powershell as an administrator and that the permissions on the node_modules folder is set to full control for the user.
+
+## Updating Tessel 2 On-board OS/Firmware
+There are two components to the Tessel on-board software: The OpenWRT Linux image on the MediaTek processor and the firmware image that runs on the Atmel co-processor.
+
+### How do I know if I need to update my T2?
+Unfortunately, [we have an open PR](https://github.com/tessel/t2-cli/pull/130) to detect the version of code running on T2 but it hasn't merged yet! If you aren't seeing your Tessel 2 show up with `t2 list`, then you probably have an old version of firmware (because the USB VID/PID is out of date). If you see functionality in the [Tessel API](https://github.com/tessel/t2-firmware#t2-hardware-api) that isn't defined on your board, then you probably need to update.
+
+### Updating
+Eventually, this will be [rolled into the CLI](https://github.com/tessel/t2-cli/issues/81) but it hasn't been built yet. For now:
+
+1. Update your co-processor firmware by following the instructions [here](https://github.com/tessel/t2-firmware/#compiling)
+2. Update the OpenWRT image on the primary processor by either [building it yourself](https://github.com/tessel/openwrt-tessel) or downloading [a prebuilt binary](https://kevinmehall.net/tmp/openwrt/openwrt-ramips-mt7620-tessel-squashfs-sysupgrade.bin) (if you're not sure which you want to do, use
+3. Transfer it to your T2 (often accomplished with `scp -i ~/.tessel/id_rsa PATH_TO_IMAGE root@IP_ADDR_OF_T2:/tmp`) and running `sysupgrade /tmp/PATH_TO_IMAGE` on your T2. Make sure it's uploaded to the `/tmp` folder on T2 - any other folder will ruin the upgrade. If you need to find the IP Address of your T2 but don't know how, first connect it to your network (`t2 wifi -n YOUR_SSID -p YOUR_PASSWORD`)
+4. Run `t2 list` to make sure it's actually connected over the LAN, and note its name.
+5. Run `ping YOUR_NAME.local` in order to see the IP address (you can also give it a simpler name first with `t2 rename NEW_NAME`. If you already know what dterm is, you can just dterm into the device and run `ifconfig`.
+6. Wait for it to automatically restart itself and you're good to go!
 
 ## Development Milestones
 Help us build Tessel 2's CLI! The [issues section](https://github.com/tessel/t2-cli/issues) of this repo is full of small, fully outlined projects to add functionality.


### PR DESCRIPTION
@johnnyman727 I had moved this out when I moved instructions to the t2-docs repo, but I shouldn't have. These ones should stay here; we can update the other one to `t2 update` but people working on the CLI should know how to update their firmware manually.