### PR TITLE
Fixes help printout

### DIFF
--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -87,7 +87,7 @@ parser.command('restart')
     default: 'ram',
     help: 'Specify where in memory the script is located: `--type=flash` (push) or `--type=ram` (run)'
   })
-  .help('Restart a previously deployed script in RAM or Flash memory. (Does not rebundle)');
+  .help('Restart a previously deployed script in RAM or Flash memory (does not rebundle)');
 
 parser.command('run')
   .callback(function(opts) {
@@ -244,7 +244,7 @@ parser.command('rename')
       .then(closeSuccessfulCommand, closeFailedCommand);
   })
   .option('timeout', timeoutOption)
-  .help('Change the name of a Tessel to something new.');
+  .help('Change the name of a Tessel to something new');
 
 parser.command('update')
   .option('version', {

--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -226,7 +226,8 @@ parser.command('key')
         logs.info('Key successfully generated.');
       })
       .then(closeSuccessfulCommand, closeFailedCommand);
-  });
+  })
+  .help('Generate a local SSH keypair for authenticating a Tessel VM');
 
 parser.command('rename')
   .option('newName', {


### PR DESCRIPTION
adds help for key command which fixes https://github.com/tessel/t2-cli/issues/173

## Here's what it does
Before merge:
```sh
➜  t2-cli git:(master) ✗ t2

Usage: /usr/local/bin/iojs t2 <command>

command     one of: provision, restart, run, push, erase, list, init, wifi, key, rename, update
```

After merge:
```sh
➜  t2-cli git:(kb-help) t2

command argument is required

Usage: /usr/local/bin/iojs t2 <command>

command
  provision     Authorize your computer to control the USB-connected Tessel
  restart       Restart a previously deployed script in RAM or Flash memory. (Does not rebundle)
  run           Deploy a script to Tessel and run it with Node
  push          Pushes the file/dir to Flash memory to be run anytime the Tessel is powered, runs the file immediately once the file is copied over
  erase         Erases files pushed to Flash using the tessel push command
  list          Lists all connected Tessels and their authorization status.
  init          Initialize repository for your Tessel project
  wifi          Configure the wireless connection
  key           Generate a local SSH keypair for authenticating a Tessel VM
  rename        Change the name of a Tessel to something new.
  update        Update the Tessel firmware and openWRT image
```

## Here's what was going on
[nomnom.js](https://github.com/harthur/nomnom/blob/master/nomnom.js) specifies in the comments:
```js
          // if there are a small number of commands and all have help strings,
          // display them in a two column table; otherwise use the brief version.
          // The arbitrary choice of "20" comes from the number commands git
          // displays as "common commands"
```

Since we don't have 20+ commands, I checked for help strings on all of our commands. Sure enough, one was missing. Adding it makes nomnom print out the much more useful two-column help format.

## What to do

- [ ] Can someone please check my help description for `key`? I'm not actually sure what it does, and it's not documented (see https://github.com/tessel/t2-docs/issues/12)
- [ ] Please be careful in adding any new commands or options to add a .help key. Perhaps we should have a test for this?