### PR TITLE
use fully resolved path when push|run single file

### DIFF
--- a/lib/tessel/deploy.js
+++ b/lib/tessel/deploy.js
@@ -193,6 +193,7 @@ actions.sendBundle = function(t, filepath, opts) {
 
         actions.findProject(opts).then(function(project) {
           opts.target = path.resolve(process.cwd(), project.pushdir);
+          opts.resolvedEntryPoint = project.entryPoint;
 
           // Collect error data as received
           remoteProcess.stderr.on('data', function(data) {
@@ -241,7 +242,7 @@ actions.tarBundle = function(opts) {
     });
 
     if (opts.single) {
-      fstream.addIgnoreRules(['*', '!' + opts.entryPoint]);
+      fstream.addIgnoreRules(['*', '!' + opts.resolvedEntryPoint]);
     }
 
     fstream.basename = '';

--- a/test/unit/deploy.js
+++ b/test/unit/deploy.js
@@ -136,7 +136,7 @@ exports['tarBundle'] = {
       target: target
     }).then(function(bundle) {
       test.equal(this.addIgnoreRules.callCount, 0);
-      test.equal(bundle.length, 3072);
+      test.equal(bundle.length, 4608);
       test.done();
     }.bind(this));
   },
@@ -150,11 +150,31 @@ exports['tarBundle'] = {
     deploy.tarBundle({
       target: target,
       entryPoint: entryPoint,
+      resolvedEntryPoint: entryPoint,
       single: true
     }).then(function(bundle) {
       test.equal(this.addIgnoreRules.callCount, 1);
       test.deepEqual(this.addIgnoreRules.lastCall.args[0], ['*', '!index.js']);
       test.equal(bundle.length, 2048);
+      test.done();
+    }.bind(this));
+  },
+
+  singleNested: function(test) {
+    test.expect(3);
+
+    var target = 'test/unit/fixtures/bundling';
+    var entryPoint = 'another.js';
+
+    deploy.tarBundle({
+      target: target,
+      entryPoint: entryPoint,
+      resolvedEntryPoint: 'nested/' + entryPoint,
+      single: true
+    }).then(function(bundle) {
+      test.equal(this.addIgnoreRules.callCount, 1);
+      test.deepEqual(this.addIgnoreRules.lastCall.args[0], ['*', '!nested/another.js']);
+      test.equal(bundle.length, 2560);
       test.done();
     }.bind(this));
   },

--- a/test/unit/fixtures/bundling/nested/another.js
+++ b/test/unit/fixtures/bundling/nested/another.js
@@ -1,0 +1,1 @@
+console.log('testing deploy');


### PR DESCRIPTION
if you push a file from a nested dir, it should untar into correct location