### PR TITLE
More reliable Tessel discovery

### DIFF
--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -16,7 +16,7 @@ var timeoutOption = {
   abbr: 't',
   metavar: 'TIMEOUT',
   help: 'Set timeout in seconds for scanning for networked tessels',
-  default: 5
+  default: 2
 };
 
 function closeSuccessfulCommand() {

--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -16,7 +16,7 @@ var timeoutOption = {
   abbr: 't',
   metavar: 'TIMEOUT',
   help: 'Set timeout in seconds for scanning for networked tessels',
-  default: 2
+  default: 5
 };
 
 function closeSuccessfulCommand() {

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -99,6 +99,7 @@ Tessel.get = function(opts) {
     var tessels = [];
     // Create a seeker object and start detecting any Tessels
     var seeker = new discover.TesselSeeker().start(timeout);
+
     function searchComplete() {
       // If we found no Tessels
       if (tessels.length === 0) {
@@ -115,12 +116,12 @@ Tessel.get = function(opts) {
       else {
         // Combine the same Tessels into one object
         controller.reconcileTessels(tessels)
-        .then(function(reconciledTessels) {
-          tessels = reconciledTessels;
-          // Run the heuristics to pick which Tessel to use
-          return controller.runHeuristics(opts, tessels)
-          .then(logAndFinish);
-        });
+          .then(function(reconciledTessels) {
+            tessels = reconciledTessels;
+            // Run the heuristics to pick which Tessel to use
+            return controller.runHeuristics(opts, tessels)
+              .then(logAndFinish);
+          });
       }
     }
 

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -18,7 +18,7 @@ Tessel.list = function(opts) {
     // Keep a list of all the Tessels we discovered
     var foundTessels = [];
     // Start looking for Tessels
-    var seeker = new discover.TesselSeeker().start();
+    var seeker = new discover.TesselSeeker().start(opts.timeout * 1000);
 
     // When a Tessel is found
     seeker.on('tessel', function displayResults(tessel) {
@@ -42,13 +42,7 @@ Tessel.list = function(opts) {
     });
 
     // Called after CTRL+C or timeout
-    function stopSearch() {
-      // If the seeker exists (it should)
-      if (seeker !== undefined) {
-        // Stop looking for more Tessels
-        seeker.stop();
-      }
-
+    seeker.once('end', function stopSearch() {
       // If there were no Tessels found
       if (foundTessels.length === 0) {
         // Report the sadness
@@ -83,54 +77,30 @@ Tessel.list = function(opts) {
               .then(resolve);
           });
       }
-    }
-
-    // If a timeout was provided and it's a number
-    if (opts.timeout && typeof opts.timeout === 'number') {
-      // Stop the search after that duration
-      setTimeout(stopSearch, opts.timeout * 1000);
-    }
+    });
 
     // Stop the search if CTRL+C is hit
-    process.once('SIGINT', stopSearch);
+    process.once('SIGINT', function() {
+      // If the seeker exists (it should)
+      if (seeker !== undefined) {
+        // Stop looking for more Tessels
+        seeker.stop();
+      }
+    });
   });
 };
 
 Tessel.get = function(opts) {
   return new Promise(function(resolve, reject) {
     logs.info('Connecting to Tessel...');
-    // Store the amount of time to look for Tessel
-    var timeout = opts.timeout || 1.5;
+    // Store the amount of time to look for Tessel in seconds
+    var timeout = (opts.timeout || 2) * 1000;
     // Collection variable as more Tessels are found
     var tessels = [];
     // Create a seeker object and start detecting any Tessels
-    var seeker = new discover.TesselSeeker().start();
-    // The handle for the search complete timeout
-    var timeoutHandle;
+    var seeker = new discover.TesselSeeker().start(timeout);
 
-    // When we find Tessels
-    seeker.on('tessel', function(tessel) {
-      // Check if this name matches the provided option (if any)
-      // This speeds up development by immediately ending the search
-      if (opts.name && opts.name === tessel.name) {
-        // Stop searching
-        seeker.stop();
-        // Don't call the timeout
-        clearTimeout(timeoutHandle);
-        // Send this Tessel back to the caller
-        logAndFinish(tessel);
-      }
-      // Otherwise
-      else {
-        // Store this Tessel with the others
-        tessels.push(tessel);
-      }
-    });
-
-    // Set the timeout for when we give up searching
-    timeoutHandle = setTimeout(function() {
-      // Stop the search
-      seeker.stop();
+    function searchComplete() {
       // If we found no Tessels
       if (tessels.length === 0) {
         // Report it
@@ -146,14 +116,35 @@ Tessel.get = function(opts) {
       else {
         // Combine the same Tessels into one object
         controller.reconcileTessels(tessels)
-          .then(function(reconciledTessels) {
-            tessels = reconciledTessels;
-            // Run the heuristics to pick which Tessel to use
-            return controller.runHeuristics(opts, tessels)
-              .then(logAndFinish);
-          });
+        .then(function(reconciledTessels) {
+          tessels = reconciledTessels;
+          // Run the heuristics to pick which Tessel to use
+          return controller.runHeuristics(opts, tessels)
+          .then(logAndFinish);
+        });
       }
-    }, timeout * 1000);
+    }
+
+    // When we find Tessels
+    seeker.on('tessel', function(tessel) {
+      // Check if this name matches the provided option (if any)
+      // This speeds up development by immediately ending the search
+      if (opts.name && opts.name === tessel.name) {
+        // Remove this listener because we don't need to search for the Tessel
+        seeker.removeListener('end', searchComplete);
+        // Stop searching
+        seeker.stop();
+        // Send this Tessel back to the caller
+        logAndFinish(tessel);
+      }
+      // Otherwise
+      else {
+        // Store this Tessel with the others
+        tessels.push(tessel);
+      }
+    });
+
+    seeker.once('end', searchComplete);
 
     // Accesses `tessels` in closure
     function logAndFinish(tessel) {

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -99,7 +99,6 @@ Tessel.get = function(opts) {
     var tessels = [];
     // Create a seeker object and start detecting any Tessels
     var seeker = new discover.TesselSeeker().start(timeout);
-
     function searchComplete() {
       // If we found no Tessels
       if (tessels.length === 0) {

--- a/lib/discover.js
+++ b/lib/discover.js
@@ -38,18 +38,15 @@ TesselSeeker.prototype.start = function(timeout) {
           self.emit('tessel', tessel);
         } else {
           debug('Fetching name:', tessel.connection.host);
-          return new Promise(function(resolve) {
             tessel.getName()
             .then(function() {
               self.emit('tessel', tessel);
-              resolve();
+              return Promise.resolve();
             })
             .catch(function(err) {
-              console.log('yeah caught a bug')
-              logs.error('unable to fetch name:', err);
-              resolve()
+              logs.err('unable to fetch name:', err);
+              return Promise.resolve()
             });
-          });
         }
       });
     // Push this Promise into the pending array
@@ -66,9 +63,6 @@ TesselSeeker.prototype.start = function(timeout) {
         .then(function() {
           debug('Done! Stopping.');
           self.stop();
-        })
-        .catch(function(err) {
-          console.log('shit sone!!!')
         });
     }, timeout);
   }

--- a/lib/discover.js
+++ b/lib/discover.js
@@ -9,12 +9,16 @@ var usb = require('./usb_connection'),
 function TesselSeeker() {
   this.lanScan = undefined;
   this.seekDuration = undefined;
+  this.scanTimeout = undefined;
 }
 
 util.inherits(TesselSeeker, EventEmitter);
 
-TesselSeeker.prototype.start = function() {
+TesselSeeker.prototype.start = function(timeout) {
   var self = this;
+
+  // An array of pending open connections
+  var pendingOpen = [];
 
   self.lanScan = lan.startScan();
 
@@ -26,7 +30,7 @@ TesselSeeker.prototype.start = function() {
 
   function connectionHandler(conn) {
     var tessel = new Tessel(conn);
-    tessel.connection.open()
+    var opening = tessel.connection.open()
       .then(function() {
         debug('Connection opened:', tessel.connection.host);
         if (conn.connectionType === 'LAN' && !conn.authorized) {
@@ -34,15 +38,39 @@ TesselSeeker.prototype.start = function() {
           self.emit('tessel', tessel);
         } else {
           debug('Fetching name:', tessel.connection.host);
-          tessel.getName()
+          return new Promise(function(resolve) {
+            tessel.getName()
             .then(function() {
               self.emit('tessel', tessel);
+              resolve();
             })
             .catch(function(err) {
+              console.log('yeah caught a bug')
               logs.error('unable to fetch name:', err);
+              resolve()
             });
+          });
         }
       });
+    // Push this Promise into the pending array
+    pendingOpen.push(opening);
+  }
+  // If a timeout was provided
+  if (timeout && typeof timeout === 'number') {
+    // Set a timeout function
+    self.scanTimeout = setTimeout(function() {
+      debug('Timeout hit! Waiting for pending to finish...');
+      // Once all the pending open commands complete
+      Promise.all(pendingOpen)
+        // Stop the scan (which emits 'end')
+        .then(function() {
+          debug('Done! Stopping.');
+          self.stop();
+        })
+        .catch(function(err) {
+          console.log('shit sone!!!')
+        });
+    }, timeout);
   }
 
   return self;
@@ -60,6 +88,16 @@ TesselSeeker.prototype.stop = function() {
     this.usbScan.stop();
 
     this.usbScan = undefined;
+  }
+
+  // If a timeout was provided
+  if (this.scanTimeout) {
+    // Clear that timeout
+    clearTimeout(this.scanTimeout);
+    // Emit that this scan stopped
+    setImmediate(function() {
+      this.emit('end');
+    }.bind(this));
   }
 
   return this;

--- a/lib/discover.js
+++ b/lib/discover.js
@@ -38,14 +38,14 @@ TesselSeeker.prototype.start = function(timeout) {
           self.emit('tessel', tessel);
         } else {
           debug('Fetching name:', tessel.connection.host);
-            tessel.getName()
+          tessel.getName()
             .then(function() {
               self.emit('tessel', tessel);
               return Promise.resolve();
             })
             .catch(function(err) {
               logs.err('unable to fetch name:', err);
-              return Promise.resolve()
+              return Promise.resolve();
             });
         }
       });

--- a/test/unit/controller.js
+++ b/test/unit/controller.js
@@ -126,13 +126,17 @@ exports['Tessel.list'] = {
     this.processOn = this.sandbox.stub(process, 'on');
     this.activeSeeker = undefined;
     this.seeker = this.sandbox.stub(Seeker, 'TesselSeeker', function Seeker() {
-      this.start = function() {
+      this.start = function(timeout) {
         self.activeSeeker = this;
+        if (timeout && typeof timeout === 'number') {
+          setTimeout(this.stop, timeout);
+        }
         return this;
       };
       this.stop = function() {
+        this.emit('end');
         return this;
-      };
+      }.bind(this);
     });
     util.inherits(this.seeker, EventEmitter);
 
@@ -266,13 +270,17 @@ exports['Tessel.get'] = {
     this.processOn = this.sandbox.stub(process, 'on');
     this.activeSeeker = undefined;
     this.seeker = this.sandbox.stub(Seeker, 'TesselSeeker', function Seeker() {
-      this.start = function() {
+      this.start = function(timeout) {
         self.activeSeeker = this;
+        if (timeout && typeof timeout === 'number') {
+          setTimeout(this.stop, timeout);
+        }
         return this;
       };
       this.stop = function() {
+        this.emit('end');
         return this;
-      };
+      }.bind(this);
     });
     util.inherits(this.seeker, EventEmitter);
 

--- a/test/unit/discover.js
+++ b/test/unit/discover.js
@@ -160,7 +160,7 @@ exports['TesselSeeker.prototype.stop'] = {
 
     test.done();
   }
-}
+};
 
 exports['TesselSeeker Scan Time'] = {
   setUp: function(done) {
@@ -195,19 +195,19 @@ exports['TesselSeeker Scan Time'] = {
     test.expect(1);
     // Scan for new connections for this period
     var scanTime = 100;
-   
+
     standardSeekerSetup(this.seeker, scanTime)
-    // When all Tessels have completed opening
-    .then(function(found) {
-      // Make sure we only have the one Tessel we created
-      test.equal(found.length, 1);
-      test.done();
-    });
+      // When all Tessels have completed opening
+      .then(function(found) {
+        // Make sure we only have the one Tessel we created
+        test.equal(found.length, 1);
+        test.done();
+      });
 
     // Create a Simulated LAN Tessel (Unathorized)
     var lan = TesselSimulater('LAN');
     // Give it a name
-    lan.connection.host = 'Tessel-Test_Subject'
+    lan.connection.host = 'Tessel-Test_Subject';
     // Create it's open function
     lan.connection.open = resolveOpenInMs.bind(this, scanTime * 2);
     // Once half of the scan time has elapsed, emit a new connection
@@ -219,10 +219,10 @@ exports['TesselSeeker Scan Time'] = {
     // Spy on the seeker stop
     this.seekerStop = this.sandbox.spy(TesselSeeker.prototype, 'stop');
 
-        // Give it a name
+    // Give it a name
     this.getName = this.sandbox.stub(Tessel.prototype, 'getName', function() {
       return new Promise(function(resolve) {
-        resolve('Tessel-Test_Subject')
+        resolve('Tessel-Test_Subject');
       });
     });
 
@@ -230,13 +230,13 @@ exports['TesselSeeker Scan Time'] = {
     var scanTime = 100;
     // When all Tessels have completed opening
     standardSeekerSetup(this.seeker, scanTime)
-    .then(function discoveryComplete(found) {
-      // Make sure we only have the one Tessel we created
-      test.equal(found.length, 1);
-      // The seeker was told to stop after the timeout ran down
-      test.equal(this.seekerStop.callCount, 1);
-      test.done();
-    }.bind(this));
+      .then(function discoveryComplete(found) {
+        // Make sure we only have the one Tessel we created
+        test.equal(found.length, 1);
+        // The seeker was told to stop after the timeout ran down
+        test.equal(this.seekerStop.callCount, 1);
+        test.done();
+      }.bind(this));
 
     // Create a Simulated LAN Tessel (Unathorized)
     var lan = TesselSimulater('LAN');
@@ -248,7 +248,7 @@ exports['TesselSeeker Scan Time'] = {
     lan.connection.open = resolveOpenInMs.bind(this, scanTime * 2);
 
     // Emit the connection halfway through the scan
-    emitConnectionInMs(this.seeker, lan.connection, scanTime / 2)
+    emitConnectionInMs(this.seeker, lan.connection, scanTime / 2);
   },
 
   oneAuthorizedLANPendingFails: function(test) {
@@ -263,12 +263,12 @@ exports['TesselSeeker Scan Time'] = {
 
     // Start scan
     standardSeekerSetup(this.seeker, scanTime)
-    // When all Tessels have completed opening
-    .then(function(found) {
-      // Make sure we don't find any Tessels
-      test.equal(found.length, 0);
-      test.done();
-    }.bind(this));
+      // When all Tessels have completed opening
+      .then(function(found) {
+        // Make sure we don't find any Tessels
+        test.equal(found.length, 0);
+        test.done();
+      }.bind(this));
 
     // Create a Simulated LAN Tessel (Unathorized)
     var lan = TesselSimulater('LAN');
@@ -293,14 +293,14 @@ exports['TesselSeeker Scan Time'] = {
     this.getName = this.sandbox.stub(Tessel.prototype, 'getName', function() {
       return Promise.resolve('Tessel-AndFriends');
     });
-    
+
     // When all Tessels have completed opening
     standardSeekerSetup(this.seeker, scanTime)
-    .then(function(found) {
-      // Make sure we only have the one Tessel we created
-      test.equal(found.length, 4);
-      test.done();
-    }.bind(this));
+      .then(function(found) {
+        // Make sure we only have the one Tessel we created
+        test.equal(found.length, 4);
+        test.done();
+      }.bind(this));
 
     // Create a simulated LAN Tessel (Unathorized)
     var lan1 = TesselSimulater('LAN');
@@ -314,7 +314,7 @@ exports['TesselSeeker Scan Time'] = {
     // complete but unauthorized opens before scan completes
     lan1.connection.open = resolveOpenInMs.bind(this, scanTime + 1);
     // Give it a name
-    lan1.connection.host = 'Tessel-TroubleMaker'
+    lan1.connection.host = 'Tessel-TroubleMaker';
     lan2.connection.open = resolveOpenInMs.bind(this, scanTime + 2);
 
     var usb1 = TesselSimulater('USB');
@@ -323,14 +323,14 @@ exports['TesselSeeker Scan Time'] = {
     usb1.connection.open = resolveOpenInMs.bind(this, scanTime + 3);
     usb2.connection.open = resolveOpenInMs.bind(this, scanTime + 4);
 
-   emitConnectionInMs(this.seeker, lan1.connection, scanTime / 4);
-   emitConnectionInMs(this.seeker, usb1.connection, scanTime / 3);
-   emitConnectionInMs(this.seeker, lan2.connection, scanTime / 2);
-   emitConnectionInMs(this.seeker, usb2.connection, scanTime / 1.1);
+    emitConnectionInMs(this.seeker, lan1.connection, scanTime / 4);
+    emitConnectionInMs(this.seeker, usb1.connection, scanTime / 3);
+    emitConnectionInMs(this.seeker, lan2.connection, scanTime / 2);
+    emitConnectionInMs(this.seeker, usb2.connection, scanTime / 1.1);
   },
 
   // A test where seeker.stop is explicitly called instead of waiting for timeout
-  explicitStop : function(test) {
+  explicitStop: function(test) {
     test.expect(1);
     // Scan for new connections for this period
     var scanTime = 100;
@@ -342,12 +342,12 @@ exports['TesselSeeker Scan Time'] = {
 
     // Start scan
     standardSeekerSetup(this.seeker, scanTime)
-    // When all Tessels have completed opening
-    .then(function(found) {
-      // Make sure we don't find any Tessels because we stopped the scan
-      test.equal(found.length, 0);
-      test.done();
-    }.bind(this));
+      // When all Tessels have completed opening
+      .then(function(found) {
+        // Make sure we don't find any Tessels because we stopped the scan
+        test.equal(found.length, 0);
+        test.done();
+      }.bind(this));
 
     // Create a Simulated LAN Tessel (Unathorized)
     var lan = TesselSimulater('LAN');
@@ -362,8 +362,8 @@ exports['TesselSeeker Scan Time'] = {
     emitConnectionInMs(this.seeker, lan.connection, scanTime / 2);
 
     setTimeout(function stopScan() {
-      this.seeker.stop()
-    }.bind(this), scanTime)
+      this.seeker.stop();
+    }.bind(this), scanTime);
   }
 };
 

--- a/test/unit/discover.js
+++ b/test/unit/discover.js
@@ -3,6 +3,8 @@ var sinon = require('sinon');
 var usb = require('../../lib/usb_connection');
 var lan = require('../../lib/lan_connection');
 var TesselSeeker = require('../../lib/discover').TesselSeeker;
+var TesselSimulater = require('../common/tessel-simulator');
+var Tessel = require('../../lib/tessel/tessel.js');
 
 
 function FakeScanner() {
@@ -156,4 +158,169 @@ exports['TesselSeeker.prototype.stop'] = {
 
     test.done();
   },
+
+  oneUnauthorizedLANPending: function(test) {
+    test.expect(1);
+    // Scan for new connections for one second
+    var scanTime = 100;
+    // Start scan
+    this.seeker.start(scanTime);
+    // Array to save found Tessels in
+    var found = [];
+
+    // When we get a Tessel
+    this.seeker.on('tessel', function(tessel) {
+      // save it
+      found.push(tessel);
+    });
+
+    // When all Tessels have completed opening
+    this.seeker.on('end', function() {
+      // Make sure we only have the one Tessel we created
+      test.equal(found.length, 1);
+      test.done();
+    });
+
+    // Create a Simulated LAN Tessel (Unathorized)
+    var lan = TesselSimulater('LAN');
+
+    // Create it's open function
+    lan.connection.open = function() {
+      // After twice the scanning time, finally resolve
+      return new Promise(function(resolve) {
+        setTimeout(function() {
+          return resolve();
+        }, scanTime * 2);
+      });
+    }
+
+    // Give it a name
+    lan.connection.host = 'Tessel-Test_Subject'
+
+    // Calculate how long half of the scan time is
+    var halfScan = scanTime / 2;
+    // Once half of the scan time has elapsed
+    setTimeout(function() {
+      // Emit a new connection
+      this.seeker.lanScan.emit('connection', lan.connection);
+    }.bind(this), halfScan);
+  },
+
+  oneAuthorizedLANPending: function(test) {
+    test.expect(2);
+    // Spy on the seeker stop
+    this.seekerStop = sinon.spy(TesselSeeker.prototype, 'stop');
+    // Scan for new connections for one second
+    var scanTime = 100;
+    // Start scan
+    this.seeker.start(scanTime);
+    // Array to save found Tessels in
+    var found = [];
+
+    // When we get a Tessel
+    this.seeker.on('tessel', function(tessel) {
+      // save it
+      found.push(tessel);
+    });
+
+    // When all Tessels have completed opening
+    this.seeker.on('end', function() {
+      // Make sure we only have the one Tessel we created
+      test.equal(found.length, 1);
+      // The seeker was told to stop after the timeout ran down
+      test.equal(this.seekerStop.callCount, 1);
+      // Restore our stub so we can stub it again later
+      this.getName.restore();
+      test.done();
+    }.bind(this));
+
+    // Create a Simulated LAN Tessel (Unathorized)
+    var lan = TesselSimulater('LAN');
+
+    // Create it's open function
+    lan.connection.open = function() {
+      // After twice the scanning time, finally resolve
+      return new Promise(function(resolve) {
+        setTimeout(function() {
+          return resolve();
+        }, scanTime * 2);
+      });
+    }
+
+    // Authorize it
+    lan.connection.authorized = true;
+    // Give it a name
+    this.getName = sinon.stub(Tessel.prototype, 'getName', function() {
+      return new Promise(function(resolve) {
+        resolve('Tessel-Test_Subject')
+      });
+    });
+
+    // Calculate how long half of the scan time is
+    var halfScan = scanTime / 2;
+    // Once half of the scan time has elapsed
+    setTimeout(function() {
+      // Emit a new connection
+      this.seeker.lanScan.emit('connection', lan.connection);
+    }.bind(this), halfScan);
+  },
+
+  oneAuthorizedLANPendingFails: function(test) {
+    test.expect(1);
+    // Scan for new connections for one second
+    var scanTime = 100;
+    // Start scan
+    this.seeker.start(scanTime);
+    // Array to save found Tessels in
+    var found = [];
+
+    // When we get a Tessel
+    this.seeker.on('tessel', function(tessel) {
+      // save it
+      found.push(tessel);
+    });
+
+    // When all Tessels have completed opening
+    this.seeker.on('end', function() {
+      console.log('DONE')
+      // Make sure we only have the one Tessel we created
+      test.equal(found.length, 0);
+      // Restore our stub so we can stub it again later
+      this.getName.restore();
+      test.done();
+    }.bind(this));
+
+    // Create a Simulated LAN Tessel (Unathorized)
+    var lan = TesselSimulater('LAN');
+
+    // Create it's open function
+    lan.connection.open = function() {
+      // After twice the scanning time, finally resolve
+      return new Promise(function(resolve) {
+        setTimeout(function() {
+          return resolve();
+        }, scanTime * 2);
+      });
+    }
+
+    // Authorize it
+    lan.connection.authorized = true;
+    // Give it a name
+    this.getName = sinon.stub(Tessel.prototype, 'getName', function() {
+      console.log('FETCHING NAME!')
+      return Promise.reject('Could not get name for some reason...');
+    });
+
+    // Calculate how long half of the scan time is
+    var halfScan = scanTime/2;
+    // Once half of the scan time has elapsed
+    setTimeout(function() {
+      // Emit a new connection
+      this.seeker.lanScan.emit('connection', lan.connection);
+    }.bind(this), halfScan);
+  },
+
+  // A test with multiple kinds of connections
+
+  // A test where seeker.stop is explicitly called instead of waiting for timeout
 };

--- a/test/unit/discover.js
+++ b/test/unit/discover.js
@@ -5,6 +5,7 @@ var lan = require('../../lib/lan_connection');
 var TesselSeeker = require('../../lib/discover').TesselSeeker;
 var TesselSimulater = require('../common/tessel-simulator');
 var Tessel = require('../../lib/tessel/tessel.js');
+var logs = require('../../lib/logs');
 
 
 function FakeScanner() {
@@ -42,10 +43,11 @@ exports['TesselSeeker'] = {
 
 exports['TesselSeeker.prototype.start'] = {
   setUp: function(done) {
-    this.usbStartScan = sinon.stub(usb, 'startScan', function() {
+    this.sandbox = sinon.sandbox.create();
+    this.usbStartScan = this.sandbox.stub(usb, 'startScan', function() {
       return new FakeScanner();
     });
-    this.lanStartScan = sinon.stub(lan, 'startScan', function() {
+    this.lanStartScan = this.sandbox.stub(lan, 'startScan', function() {
       return new FakeScanner();
     });
 
@@ -55,8 +57,7 @@ exports['TesselSeeker.prototype.start'] = {
   },
 
   tearDown: function(done) {
-    this.usbStartScan.restore();
-    this.lanStartScan.restore();
+    this.sandbox.restore();
     done();
   },
 
@@ -75,12 +76,15 @@ exports['TesselSeeker.prototype.start'] = {
 
 exports['TesselSeeker.prototype.stop'] = {
   setUp: function(done) {
-    this.stop = sinon.spy(FakeScanner.prototype, 'stop');
 
-    this.usbStartScan = sinon.stub(usb, 'startScan', function() {
+    this.sandbox = sinon.sandbox.create();
+
+    this.stop = this.sandbox.spy(FakeScanner.prototype, 'stop');
+
+    this.usbStartScan = this.sandbox.stub(usb, 'startScan', function() {
       return new FakeScanner();
     });
-    this.lanStartScan = sinon.stub(lan, 'startScan', function() {
+    this.lanStartScan = this.sandbox.stub(lan, 'startScan', function() {
       return new FakeScanner();
     });
     this.seeker = new TesselSeeker();
@@ -89,9 +93,7 @@ exports['TesselSeeker.prototype.stop'] = {
   },
 
   tearDown: function(done) {
-    this.stop.restore();
-    this.usbStartScan.restore();
-    this.lanStartScan.restore();
+    this.sandbox.restore();
     done();
   },
 
@@ -157,25 +159,46 @@ exports['TesselSeeker.prototype.stop'] = {
     test.equal(this.stop.callCount, 1);
 
     test.done();
+  }
+}
+
+exports['TesselSeeker Scan Time'] = {
+  setUp: function(done) {
+
+    this.sandbox = sinon.sandbox.create();
+    this.logsWarn = this.sandbox.stub(logs, 'warn', function() {});
+    this.logsInfo = this.sandbox.stub(logs, 'info', function() {});
+    this.logsBasic = this.sandbox.stub(logs, 'basic', function() {});
+    this.logsBasic = this.sandbox.stub(logs, 'err', function() {});
+
+    this.stop = this.sandbox.spy(FakeScanner.prototype, 'stop');
+
+    this.usbStartScan = this.sandbox.stub(usb, 'startScan', function() {
+      return new FakeScanner();
+    });
+    this.lanStartScan = this.sandbox.stub(lan, 'startScan', function() {
+      return new FakeScanner();
+    });
+    this.seeker = new TesselSeeker();
+
+    done();
+  },
+
+  tearDown: function(done) {
+    // Remove sigint listeners once we finish with the Tessels
+    process.removeAllListeners('SIGINT');
+    this.sandbox.restore();
+    done();
   },
 
   oneUnauthorizedLANPending: function(test) {
     test.expect(1);
-    // Scan for new connections for one second
+    // Scan for new connections for this period
     var scanTime = 100;
-    // Start scan
-    this.seeker.start(scanTime);
-    // Array to save found Tessels in
-    var found = [];
-
-    // When we get a Tessel
-    this.seeker.on('tessel', function(tessel) {
-      // save it
-      found.push(tessel);
-    });
-
+   
+    standardSeekerSetup(this.seeker, scanTime)
     // When all Tessels have completed opening
-    this.seeker.on('end', function() {
+    .then(function(found) {
       // Make sure we only have the one Tessel we created
       test.equal(found.length, 1);
       test.done();
@@ -183,144 +206,199 @@ exports['TesselSeeker.prototype.stop'] = {
 
     // Create a Simulated LAN Tessel (Unathorized)
     var lan = TesselSimulater('LAN');
-
-    // Create it's open function
-    lan.connection.open = function() {
-      // After twice the scanning time, finally resolve
-      return new Promise(function(resolve) {
-        setTimeout(function() {
-          return resolve();
-        }, scanTime * 2);
-      });
-    }
-
     // Give it a name
     lan.connection.host = 'Tessel-Test_Subject'
-
-    // Calculate how long half of the scan time is
-    var halfScan = scanTime / 2;
-    // Once half of the scan time has elapsed
-    setTimeout(function() {
-      // Emit a new connection
-      this.seeker.lanScan.emit('connection', lan.connection);
-    }.bind(this), halfScan);
+    // Create it's open function
+    lan.connection.open = resolveOpenInMs.bind(this, scanTime * 2);
+    // Once half of the scan time has elapsed, emit a new connection
+    emitConnectionInMs(this.seeker, lan.connection, scanTime / 2);
   },
 
   oneAuthorizedLANPending: function(test) {
     test.expect(2);
     // Spy on the seeker stop
-    this.seekerStop = sinon.spy(TesselSeeker.prototype, 'stop');
-    // Scan for new connections for one second
-    var scanTime = 100;
-    // Start scan
-    this.seeker.start(scanTime);
-    // Array to save found Tessels in
-    var found = [];
+    this.seekerStop = this.sandbox.spy(TesselSeeker.prototype, 'stop');
 
-    // When we get a Tessel
-    this.seeker.on('tessel', function(tessel) {
-      // save it
-      found.push(tessel);
-    });
-
-    // When all Tessels have completed opening
-    this.seeker.on('end', function() {
-      // Make sure we only have the one Tessel we created
-      test.equal(found.length, 1);
-      // The seeker was told to stop after the timeout ran down
-      test.equal(this.seekerStop.callCount, 1);
-      // Restore our stub so we can stub it again later
-      this.getName.restore();
-      test.done();
-    }.bind(this));
-
-    // Create a Simulated LAN Tessel (Unathorized)
-    var lan = TesselSimulater('LAN');
-
-    // Create it's open function
-    lan.connection.open = function() {
-      // After twice the scanning time, finally resolve
-      return new Promise(function(resolve) {
-        setTimeout(function() {
-          return resolve();
-        }, scanTime * 2);
-      });
-    }
-
-    // Authorize it
-    lan.connection.authorized = true;
-    // Give it a name
-    this.getName = sinon.stub(Tessel.prototype, 'getName', function() {
+        // Give it a name
+    this.getName = this.sandbox.stub(Tessel.prototype, 'getName', function() {
       return new Promise(function(resolve) {
         resolve('Tessel-Test_Subject')
       });
     });
 
-    // Calculate how long half of the scan time is
-    var halfScan = scanTime / 2;
-    // Once half of the scan time has elapsed
-    setTimeout(function() {
-      // Emit a new connection
-      this.seeker.lanScan.emit('connection', lan.connection);
-    }.bind(this), halfScan);
-  },
-
-  oneAuthorizedLANPendingFails: function(test) {
-    test.expect(1);
-    // Scan for new connections for one second
+    // Scan for this period
     var scanTime = 100;
-    // Start scan
-    this.seeker.start(scanTime);
-    // Array to save found Tessels in
-    var found = [];
-
-    // When we get a Tessel
-    this.seeker.on('tessel', function(tessel) {
-      // save it
-      found.push(tessel);
-    });
-
     // When all Tessels have completed opening
-    this.seeker.on('end', function() {
-      console.log('DONE')
+    standardSeekerSetup(this.seeker, scanTime)
+    .then(function discoveryComplete(found) {
       // Make sure we only have the one Tessel we created
-      test.equal(found.length, 0);
-      // Restore our stub so we can stub it again later
-      this.getName.restore();
+      test.equal(found.length, 1);
+      // The seeker was told to stop after the timeout ran down
+      test.equal(this.seekerStop.callCount, 1);
       test.done();
     }.bind(this));
 
     // Create a Simulated LAN Tessel (Unathorized)
     var lan = TesselSimulater('LAN');
 
-    // Create it's open function
-    lan.connection.open = function() {
-      // After twice the scanning time, finally resolve
-      return new Promise(function(resolve) {
-        setTimeout(function() {
-          return resolve();
-        }, scanTime * 2);
-      });
-    }
-
     // Authorize it
     lan.connection.authorized = true;
-    // Give it a name
-    this.getName = sinon.stub(Tessel.prototype, 'getName', function() {
-      console.log('FETCHING NAME!')
+
+    // Create it's open function
+    lan.connection.open = resolveOpenInMs.bind(this, scanTime * 2);
+
+    // Emit the connection halfway through the scan
+    emitConnectionInMs(this.seeker, lan.connection, scanTime / 2)
+  },
+
+  oneAuthorizedLANPendingFails: function(test) {
+    test.expect(1);
+    // Scan for new connections for this period
+    var scanTime = 100;
+
+    // Error on name fetch
+    this.getName = this.sandbox.stub(Tessel.prototype, 'getName', function() {
       return Promise.reject('Could not get name for some reason...');
     });
 
-    // Calculate how long half of the scan time is
-    var halfScan = scanTime/2;
-    // Once half of the scan time has elapsed
-    setTimeout(function() {
-      // Emit a new connection
-      this.seeker.lanScan.emit('connection', lan.connection);
-    }.bind(this), halfScan);
+    // Start scan
+    standardSeekerSetup(this.seeker, scanTime)
+    // When all Tessels have completed opening
+    .then(function(found) {
+      // Make sure we don't find any Tessels
+      test.equal(found.length, 0);
+      test.done();
+    }.bind(this));
+
+    // Create a Simulated LAN Tessel (Unathorized)
+    var lan = TesselSimulater('LAN');
+
+    // Authorize it
+    lan.connection.authorized = true;
+
+    // Create it's open function
+    lan.connection.open = resolveOpenInMs.bind(this, scanTime * 2);
+
+    // Emit the connection halfway through the scan
+    emitConnectionInMs(this.seeker, lan.connection, scanTime / 2);
   },
 
-  // A test with multiple kinds of connections
+  // A test with multiple kinds of connections emitted at different times
+  usbAndLANConnections: function(test) {
+    test.expect(1);
+    // Scan for new connections for one second
+    var scanTime = 100;
+
+    // Give it a name
+    this.getName = this.sandbox.stub(Tessel.prototype, 'getName', function() {
+      return Promise.resolve('Tessel-AndFriends');
+    });
+    
+    // When all Tessels have completed opening
+    standardSeekerSetup(this.seeker, scanTime)
+    .then(function(found) {
+      // Make sure we only have the one Tessel we created
+      test.equal(found.length, 4);
+      test.done();
+    }.bind(this));
+
+    // Create a simulated LAN Tessel (Unathorized)
+    var lan1 = TesselSimulater('LAN');
+    // Create a simulated LAN Tessel (authorized)
+    var lan2 = TesselSimulater('LAN');
+
+    // Authorize it
+    lan2.connection.authorized = true;
+
+    // Create open functions authorized Tessel opens after scan has 
+    // complete but unauthorized opens before scan completes
+    lan1.connection.open = resolveOpenInMs.bind(this, scanTime + 1);
+    // Give it a name
+    lan1.connection.host = 'Tessel-TroubleMaker'
+    lan2.connection.open = resolveOpenInMs.bind(this, scanTime + 2);
+
+    var usb1 = TesselSimulater('USB');
+    var usb2 = TesselSimulater('USB');
+
+    usb1.connection.open = resolveOpenInMs.bind(this, scanTime + 3);
+    usb2.connection.open = resolveOpenInMs.bind(this, scanTime + 4);
+
+   emitConnectionInMs(this.seeker, lan1.connection, scanTime / 4);
+   emitConnectionInMs(this.seeker, usb1.connection, scanTime / 3);
+   emitConnectionInMs(this.seeker, lan2.connection, scanTime / 2);
+   emitConnectionInMs(this.seeker, usb2.connection, scanTime / 1.1);
+  },
 
   // A test where seeker.stop is explicitly called instead of waiting for timeout
+  explicitStop : function(test) {
+    test.expect(1);
+    // Scan for new connections for this period
+    var scanTime = 100;
+
+    // Error on name fetch
+    this.getName = this.sandbox.stub(Tessel.prototype, 'getName', function() {
+      return Promise.resolve('Frank');
+    });
+
+    // Start scan
+    standardSeekerSetup(this.seeker, scanTime)
+    // When all Tessels have completed opening
+    .then(function(found) {
+      // Make sure we don't find any Tessels because we stopped the scan
+      test.equal(found.length, 0);
+      test.done();
+    }.bind(this));
+
+    // Create a Simulated LAN Tessel (Unathorized)
+    var lan = TesselSimulater('LAN');
+
+    // Authorize it
+    lan.connection.authorized = true;
+
+    // Create it's open function
+    lan.connection.open = resolveOpenInMs.bind(this, scanTime * 2);
+
+    // Emit the connection halfway through the scan
+    emitConnectionInMs(this.seeker, lan.connection, scanTime / 2);
+
+    setTimeout(function stopScan() {
+      this.seeker.stop()
+    }.bind(this), scanTime)
+  }
 };
+
+function standardSeekerSetup(seeker, scanTime) {
+  return new Promise(function(resolve) {
+    // Start scan
+    seeker.start(scanTime);
+    // Array to save found Tessels in
+    var found = [];
+
+    // When we get a Tessel
+    seeker.on('tessel', function(tessel) {
+      // save it
+      found.push(tessel);
+    });
+
+    // When all Tessels have completed opening
+    seeker.once('end', function() {
+      return resolve(found);
+    });
+  });
+}
+
+function resolveOpenInMs(ms) {
+  // After twice the scanning time, finally resolve
+  return new Promise(function(resolve) {
+    setTimeout(function() {
+      return resolve();
+    }, ms);
+  });
+}
+
+function emitConnectionInMs(seeker, connection, ms) {
+  setTimeout(function() {
+    // Emit a new connection
+    seeker.lanScan.emit('connection', connection);
+  }, ms);
+}

--- a/test/unit/tessel.js
+++ b/test/unit/tessel.js
@@ -4,8 +4,9 @@ var Seeker = require('../../lib/discover.js');
 var util = require('util');
 var EventEmitter = require('events').EventEmitter;
 var logs = require('../../lib/logs');
-// Require this function so that the functions in the controller placed on the Tessel prototype
-require('../../lib/controller')
+// Require this function so that the functions in the 
+// controller placed on the Tessel prototype
+require('../../lib/controller');
 
 exports['Tessel (endConnection)'] = {
   setUp: function(done) {

--- a/test/unit/tessel.js
+++ b/test/unit/tessel.js
@@ -4,6 +4,8 @@ var Seeker = require('../../lib/discover.js');
 var util = require('util');
 var EventEmitter = require('events').EventEmitter;
 var logs = require('../../lib/logs');
+// Require this function so that the functions in the controller placed on the Tessel prototype
+require('../../lib/controller')
 
 exports['Tessel (endConnection)'] = {
   setUp: function(done) {
@@ -66,11 +68,13 @@ exports['Tessel (get)'] = {
     // This is necessary to prevent an EventEmitter memory leak warning
     this.processOn = this.sandbox.stub(process, 'on');
     this.seeker = this.sandbox.stub(Seeker, 'TesselSeeker', function Seeker() {
-      this.start = function() {
+      this.start = function(timeout) {
         self.activeSeeker = this;
+        setTimeout(this.stop.bind(this), timeout);
         return this;
       };
       this.stop = function() {
+        this.emit('end');
         return this;
       };
     });


### PR DESCRIPTION
This PR makes Tessel discovery much more robust. Especially during `t2 update`, I was noticing that my LAN connection would come up on `t2 list` but when I ran `t2 update`, only my USB connection was found and that's what was used. USB connection takes forever for update so I'd basically need to run the command again.

The problem is that the CLI was just using a timeout for when Tessel discovery is complete. That leads to situations where a LAN connection is found but not opened before the timeout is hit.

This PR makes the discovery process wait for all pending connections to either open or fail before ending the search.

Additionally, I've pulled the default timeout back to 2 seconds because generally, you find the LAN connection within ~1s so 2s gives a nice margin of error. The fetch usually completes around 3s now.