### PR TITLE
lib: remove workaround for mdns library bug

### DIFF
--- a/lib/discover.js
+++ b/lib/discover.js
@@ -52,6 +52,7 @@ TesselSeeker.prototype.start = function(timeout) {
     // Push this Promise into the pending array
     pendingOpen.push(opening);
   }
+
   // If a timeout was provided
   if (timeout && typeof timeout === 'number') {
     // Set a timeout function

--- a/lib/lan_connection.js
+++ b/lib/lan_connection.js
@@ -142,9 +142,7 @@ LAN.Scanner.prototype.start = function() {
         // Start discovering Tessels
         self.browser.discover();
       } catch (err) {
-        process.nextTick(function() {
-          self.emit('error', err);
-        });
+        self.emit('error', err);
       }
     });
 
@@ -161,9 +159,7 @@ LAN.Scanner.prototype.start = function() {
 
         self.emit('connection', connection);
       } catch (err) {
-        process.nextTick(function() {
-          self.emit('error', err);
-        });
+        self.emit('error', err);
       }
     });
   });

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "fstream-ignore": "^1.0.2",
     "keypress": "^0.2.1",
     "lodash": "^3.5.0",
-    "mdns-js": "^0.3.1",
+    "mdns-js": "^0.4.0",
     "nomnom": "^1.8.1",
     "npm": "^2.7.1",
     "osenv": "^0.1.0",

--- a/test/unit/provision.js
+++ b/test/unit/provision.js
@@ -84,6 +84,12 @@ exports['controller.provisionTessel'] = {
 
     this.provisionSpy = sinon.spy(Tessel.prototype, 'provisionTessel');
 
+    this.getName = sinon.stub(Tessel.prototype, 'getName', function() {
+      return new Promise(function(resolve) {
+        resolve('Tessel-1');
+      });
+    });
+
     this.getTessel = sinon.stub(Tessel, 'get', function() {
       return new Promise(function(resolve) {
         resolve(self.tessel);
@@ -102,6 +108,7 @@ exports['controller.provisionTessel'] = {
     this.provisionTessel.restore();
     this.provisionSpy.restore();
     this.exec.restore();
+    this.getName.restore();
     this.getTessel.restore();
     this.logsWarn.restore();
     this.logsInfo.restore();


### PR DESCRIPTION
This workaround is no longer required since this have been fixed upstream in `0.4.0`

@johnnyman727 care to review?