### PR TITLE
Add neutral wifi command to list Tessel Wifi Information

### DIFF
--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -197,7 +197,6 @@ parser.command('wifi')
         closeFailedCommand(new Error(msg));
       }
     } else {
-      console.log(opts);
       controller.getWifiInfo(opts)
         .then(closeSuccessfulCommand, closeFailedCommand);
     }

--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -23,19 +23,12 @@ function closeSuccessfulCommand() {
   process.exit(0);
 }
 
-// Allow options to be partially applied
-function closeFailedCommand(opts, err) {
-  if (!err) {
-    err = opts;
-    opts = {};
-  }
-
+function closeFailedCommand(err) {
   if (err instanceof Error) {
     throw err;
   } else {
     // Print a stern warning by default
-    opts.type = opts.type || 'warn';
-    logs[opts.type](err);
+    logs.warn(err);
   }
   // NOTE: Exit code is non-zero
   process.exit(1);
@@ -201,11 +194,10 @@ parser.command('wifi')
         var msg = opts.ssid ?
           'Please provide a password with -p <password>' :
           'Please provide a network name (SSID) with -n <name>';
-        closeFailedCommand({
-          type: 'err'
-        }, msg);
+        closeFailedCommand(new Error(msg));
       }
     } else {
+      console.log(opts);
       controller.getWifiInfo(opts)
         .then(closeSuccessfulCommand, closeFailedCommand);
     }

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -457,7 +457,6 @@ controller.getWifiInfo = function(opts) {
       return selectedTessel.getWifiInfo()
         .then(function(network) {
           // Grab inet lines, flatmap them, remove empty
-          // Wanted to do this with awk and cut inside commands.js
           var ips = network.ips.filter(function(item) {
               return /inet/.exec(item);
             })
@@ -484,7 +483,11 @@ controller.getWifiInfo = function(opts) {
           logs.info('Signal Strength: (' + network.quality + '/' + network.quality_max + ')');
           logs.info('Bitrate: ' + Math.round(network.bitrate / 1000) + 'mbps');
         })
-        .then(function() {
+        .catch(function(err) {
+          // Handle no Wi-Fi
+          logs.err(err.message);
+        })
+        .finally(function() {
           return controller.closeTesselConnections(selectedTessel);
         });
     });

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -451,6 +451,45 @@ controller.printAvailableNetworks = function(opts) {
     });
 };
 
