### PR TITLE
If the user explicitly specified the usb flag, then we need to ignore authorization filtering.

### DIFF
--- a/lib/discover.js
+++ b/lib/discover.js
@@ -23,6 +23,12 @@ TesselSeeker.prototype.start = function(opts) {
   // An array of pending open connections
   var pendingOpen = [];
 
+  // If the user explicitly specified the usb flag,
+  // then cli should not filter on authorization status.
+  if (opts.usb && !opts.lan) {
+    opts.authorized = undefined;
+  }
+
   // If no connection preference was supplied
   if (!opts.usb && !opts.lan) {
     // Default to all connections


### PR DESCRIPTION
If a user has a Tessel 2 connected via USB and runs a command with the "usb" flag, the "authorized" filter should not interfere with surfacing a USB connected device.


This is blocking us from working in a LAN-less environment. 