### PR TITLE
Point out two failure modes in t2 update.

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -506,6 +506,10 @@ controller.update = function(opts) {
               // Once we have the current SHA, provide the version
               .then(function(currentSHA) {
                 return resolve(updates.findBuild(builds, 'sha', currentSHA).version);
+              })
+              .catch(function () {
+                console.log('Could not fetch current tessel version. Perhaps use --force?');
+                tessel.close();
               });
           });
         }

--- a/lib/tessel/update.js
+++ b/lib/tessel/update.js
@@ -94,7 +94,14 @@ Tessel.prototype.updateOpenWRT = function(image) {
                   return;
                 }
               });
-            });
+            })
+            .catch(function () {
+              // SHRUG. If the SSH session cut out, perhaps we can continue.
+              console.log('Maybe the update completed...? Waiting 30s');
+              setTimeout(function () {
+                resolve();
+              }, 30*1000)
+            })
         });
         logs.info('Transferring image of size', (image.length / 1e6).toFixed(2), 'MB');
         // Write the image


### PR DESCRIPTION
I can fix this to be a proper patch, but these are the two hacks I needed to get my Tessel to update properly:

1. My tessel has no /etc/tessel-version, so the script choked.
2. The SSH session dying didn't always go to the following `.then` (at least once it did though), so I added a clause just in case.

How should I improve this?