### PR TITLE
friendlier blinky

### DIFF
--- a/resources/index.js
+++ b/resources/index.js
@@ -1,11 +1,13 @@
 // Import the interface to Tessel hardware
 var tessel = require('tessel');
 
-// Set the led pins as outputs with initial states
-// Truthy initial state sets the pin high
-// Falsy sets it low.
-var led1 = tessel.led[0];
-var led2 = tessel.led[1];
+// Set the led pins as outputs
+var led1 = tessel.led[2];
+var led2 = tessel.led[3];
+
+// Set initial LED states
+led1.output(1);
+led2.output(0);
 
 setInterval(function () {
     console.log("I'm blinking! (Press CTRL + C to stop)");


### PR DESCRIPTION
Current blinky from `t2 init` flashes red and yellow in sync - not only overwriting error and wifi LEDs but also perfectly mimicking crash behavior from T1.

This blinks alternating green and yellow just like T1 blinky.