### PR TITLE
[Bug Fix] Wait for deploy folder to be created before deploying to it

### DIFF
--- a/lib/tessel/deploy.js
+++ b/lib/tessel/deploy.js
@@ -39,7 +39,7 @@ Tessel.prototype.deployScript = function(opts) {
           // Delete any code that was previously at this file path
           prom = actions.execRemoteCommand(self, 'deleteFolder', filepath);
           // Create the folder again
-          prom.then(function() {
+          prom = prom.then(function() {
             return actions.execRemoteCommand(self, 'createFolder', filepath);
           });
         }


### PR DESCRIPTION
@wprater could you review?

I believe we had a small regression in #311 that is causing #336 and #319.

This change ensures that the `createFolder` command completes before moving on to deploying to that folder.