### PR TITLE
Colorize `t2 list` by USB, LAN, PROVISIONED and NOT AUTHORIZED

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -40,6 +40,8 @@ Tessel.list = function(opts) {
       responses.noAuth :
       responses.auth;
 
+    var provisioned = Tessel.isProvisioned();
+
     // When a Tessel is found
     seeker.on('tessel', function displayResults(tessel) {
 
@@ -51,10 +53,15 @@ Tessel.list = function(opts) {
       // Add a note if the user isn't authorized to use it yet
       if (tessel.connection.connectionType === 'LAN' && !tessel.connection.authorized) {
         note = '(USB connect and run `t2 provision` to authorize)';
+        logs.basic(sprintf('\t%s\t%s\t%s'.red, tessel.name, tessel.connection.connectionType, note));
+      } else if (tessel.connection.connectionType === 'USB' && !provisioned) {
+        // if the user never used the t2 provision at this place
+        note = '(USB connect and run `t2 provision` to authorize)';
+        logs.basic(sprintf('\t%s\t%s\t%s'.blue, tessel.name, tessel.connection.connectionType, note));
+      } else {
+        // Print out details...
+        logs.basic(sprintf('\t%s\t%s\t%s', tessel.name, tessel.connection.connectionType, note));
       }
-
-      // Print out details...
-      logs.basic(sprintf('\t%s\t%s\t%s', tessel.name, tessel.connection.connectionType, note));
     });
 
     // Called after CTRL+C or timeout


### PR DESCRIPTION
As you could see at summit a lot of listed Tessel 2 will make it difficult to find your own.
![t2listcolored3](https://cloud.githubusercontent.com/assets/5132566/10563624/9d688af0-7590-11e5-9165-670be4caeaf5.png)
So I made a difference from not authorized Tessels when no `~/.tessel/id_rsa` is present. This will help the customer to find own Tessel-Name faster.
