### PR TITLE
Global --key option

### DIFF
--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -6,7 +6,7 @@ var controller = require('../lib/controller');
 var key = require('../lib/key');
 var init = require('../lib/init');
 var logs = require('../lib/logs');
-
+var TESSEL_AUTH_KEY = require('../lib/tessel/provision.js').TESSEL_AUTH_KEY;
 
 function closeSuccessfulCommand() {
   process.exit(0);
@@ -34,6 +34,13 @@ function makeCommand(commandName) {
       metavar: 'TIMEOUT',
       help: 'Set timeout in seconds for scanning for networked tessels',
       default: 5
+    })
+    .option('key', {
+      required: false,
+      metavar: 'PRIVATEKEY',
+      abbr: 'i',
+      default: TESSEL_AUTH_KEY,
+      help: 'RSA key for authorization with your Tessel'
     })
     .option('name', {
       metavar: 'NAME',

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -8,10 +8,15 @@ var cp = require('child_process');
 var async = require('async');
 var updates = require('./update-fetch');
 var controller = {};
+var provision = require('./tessel/provision');
 
 Tessel.list = function(opts) {
 
   return new Promise(function(resolve, reject) {
+
+    // check whether --key is set 
+    provision.setDefaultKey(opts);
+
     // Grab all attached Tessels
     logs.info('Searching for nearby Tessels...');
 
@@ -92,6 +97,9 @@ Tessel.list = function(opts) {
 
 Tessel.get = function(opts) {
   return new Promise(function(resolve, reject) {
+    // check whether --key is set 
+    provision.setDefaultKey(opts);
+
     logs.info('Looking for your Tessel...');
     // Store the amount of time to look for Tessel in seconds
     var timeout = (opts.timeout || 2) * 1000;
@@ -106,7 +114,7 @@ Tessel.get = function(opts) {
         // Report it
         reject('No Tessels Found.');
         return;
-      } 
+      }
       // The name match for a given Tessel happens upon discovery, not at 
       // the completion of discovery. So if we got to this point, no Tessel
       // was found with that name

--- a/lib/lan_connection.js
+++ b/lib/lan_connection.js
@@ -29,7 +29,7 @@ LAN.Connection = function(opts) {
   this.ssh = undefined;
 
   if (Tessel.isProvisioned()) {
-    this.auth.privateKey = opts.privateKey || fs.readFileSync(path.join(Tessel.TESSEL_AUTH_PATH + '/id_rsa'));
+    this.auth.privateKey = opts.privateKey || fs.readFileSync(path.join(Tessel.TESSEL_AUTH_KEY));
   }
 };
 

--- a/lib/tessel/provision.js
+++ b/lib/tessel/provision.js
@@ -13,6 +13,16 @@ var directory = path.join(osenv.home(), '.tessel');
 var filename = 'id_rsa';
 var filepath = path.join(directory, filename);
 var remoteAuthFile = '/etc/dropbear/authorized_keys';
+var debug = require('debug')('provision');
+
+Object.defineProperty(Tessel, 'TESSEL_AUTH_KEY', {
+  get: function() {
+    return filepath;
+  },
+  set: function(value) {
+    filepath = value;
+  }
+});
 
 Object.defineProperty(Tessel, 'TESSEL_AUTH_PATH', {
   get: function() {
@@ -170,6 +180,27 @@ actions.checkAuthFileExists = function(tessel, authFile) {
   });
 };
 
+actions.setDefaultKey = function(opts) {
+
+  if (opts.key && typeof opts.key === 'string') {
+    debug('Using --key ' + opts.key + ' after checking existens');
+    filepath = opts.key;
+  } else if (opts.key && typeof opts.key !== 'string') {
+    logs.err('No valid path for private key');
+    process.exit();
+  }
+  try {
+    if (fs.statSync(filepath).isFile() &&
+      fs.statSync(filepath + '.pub').isFile()) {
+      return;
+    }
+  } catch (e) {
+    debug('Keyfiles not found', e);
+    logs.err('Could not find ' + filepath + ' and its public key (.pub)');
+    process.exit();
+  }
+};
+
 function checkIfKeyInFile(tessel, authFile, pubKey) {
   return new Promise(function(resolve, reject) {
     // Read the public keys from the auth file
@@ -256,7 +287,7 @@ function AlreadyAuthenticatedError() {
 util.inherits(AlreadyAuthenticatedError, Error);
 
 actions.AlreadyAuthenticatedError = AlreadyAuthenticatedError;
-
+module.exports.TESSEL_AUTH_KEY = filepath;
 module.exports = actions;
 
 if (global.IS_TEST_ENV) {

--- a/lib/tessel/provision.js
+++ b/lib/tessel/provision.js
@@ -183,7 +183,7 @@ actions.checkAuthFileExists = function(tessel, authFile) {
 actions.setDefaultKey = function(opts) {
 
   if (opts.key && typeof opts.key === 'string') {
-    debug('Using --key ' + opts.key + ' after checking existens');
+    debug('Using --key ' + opts.key + ' after checking existence');
     filepath = opts.key;
   } else if (opts.key && typeof opts.key !== 'string') {
     logs.err('No valid path for private key');


### PR DESCRIPTION
# Usage
You can verify the use of the global option is working well by
`t2 list --key ~/.ssh/id_rsa`
instead *~/.tessel/id_rsa* what is default.
The result should be (in compression to `t2 list`) your discovered
Tessels will show as non provisioned with note `(USB connect and run
`tessel provision` to authorize)`

This PR is a part of others will base on it. It should work without
conflicts.