+controller.getWifiInfo = function(opts) {
+  return Tessel.get(opts)
+    .then(function(selectedTessel) {
+      return selectedTessel.getWifiInfo()
+        .then(function(network) {
+          // Grab inet lines, flatmap them, remove empty
+          // Wanted to do this with awk and cut inside commands.js
+          var ips = network.ips.filter(function(item) {
+              return /inet/.exec(item);
+            })
+            .map(function(line) {
+              return line.split(' ');
+            })
+            .reduce(function(a, b) {
+              return a.concat(b);
+            })
+            .filter(function(item) {
+              return /addr/.exec(item);
+            })
+            .map(function(chunk) {
+              return chunk.split(':')[1];
+            })
+            .filter(function(addr) {
+              return addr.length;
+            });
+
+          logs.info('Connected to "' + network.ssid + '"');
+          ips.forEach(function(ip) {
+            logs.info('IP Address: ' + ip);
+          });
+          logs.info('Signal Strength: (' + network.quality + '/' + network.quality_max + ')');
+          logs.info('Bitrate: ' + Math.round(network.bitrate / 1000) + 'mbps');
+        })
+        .then(function() {
+          return controller.closeTesselConnections(selectedTessel);
+        });
+    });
+};
+
 controller.connectToNetwork = function(opts) {
   // Grab the preferred Tessel
   return Tessel.get(opts)

--- a/lib/tessel/commands.js
+++ b/lib/tessel/commands.js
@@ -4,6 +4,12 @@ module.exports.readFile = function(filepath) {
 module.exports.scanWiFi = function() {
   return ['ubus', 'call', 'iwinfo', 'scan', '{"device":"wlan0"}'];
 };
+module.exports.getWifiInfo = function() {
+  return ['ubus', 'call', 'iwinfo', 'info', '{"device":"wlan0"}'];
+};
+module.exports.getIPAddress = function() {
+  return ['ifconfig', 'wlan0'];
+};
 module.exports.stopRunningScript = function() {
   return ['/etc/init.d/tessel-app', 'stop'];
 };

--- a/lib/tessel/wifi.js
+++ b/lib/tessel/wifi.js
@@ -3,6 +3,10 @@ var Tessel = require('./tessel'),
   logs = require('../logs'),
   Promise = require('bluebird');
 
+function logErr(d) {
+  logs.err(d.toString());
+}
+
 Tessel.prototype.findAvailableNetworks = function() {
   var self = this;
   return new Promise(function(resolve, reject) {
@@ -12,9 +16,7 @@ Tessel.prototype.findAvailableNetworks = function() {
 
         var resultsJSON = '';
 
-        remoteProcess.stderr.on('data', function(d) {
-          logs.err(d.toString());
-        });
+        remoteProcess.stderr.on('data', logErr);
 
         // Gather the results
         remoteProcess.stdout.on('data', function(d) {
@@ -50,6 +52,56 @@ Tessel.prototype.findAvailableNetworks = function() {
             .then(function() {
               // Return the networks
               return resolve(networks);
+            });
+        });
+      });
+  });
+};
+
+Tessel.prototype.getWifiInfo = function() {
+  var self = this;
+  return new Promise(function(resolve, reject) {
+    return self.connection.exec(commands.getWifiInfo())
+      .then(function(remoteProcess) {
+        var resultsJSON = '';
+
+        remoteProcess.stdout.on('data', function(d) {
+          resultsJSON += d;
+        });
+        remoteProcess.stderr.on('data', logErr);
+        remoteProcess.once('close', function() {
+          try {
+            var network = JSON.parse(resultsJSON);
+          } catch (err) {
+            return self.connection.end()
+              .then(function() {
+                reject(err);
+              });
+          }
+
+          return self.connection.exec(commands.getIPAddress())
+            .then(function(rp) {
+              var result = '';
+
+              rp.stdout.on('data', function(d) {
+                result += d;
+              });
+              rp.stderr.on('data', logErr);
+              rp.once('close', function() {
+                try {
+                  network.ips = result.split('\n');
+                } catch (err) {
+                  return self.connection.end()
+                    .then(function() {
+                      reject(err);
+                    });
+                }
+
+                return self.connection.end()
+                  .then(function() {
+                    return resolve(network);
+                  });
+              });
             });
         });
       });
@@ -95,7 +147,7 @@ Tessel.prototype.connectToNetwork = function(opts) {
       .then(function(remoteProcess) {
         // Once the credentials have been comitted
         remoteProcess.once('close', function() {
-          // Restart the wifi 
+          // Restart the wifi
           return self.connection.exec(commands.reconnectWifi())
             .then(function(remoteProcess) {
               // Once the wifi restart process closes

--- a/lib/tessel/wifi.js
+++ b/lib/tessel/wifi.js
@@ -3,39 +3,35 @@ var Tessel = require('./tessel'),
   logs = require('../logs'),
   Promise = require('bluebird');
 
-function logErr(d) {
-  logs.err(d.toString());
-}
-
 Tessel.prototype.findAvailableNetworks = function() {
   var self = this;
   return new Promise(function(resolve, reject) {
     logs.info('Scanning for available networks...');
     return self.connection.exec(commands.scanWiFi())
       .then(function(remoteProcess) {
-
+        var err = '';
         var resultsJSON = '';
 
-        remoteProcess.stderr.on('data', logErr);
-
-        // Gather the results
+        // Gather errors and results
+        remoteProcess.stderr.on('data', function(d) {
+          err += d.toString();
+        });
         remoteProcess.stdout.on('data', function(d) {
-          resultsJSON += d;
+          resultsJSON += d.toString();
         });
 
         // Wait for the transfer to finish...
         remoteProcess.once('close', function() {
+          if (err.length) {
+            reject(new Error(err));
+          }
           var networks;
 
-          // Parse the response
           try {
             networks = JSON.parse(resultsJSON).results;
           } catch (err) {
             self.connection.end();
-            // Throw any unfortunate errors
-            if (err) {
-              return reject(err);
-            }
+            return reject(err);
           }
 
           // Sort by signal strength
@@ -63,15 +59,24 @@ Tessel.prototype.getWifiInfo = function() {
   return new Promise(function(resolve, reject) {
     return self.connection.exec(commands.getWifiInfo())
       .then(function(remoteProcess) {
+        var err = '';
         var resultsJSON = '';
 
-        remoteProcess.stdout.on('data', function(d) {
-          resultsJSON += d;
+        remoteProcess.stderr.on('data', function(d) {
+          err += d.toString();
         });
-        remoteProcess.stderr.on('data', logErr);
+        remoteProcess.stdout.on('data', function(d) {
+          resultsJSON += d.toString();
+        });
+
         remoteProcess.once('close', function() {
+          var network;
+          if (err.length) {
+            return reject(new Error(err));
+          }
+
           try {
-            var network = JSON.parse(resultsJSON);
+            network = JSON.parse(resultsJSON);
           } catch (err) {
             return self.connection.end()
               .then(function() {
@@ -79,15 +84,28 @@ Tessel.prototype.getWifiInfo = function() {
               });
           }
 
+          if (network.ssid === undefined) {
+            var msg = self.name + ' is not connected to Wi-Fi (run "tessel wifi -l" to see available networks)';
+            return reject(new Error(msg));
+          }
+
           return self.connection.exec(commands.getIPAddress())
             .then(function(rp) {
+              var err = '';
               var result = '';
 
-              rp.stdout.on('data', function(d) {
-                result += d;
+              rp.stderr.on('data', function(d) {
+                err += d.toString();
               });
-              rp.stderr.on('data', logErr);
+              rp.stdout.on('data', function(d) {
+                result += d.toString();
+              });
+
               rp.once('close', function() {
+                if (err.length) {
+                  reject(new Error(err));
+                }
+
                 try {
                   network.ips = result.split('\n');
                 } catch (err) {
@@ -123,11 +141,7 @@ Tessel.prototype.connectToNetwork = function(opts) {
   var ssid = opts.ssid;
   var password = opts.password;
 
-  return new Promise(function(resolve, reject) {
-    if (!ssid || !password) {
-      return reject(new Error('Invalid credentials. Must set ssid and password'));
-    }
-
+  return new Promise(function(resolve) {
     logs.info('Setting SSID:', ssid, 'and password:', password);
 
     // Set the network SSID
@@ -160,7 +174,6 @@ Tessel.prototype.connectToNetwork = function(opts) {
             });
         });
       });
-
   });
 };
 


### PR DESCRIPTION
It does this:

```bash
~/s/t/bin ❯❯❯ /.nvm/versions/io.js/v2.2.1/bin/iojs tessel-2.js wifi
INFO Connecting to Tessel...
INFO Connected to pixel over USB
INFO Connected to "NETWORK"
INFO IP Address: 10.0.0.40
INFO Signal Strength: (61/70)
INFO Bitrate: 65mbps
```

Adds two commands, and a fairly painful method to wifi.js.