### PR TITLE
Initial access point creation implementation

### DIFF
--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -277,6 +277,28 @@ makeCommand('version')
   .callback(callControllerCallback('tesselFirmwareVerion'))
   .help('Display Tessel\'s current firmware version');
 
+makeCommand('ap')
+  .option('ssid', {
+    abbr: 'n',
+    help: 'Name of the network.'
+  })
+  .option('pass', {
+    abbr: 'p',
+    help: 'Password to access network.'
+  })
+  .option('security', {
+    abbr: 's',
+    help: 'Encryption to use on network (i.e. WEP, WPA, PSK).'
+  })
+  .option('trigger', {
+    position: 0,
+    help: 'Trigger, i.e. on OR off, the access point'
+  })
+  .help('Configure the Tessel as an access point')
+  .callback(function(opts) {
+    callControllerWith('createAccessPoint', opts);
+  });
+
 
 module.exports = function(args) {
   parser.parse(args);

--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -288,7 +288,7 @@ makeCommand('ap')
   })
   .option('security', {
     abbr: 's',
-    help: 'Encryption to use on network (i.e. WEP, WPA, PSK).'
+    help: 'Encryption to use on network (i.e. wep, psk, psk2, wpa, wpa2).'
   })
   .option('trigger', {
     position: 1,

--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -291,12 +291,20 @@ makeCommand('ap')
     help: 'Encryption to use on network (i.e. WEP, WPA, PSK).'
   })
   .option('trigger', {
-    position: 0,
+    position: 1,
     help: 'Trigger, i.e. on OR off, the access point'
   })
   .help('Configure the Tessel as an access point')
   .callback(function(opts) {
-    callControllerWith('createAccessPoint', opts);
+    if (opts.trigger) {
+      if (opts.trigger === 'on') {
+        callControllerWith('enableAccessPoint', opts);
+      } else {
+        callControllerWith('disableAccessPoint', opts);
+      }
+    } else {
+      callControllerWith('createAccessPoint', opts);
+    }
   });
 
 

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -636,6 +636,20 @@ controller.createAccessPoint = function(opts) {
   });
 };
 
+controller.enableAccessPoint = function(opts) {
+  opts.authorized = true;
+  return controller.standardTesselCommand(opts, function(tessel) {
+    return tessel.enableAccessPoint();
+  });
+};
+
+controller.disableAccessPoint = function(opts) {
+  opts.authorized = true;
+  return controller.standardTesselCommand(opts, function(tessel) {
+    return tessel.disableAccessPoint();
+  });
+};
+
 controller.printAvailableUpdates = function() {
   return updates.requestBuildList().then(function(builds) {
     logs.info('Latest builds:');

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -631,9 +631,30 @@ controller.connectToNetwork = function(opts) {
 
 controller.createAccessPoint = function(opts) {
   opts.authorized = true;
-  return controller.standardTesselCommand(opts, function(tessel) {
-    return tessel.createAccessPoint(opts);
-  });
+  var ssid = opts.ssid;
+  var password = opts.pass;
+  var security = opts.security;
+  var securityOptions = ['none', 'wep', 'psk', 'psk2', 'wpa', 'wpa2'];
+
+  return new Promise(function(resolve, reject) {
+      if (!ssid) {
+        reject(new Error('Invalid credentials. Must set ssid'));
+      }
+
+      if (security && !password) {
+        reject(new Error('Invalid credentials. Must set a password with security option'));
+      }
+
+      if (security && securityOptions.indexOf(security) < 0) {
+        reject(new Error(security + ' is not a valid security option. Please choose on of the following: ' + securityOptions.join(', ')));
+      }
+      resolve();
+    })
+    .then(function() {
+      return controller.standardTesselCommand(opts, function(tessel) {
+        return tessel.createAccessPoint(opts);
+      });
+    });
 };
 
 controller.enableAccessPoint = function(opts) {

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -638,15 +638,15 @@ controller.createAccessPoint = function(opts) {
 
   return new Promise(function(resolve, reject) {
       if (!ssid) {
-        reject(new Error('Invalid credentials. Must set ssid'));
+        reject('Invalid credentials. Must set ssid');
       }
 
       if (security && !password) {
-        reject(new Error('Invalid credentials. Must set a password with security option'));
+        reject('Invalid credentials. Must set a password with security option');
       }
 
       if (security && securityOptions.indexOf(security) < 0) {
-        reject(new Error(security + ' is not a valid security option. Please choose on of the following: ' + securityOptions.join(', ')));
+        reject(security + ' is not a valid security option. Please choose on of the following: ' + securityOptions.join(', '));
       }
       resolve();
     })

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -629,6 +629,13 @@ controller.connectToNetwork = function(opts) {
   });
 };
 
+controller.createAccessPoint = function(opts) {
+  opts.authorized = true;
+  return controller.standardTesselCommand(opts, function(tessel) {
+    return tessel.createAccessPoint(opts);
+  });
+};
+
 controller.printAvailableUpdates = function() {
   return updates.requestBuildList().then(function(builds) {
     logs.info('Latest builds:');

--- a/lib/tessel/access-point.js
+++ b/lib/tessel/access-point.js
@@ -1,0 +1,65 @@
+var Tessel = require('./tessel'),
+  commands = require('./commands'),
+  logs = require('../logs');
+
+function commitAndClose(resolve) {
+  var self = Tessel;
+
+  return self.connection.exec(commands.commitWirelessCredentials())
+    .then(function(remoteProcess) {
+      remoteProcess.once('close', function() {
+        return self.connection.exec(commands.reconnectWifi())
+          .then(function(remoteProcess) {
+            return self.receive(remoteProcess).then(function() {
+              logs.info('Access Point credentials set!');
+
+              return self.connection.end()
+                .then(resolve);
+            });
+          });
+      });
+    });
+}
+
+Tessel.prototype.createAccessPoint = function(opts) {
+  var self = this;
+  var ssid = opts.ssid;
+  var password = opts.password;
+  var security = opts.security;
+
+  return new Promise(function(resolve, reject) {
+    if (!ssid) {
+      return reject(new Error('Invalid credentials. Must set ssid'));
+    }
+
+    if (!password || !security) {
+      if (!security) {
+        logs.info('Setting Access Point with SSID:', ssid, 'and password:', password, 'and security mode:', security);
+      } else {
+        logs.info('Setting Access Point with SSID:', ssid, 'and password:', password);
+      }
+    } else {
+      logs.info('Setting Access Point with SSID:', ssid);
+    }
+
+    return self.connection.exec(commands.setAccessPointSSID(ssid))
+      .then(function() {
+        if (password) {
+          return self.connection.exec(commands.setAccessPointPassword(password));
+        } else {
+          return commitAndClose(resolve);
+        }
+      })
+      .then(function() {
+        if (security) {
+          return self.connection.exec(commands.setAccessPointSecurity(security));
+        } else {
+          return commitAndClose(resolve);
+        }
+      })
+      .then(function() {
+        return self.connection.exec(commands.turnAccessPointOn(true))
+          .then(commitAndClose.bind(null, resolve));
+      });
+  });
+};

--- a/lib/tessel/access-point.js
+++ b/lib/tessel/access-point.js
@@ -66,63 +66,81 @@ Tessel.prototype.createAccessPoint = function(opts) {
   var security = opts.security;
   var securityOptions = ['none', 'wep', 'psk', 'psk2', 'wpa', 'wpa2'];
 
-  if (!ssid) {
-    return Promise.reject(new Error('Invalid credentials. Must set ssid'));
-  }
+  var setupAccessPoint = function() {
 
-  if (security && !password) {
-    return Promise.reject(new Error('Invalid credentials. Must set a password with security option'));
-  }
-
-  if (security && securityOptions.indexOf(security) < 0) {
-    return Promise.reject(new Error(security + ' is not a valid security option. Please choose on of the following: ' + securityOptions.join(', ')));
-  }
-
-  if (password && !security) {
-    security = 'psk2';
-  }
-
-  if (password && security) {
-    logs.info('Setting Access Point with SSID:', ssid, 'and password:', password, 'and security mode:', security);
-  } else if (!password && !security) {
-    security = 'none';
-    logs.info('Setting Access Point with SSID:', ssid);
-  }
-
-  var setSSID = function() {
-    return self.connection.exec(commands.setAccessPointSSID(ssid));
-  };
-
-  var setAccessPointPassword = function() {
-    return self.connection.exec(commands.setAccessPointPassword(password));
-  };
-
-  var setAccessPointSecurity = function() {
-    self.connection.exec(commands.setAccessPointSecurity(security));
-  };
-
-  var turnAccessPointOn = function() {
-    return self.connection.exec(commands.turnAccessPointOn());
-  };
-
-  var commitAndClosePromise = function() {
-    return new Promise(function(resolve) {
-      commitAndClose(self, resolve);
-    });
-  };
-
-  var setup = function() {
-    if (password) {
-      return setSSID(ssid)
-        .then(setAccessPointPassword)
-        .then(setAccessPointSecurity);
-    } else {
-      return setSSID(ssid)
-        .then(setAccessPointSecurity);
+    if (!ssid) {
+      return Promise.reject(new Error('Invalid credentials. Must set ssid'));
     }
+
+    if (security && !password) {
+      return Promise.reject(new Error('Invalid credentials. Must set a password with security option'));
+    }
+
+    if (security && securityOptions.indexOf(security) < 0) {
+      return Promise.reject(new Error(security + ' is not a valid security option. Please choose on of the following: ' + securityOptions.join(', ')));
+    }
+
+    if (password && !security) {
+      security = 'psk2';
+    }
+
+    if (password && security) {
+      logs.info('Setting Access Point with SSID:', ssid, 'and password:', password, 'and security mode:', security);
+    } else if (!password && !security) {
+      security = 'none';
+      logs.info('Setting Access Point with SSID:', ssid);
+    }
+
+    var setSSID = function() {
+      return self.connection.exec(commands.setAccessPointSSID(ssid));
+    };
+
+    var setAccessPointPassword = function() {
+      return self.connection.exec(commands.setAccessPointPassword(password));
+    };
+
+    var setAccessPointSecurity = function() {
+      self.connection.exec(commands.setAccessPointSecurity(security));
+    };
+
+    var turnAccessPointOn = function() {
+      return self.connection.exec(commands.turnAccessPointOn());
+    };
+
+    var commitAndClosePromise = function() {
+      return new Promise(function(resolve) {
+        commitAndClose(self, resolve);
+      });
+    };
+
+    var setup = function() {
+      if (password) {
+        return setSSID(ssid)
+          .then(setAccessPointPassword)
+          .then(setAccessPointSecurity);
+      } else {
+        return setSSID(ssid)
+          .then(setAccessPointSecurity);
+      }
+    };
+
+    return setup()
+      .then(turnAccessPointOn)
+      .then(commitAndClosePromise);
   };
 
-  return setup()
-    .then(turnAccessPointOn)
-    .then(commitAndClosePromise);
+
+  return this.connection.exec(commands.getAccessPointSSID())
+    .then(function(remoteProcess) {
+
+
+      return self.receive(remoteProcess).then(function(data) {
+        return setupAccessPoint();
+      }).catch(function(error) {
+
+        // TODO: @nick, this is where you need to create the NEW
+        // network iface, then call setupAccessPoint()
+        console.log('error: ', error.message);
+      });
+    });
 };

--- a/lib/tessel/access-point.js
+++ b/lib/tessel/access-point.js
@@ -4,19 +4,25 @@ var Tessel = require('./tessel'),
 
 function commitAndClose(self, resolve) {
   return self.connection.exec(commands.commitWirelessCredentials())
-    .then(function(remoteProcess) {
-      remoteProcess.once('close', function() {
-        return self.connection.exec(commands.reconnectWifi())
+  .then(function(remoteProcess) {
+    remoteProcess.once('close', function() {
+      return self.connection.exec(commands.reconnectWifi())
+      .then(function() {
+        return self.connection.exec(commands.reconnectDnsmasq())
+        .then(function() {
+          return self.connection.exec(commands.reconnectDhcp())
           .then(function(remoteProcess) {
             return self.receive(remoteProcess).then(function() {
               logs.info('Access Point credentials set!');
 
               return self.connection.end()
-                .then(resolve);
+              .then(resolve);
             });
           });
+        });
       });
     });
+  });
 }
 
 Tessel.prototype.createAccessPoint = function(opts) {
@@ -30,14 +36,18 @@ Tessel.prototype.createAccessPoint = function(opts) {
       return reject(new Error('Invalid credentials. Must set ssid'));
     }
 
-    if (!password || !security) {
-      if (!security) {
-        logs.info('Setting Access Point with SSID:', ssid, 'and password:', password, 'and security mode:', security);
-      } else {
-        logs.info('Setting Access Point with SSID:', ssid, 'and password:', password);
-      }
-    } else {
-      logs.info('Setting Access Point with SSID:', ssid);
+    if (security && !password) {
+      return reject(new Error('Invalid credentials. Must set a password with security option'));
+    }
+
+    if (password && !security) {
+      security = 'psk2';
+    }
+
+    if (password && security) {
+      logs.info('Setting Access Point with SSID:', ssid, 'and password:', password, 'and security mode:', security);
+    } else if (!password && !security) {
+        logs.info('Setting Access Point with SSID:', ssid);
     }
 
     return self.connection.exec(commands.setAccessPointSSID(ssid))

--- a/lib/tessel/access-point.js
+++ b/lib/tessel/access-point.js
@@ -64,46 +64,65 @@ Tessel.prototype.createAccessPoint = function(opts) {
   var ssid = opts.ssid;
   var password = opts.pass;
   var security = opts.security;
+  var securityOptions = ['none', 'wep', 'psk', 'psk2', 'wpa', 'wpa2'];
 
-  return new Promise(function(resolve, reject) {
-    if (!ssid) {
-      return reject(new Error('Invalid credentials. Must set ssid'));
+  if (!ssid) {
+    return Promise.reject(new Error('Invalid credentials. Must set ssid'));
+  }
+
+  if (security && !password) {
+    return Promise.reject(new Error('Invalid credentials. Must set a password with security option'));
+  }
+
+  if (security && securityOptions.indexOf(security) < 0) {
+    return Promise.reject(new Error(security + ' is not a valid security option. Please choose on of the following: ' + securityOptions.join(', ')));
+  }
+
+  if (password && !security) {
+    security = 'psk2';
+  }
+
+  if (password && security) {
+    logs.info('Setting Access Point with SSID:', ssid, 'and password:', password, 'and security mode:', security);
+  } else if (!password && !security) {
+    security = 'none';
+    logs.info('Setting Access Point with SSID:', ssid);
+  }
+
+  var setSSID = function() {
+    return self.connection.exec(commands.setAccessPointSSID(ssid));
+  };
+
+  var setAccessPointPassword = function() {
+    return self.connection.exec(commands.setAccessPointPassword(password));
+  };
+
+  var setAccessPointSecurity = function() {
+    self.connection.exec(commands.setAccessPointSecurity(security));
+  };
+
+  var turnAccessPointOn = function() {
+    return self.connection.exec(commands.turnAccessPointOn());
+  };
+
+  var commitAndClosePromise = function() {
+    return new Promise(function(resolve) {
+      commitAndClose(self, resolve);
+    });
+  };
+
+  var setup = function() {
+    if (password) {
+      return setSSID(ssid)
+        .then(setAccessPointPassword)
+        .then(setAccessPointSecurity);
+    } else {
+      return setSSID(ssid)
+        .then(setAccessPointSecurity);
     }
+  };
 
-    if (security && !password) {
-      return reject(new Error('Invalid credentials. Must set a password with security option'));
-    }
-
-    if (password && !security) {
-      security = 'psk2';
-    }
-
-    if (password && security) {
-      logs.info('Setting Access Point with SSID:', ssid, 'and password:', password, 'and security mode:', security);
-    } else if (!password && !security) {
-      logs.info('Setting Access Point with SSID:', ssid);
-    }
-
-    return self.connection.exec(commands.setAccessPointSSID(ssid))
-      .then(function() {
-        if (password) {
-          return self.connection.exec(commands.setAccessPointPassword(password))
-            .then(function() {
-              if (security) {
-                return self.connection.exec(commands.setAccessPointSecurity(security))
-                  .then(function() {
-                    return self.connection.exec(commands.turnAccessPointOn())
-                      .then(commitAndClose.bind(null, self, resolve));
-                  });
-              } else {
-                return self.connection.exec(commands.turnAccessPointOn())
-                  .then(commitAndClose.bind(null, self, resolve));
-              }
-            });
-        } else {
-          return self.connection.exec(commands.turnAccessPointOn())
-            .then(commitAndClose.bind(null, self, resolve));
-        }
-      });
-  });
+  return setup()
+    .then(turnAccessPointOn)
+    .then(commitAndClosePromise);
 };

--- a/lib/tessel/access-point.js
+++ b/lib/tessel/access-point.js
@@ -2,9 +2,7 @@ var Tessel = require('./tessel'),
   commands = require('./commands'),
   logs = require('../logs');
 
-function commitAndClose(resolve) {
-  var self = Tessel;
-
+function commitAndClose(self, resolve) {
   return self.connection.exec(commands.commitWirelessCredentials())
     .then(function(remoteProcess) {
       remoteProcess.once('close', function() {
@@ -24,7 +22,7 @@ function commitAndClose(resolve) {
 Tessel.prototype.createAccessPoint = function(opts) {
   var self = this;
   var ssid = opts.ssid;
-  var password = opts.password;
+  var password = opts.pass;
   var security = opts.security;
 
   return new Promise(function(resolve, reject) {
@@ -47,19 +45,19 @@ Tessel.prototype.createAccessPoint = function(opts) {
         if (password) {
           return self.connection.exec(commands.setAccessPointPassword(password));
         } else {
-          return commitAndClose(resolve);
+          return commitAndClose(self, resolve);
         }
       })
       .then(function() {
         if (security) {
           return self.connection.exec(commands.setAccessPointSecurity(security));
         } else {
-          return commitAndClose(resolve);
+          return commitAndClose(self, resolve);
         }
       })
       .then(function() {
         return self.connection.exec(commands.turnAccessPointOn(true))
-          .then(commitAndClose.bind(null, resolve));
+          .then(commitAndClose.bind(null, self, resolve));
       });
   });
 };

--- a/lib/tessel/access-point.js
+++ b/lib/tessel/access-point.js
@@ -3,26 +3,38 @@ var Tessel = require('./tessel'),
   logs = require('../logs');
 
 function commitAndClose(self, resolve) {
-  return self.connection.exec(commands.commitWirelessCredentials())
-    .then(function(remoteProcess) {
-      remoteProcess.once('close', function() {
-        return self.connection.exec(commands.reconnectWifi())
-          .then(function() {
-            return self.connection.exec(commands.reconnectDnsmasq())
-              .then(function() {
-                return self.connection.exec(commands.reconnectDhcp())
-                  .then(function(remoteProcess) {
-                    return self.receive(remoteProcess).then(function() {
-                      logs.info('Access Point credentials set!');
-
-                      self.connection.end()
-                        .then(resolve);
-                    });
-                  });
-              });
-          });
-      });
+  var waitForClose = function(remoteProcess) {
+    return new Promise(function(resolve) {
+      remoteProcess.once('close', resolve);
     });
+  };
+
+  var reconnectWifi = function() {
+    return self.connection.exec(commands.reconnectWifi());
+  };
+
+  var reconnectDnsmasq = function() {
+    return self.connection.exec(commands.reconnectDnsmasq());
+  };
+
+  var reconnectDhcp = function() {
+    return self.connection.exec(commands.reconnectDhcp());
+  };
+
+  var cleanup = function(remoteProcess) {
+    return self.receive(remoteProcess).then(function() {
+      logs.info('Access Point credentials set!');
+      return self.connection.end();
+    });
+  };
+
+  return self.connection.exec(commands.commitWirelessCredentials())
+    .then(waitForClose)
+    .then(reconnectWifi)
+    .then(reconnectDnsmasq)
+    .then(reconnectDhcp)
+    .then(cleanup)
+    .then(resolve);
 }
 
 Tessel.prototype.enableAccessPoint = function() {

--- a/lib/tessel/access-point.js
+++ b/lib/tessel/access-point.js
@@ -4,48 +4,48 @@ var Tessel = require('./tessel'),
 
 function commitAndClose(self, resolve) {
   return self.connection.exec(commands.commitWirelessCredentials())
-  .then(function(remoteProcess) {
-    remoteProcess.once('close', function() {
-      return self.connection.exec(commands.reconnectWifi())
-      .then(function() {
-        return self.connection.exec(commands.reconnectDnsmasq())
-        .then(function() {
-          return self.connection.exec(commands.reconnectDhcp())
-          .then(function(remoteProcess) {
-            return self.receive(remoteProcess).then(function() {
-              logs.info('Access Point credentials set!');
+    .then(function(remoteProcess) {
+      remoteProcess.once('close', function() {
+        return self.connection.exec(commands.reconnectWifi())
+          .then(function() {
+            return self.connection.exec(commands.reconnectDnsmasq())
+              .then(function() {
+                return self.connection.exec(commands.reconnectDhcp())
+                  .then(function(remoteProcess) {
+                    return self.receive(remoteProcess).then(function() {
+                      logs.info('Access Point credentials set!');
 
-              return self.connection.end()
-              .then(resolve);
-            });
+                      self.connection.end()
+                        .then(resolve);
+                    });
+                  });
+              });
           });
-        });
       });
     });
-  });
 }
 
-Tessel.prototype.enableAccessPoint = function () {
+Tessel.prototype.enableAccessPoint = function() {
   var self = this;
 
-  return new Promise(function(resolve, reject) {
+  return new Promise(function(resolve) {
     return self.connection.exec(commands.turnAccessPointOn())
       .then(function() {
         return commitAndClose(self, resolve);
       });
   });
-}
+};
 
-Tessel.prototype.disableAccessPoint = function () {
+Tessel.prototype.disableAccessPoint = function() {
   var self = this;
 
-  return new Promise(function(resolve, reject) {
+  return new Promise(function(resolve) {
     return self.connection.exec(commands.turnAccessPointOff())
       .then(function() {
         return commitAndClose(self, resolve);
       });
   });
-}
+};
 
 Tessel.prototype.createAccessPoint = function(opts) {
   var self = this;
@@ -69,27 +69,29 @@ Tessel.prototype.createAccessPoint = function(opts) {
     if (password && security) {
       logs.info('Setting Access Point with SSID:', ssid, 'and password:', password, 'and security mode:', security);
     } else if (!password && !security) {
-        logs.info('Setting Access Point with SSID:', ssid);
+      logs.info('Setting Access Point with SSID:', ssid);
     }
 
     return self.connection.exec(commands.setAccessPointSSID(ssid))
       .then(function() {
         if (password) {
-          return self.connection.exec(commands.setAccessPointPassword(password));
+          return self.connection.exec(commands.setAccessPointPassword(password))
+            .then(function() {
+              if (security) {
+                return self.connection.exec(commands.setAccessPointSecurity(security))
+                  .then(function() {
+                    return self.connection.exec(commands.turnAccessPointOn())
+                      .then(commitAndClose.bind(null, self, resolve));
+                  });
+              } else {
+                return self.connection.exec(commands.turnAccessPointOn())
+                  .then(commitAndClose.bind(null, self, resolve));
+              }
+            });
         } else {
-          return commitAndClose(self, resolve);
+          return self.connection.exec(commands.turnAccessPointOn())
+            .then(commitAndClose.bind(null, self, resolve));
         }
-      })
-      .then(function() {
-        if (security) {
-          return self.connection.exec(commands.setAccessPointSecurity(security));
-        } else {
-          return commitAndClose(self, resolve);
-        }
-      })
-      .then(function() {
-        return self.connection.exec(commands.turnAccessPointOn(true))
-          .then(commitAndClose.bind(null, self, resolve));
       });
   });
 };

--- a/lib/tessel/access-point.js
+++ b/lib/tessel/access-point.js
@@ -74,10 +74,10 @@ Tessel.prototype.createAccessPoint = function(opts) {
     }
 
     if (password && security) {
-      status += ` SSID: ${ssid}, password ${password}, security mode: ${security}`;
+      status += ' SSID: ' + ssid + ', password ' + password + ', security mode: ' + security;
     } else if (!password && !security) {
       security = 'none';
-      status += ` SSID: ${ssid}`;
+      status += ' SSID: ' + ssid;
     }
 
     var setSSID = function() {

--- a/lib/tessel/access-point.js
+++ b/lib/tessel/access-point.js
@@ -25,6 +25,28 @@ function commitAndClose(self, resolve) {
   });
 }
 
+Tessel.prototype.enableAccessPoint = function () {
+  var self = this;
+
+  return new Promise(function(resolve, reject) {
+    return self.connection.exec(commands.turnAccessPointOn())
+      .then(function() {
+        return commitAndClose(self, resolve);
+      });
+  });
+}
+
+Tessel.prototype.disableAccessPoint = function () {
+  var self = this;
+
+  return new Promise(function(resolve, reject) {
+    return self.connection.exec(commands.turnAccessPointOff())
+      .then(function() {
+        return commitAndClose(self, resolve);
+      });
+  });
+}
+
 Tessel.prototype.createAccessPoint = function(opts) {
   var self = this;
   var ssid = opts.ssid;

--- a/lib/tessel/access-point.js
+++ b/lib/tessel/access-point.js
@@ -64,22 +64,8 @@ Tessel.prototype.createAccessPoint = function(opts) {
   var ssid = opts.ssid;
   var password = opts.pass;
   var security = opts.security;
-  var securityOptions = ['none', 'wep', 'psk', 'psk2', 'wpa', 'wpa2'];
 
   var setupAccessPoint = function() {
-
-    if (!ssid) {
-      return Promise.reject(new Error('Invalid credentials. Must set ssid'));
-    }
-
-    if (security && !password) {
-      return Promise.reject(new Error('Invalid credentials. Must set a password with security option'));
-    }
-
-    if (security && securityOptions.indexOf(security) < 0) {
-      return Promise.reject(new Error(security + ' is not a valid security option. Please choose on of the following: ' + securityOptions.join(', ')));
-    }
-
     if (password && !security) {
       security = 'psk2';
     }
@@ -130,17 +116,37 @@ Tessel.prototype.createAccessPoint = function(opts) {
   };
 
 
-  return this.connection.exec(commands.getAccessPointSSID())
+  return self.connection.exec(commands.getAccessPointSSID())
     .then(function(remoteProcess) {
 
 
-      return self.receive(remoteProcess).then(function(data) {
+      return self.receive(remoteProcess).then(function() {
         return setupAccessPoint();
-      }).catch(function(error) {
+      }).catch(function() {
 
-        // TODO: @nick, this is where you need to create the NEW
-        // network iface, then call setupAccessPoint()
-        console.log('error: ', error.message);
+        var setAccessPoint = function() {
+          return self.connection.exec(commands.setAccessPoint())
+            .then(self.connection.exec.bind(self.connection, commands.setAccessPointDevice()))
+            .then(self.connection.exec.bind(self.connection, commands.setAccessPointNetwork()))
+            .then(self.connection.exec.bind(self.connection, commands.setAccessPointMode()));
+        };
+
+        var setLanNetwork = function() {
+          return self.connection.exec(commands.setLanNetwork())
+            .then(self.connection.exec.bind(self.connection, commands.setLanNetworkIfname()))
+            .then(self.connection.exec.bind(self.connection, commands.setLanNetworkProto()))
+            .then(self.connection.exec.bind(self.connection, commands.setLanNetworkIP()))
+            .then(self.connection.exec.bind(self.connection, commands.setLanNetworkNetmask()));
+        };
+
+        var commitNetwork = function() {
+          return self.connection.exec(commands.commitNetwork());
+        };
+
+        return setAccessPoint()
+          .then(setLanNetwork)
+          .then(commitNetwork)
+          .then(setupAccessPoint);
       });
     });
 };

--- a/lib/tessel/access-point.js
+++ b/lib/tessel/access-point.js
@@ -2,7 +2,7 @@ var Tessel = require('./tessel'),
   commands = require('./commands'),
   logs = require('../logs');
 
-function commitAndClose(self, resolve) {
+function commitAndClose(tessel, status, resolve) {
   var waitForClose = function(remoteProcess) {
     return new Promise(function(resolve) {
       remoteProcess.once('close', resolve);
@@ -10,25 +10,25 @@ function commitAndClose(self, resolve) {
   };
 
   var reconnectWifi = function() {
-    return self.connection.exec(commands.reconnectWifi());
+    return tessel.connection.exec(commands.reconnectWifi());
   };
 
   var reconnectDnsmasq = function() {
-    return self.connection.exec(commands.reconnectDnsmasq());
+    return tessel.connection.exec(commands.reconnectDnsmasq());
   };
 
   var reconnectDhcp = function() {
-    return self.connection.exec(commands.reconnectDhcp());
+    return tessel.connection.exec(commands.reconnectDhcp());
   };
 
   var cleanup = function(remoteProcess) {
-    return self.receive(remoteProcess).then(function() {
-      logs.info('Access Point credentials set!');
-      return self.connection.end();
+    return tessel.receive(remoteProcess).then(function() {
+      logs.info(status);
+      return tessel.connection.end();
     });
   };
 
-  return self.connection.exec(commands.commitWirelessCredentials())
+  return tessel.connection.exec(commands.commitWirelessCredentials())
     .then(waitForClose)
     .then(reconnectWifi)
     .then(reconnectDnsmasq)
@@ -39,22 +39,24 @@ function commitAndClose(self, resolve) {
 
 Tessel.prototype.enableAccessPoint = function() {
   var self = this;
+  var status = 'Access Point successfully enabled.';
 
   return new Promise(function(resolve) {
     return self.connection.exec(commands.turnAccessPointOn())
       .then(function() {
-        return commitAndClose(self, resolve);
+        return commitAndClose(self, status, resolve);
       });
   });
 };
 
 Tessel.prototype.disableAccessPoint = function() {
   var self = this;
+  var status = 'Access Point successfully disabled.';
 
   return new Promise(function(resolve) {
     return self.connection.exec(commands.turnAccessPointOff())
       .then(function() {
-        return commitAndClose(self, resolve);
+        return commitAndClose(self, status, resolve);
       });
   });
 };
@@ -64,6 +66,7 @@ Tessel.prototype.createAccessPoint = function(opts) {
   var ssid = opts.ssid;
   var password = opts.pass;
   var security = opts.security;
+  var status = 'Created Access Point successfully.';
 
   var setupAccessPoint = function() {
     if (password && !security) {
@@ -71,10 +74,10 @@ Tessel.prototype.createAccessPoint = function(opts) {
     }
 
     if (password && security) {
-      logs.info('Setting Access Point with SSID:', ssid, 'and password:', password, 'and security mode:', security);
+      status += ` SSID: ${ssid}, password ${password}, security mode: ${security}`;
     } else if (!password && !security) {
       security = 'none';
-      logs.info('Setting Access Point with SSID:', ssid);
+      status += ` SSID: ${ssid}`;
     }
 
     var setSSID = function() {
@@ -95,7 +98,7 @@ Tessel.prototype.createAccessPoint = function(opts) {
 
     var commitAndClosePromise = function() {
       return new Promise(function(resolve) {
-        commitAndClose(self, resolve);
+        commitAndClose(self, status, resolve);
       });
     };
 
@@ -118,9 +121,10 @@ Tessel.prototype.createAccessPoint = function(opts) {
 
   return self.connection.exec(commands.getAccessPointSSID())
     .then(function(remoteProcess) {
-
-
       return self.receive(remoteProcess).then(function() {
+        // When an AP exists, change the status to
+        // reflect an "update" vs. "create":
+        status = 'Updated Access Point successfully.';
         return setupAccessPoint();
       }).catch(function() {
 

--- a/lib/tessel/commands.js
+++ b/lib/tessel/commands.js
@@ -97,8 +97,11 @@ module.exports.setAccessPointPassword = function(password) {
 module.exports.setAccessPointSecurity = function(security) {
   return ['uci', 'set', 'wireless.@wifi-iface[1].encryption=' + security];
 };
-module.exports.turnAccessPointOn = function(enabled) {
-  return ['uci', 'set', 'wireless.@wifi-iface[1].disabled=' + Number(enabled ? 0 : 1).toString()];
+module.exports.turnAccessPointOn = function() {
+  return ['uci', 'set', 'wireless.@wifi-iface[1].disabled=0'];
+};
+module.exports.turnAccessPointOff = function() {
+  return ['uci', 'set', 'wireless.@wifi-iface[1].disabled=1'];
 };
 module.exports.reconnectDnsmasq = function() {
   return ['/etc/init.d/dnsmasq', 'restart'];

--- a/lib/tessel/commands.js
+++ b/lib/tessel/commands.js
@@ -88,3 +88,15 @@ module.exports.sysupgrade = function(path) {
 module.exports.getMemoryInfo = function() {
   return ['cat', '/proc/meminfo'];
 };
+module.exports.setAccessPointSSID = function(ssid) {
+  return ['uci', 'set', 'wireless.@wifi-iface[1].ssid=' + ssid];
+};
+module.exports.setAccessPointPassword = function(password) {
+  return ['uci', 'set', 'wireless.@wifi-iface[1].key=' + password];
+};
+module.exports.setAccessPointSecurity = function(security) {
+  return ['uci', 'set', 'wireless.@wifi-iface[1].encryption=' + security];
+};
+module.exports.turnAccessPointOn = function(enabled) {
+  return ['uci', 'set', 'wireless.@wifi-iface[1].disabled=' + Number(enabled ? 0 : 1).toString()];
+};

--- a/lib/tessel/commands.js
+++ b/lib/tessel/commands.js
@@ -100,3 +100,9 @@ module.exports.setAccessPointSecurity = function(security) {
 module.exports.turnAccessPointOn = function(enabled) {
   return ['uci', 'set', 'wireless.@wifi-iface[1].disabled=' + Number(enabled ? 0 : 1).toString()];
 };
+module.exports.reconnectDnsmasq = function() {
+  return ['/etc/init.d/dnsmasq', 'restart'];
+};
+module.exports.reconnectDhcp = function() {
+  return ['/etc/init.d/odhcpd', 'restart'];
+};

--- a/lib/tessel/commands.js
+++ b/lib/tessel/commands.js
@@ -88,8 +88,38 @@ module.exports.sysupgrade = function(path) {
 module.exports.getMemoryInfo = function() {
   return ['cat', '/proc/meminfo'];
 };
+module.exports.setLanNetwork = function() {
+  return ['uci', 'set', 'network.lan=interface'];
+};
+module.exports.setLanNetworkIfname = function() {
+  return ['uci', 'set', 'network.lan.ifname=wlan0'];
+};
+module.exports.setLanNetworkProto = function() {
+  return ['uci', 'set', 'network.lan.proto=static'];
+};
+module.exports.setLanNetworkIP = function() {
+  return ['uci', 'set', 'network.lan.ipaddr=192.168.1.101'];
+};
+module.exports.setLanNetworkNetmask = function() {
+  return ['uci', 'set', 'network.lan.netmask=255.255.255.0'];
+};
+module.exports.commitNetwork = function() {
+  return ['uci', 'commit', 'network'];
+};
 module.exports.getAccessPointSSID = function() {
   return ['uci', 'get', 'wireless.@wifi-iface[1].ssid'];
+};
+module.exports.setAccessPoint = function() {
+  return ['uci', 'add', 'wireless', 'wifi-iface'];
+};
+module.exports.setAccessPointDevice = function() {
+  return ['uci', 'set', 'wireless.@wifi-iface[1].device=radio0'];
+};
+module.exports.setAccessPointNetwork = function() {
+  return ['uci', 'set', 'wireless.@wifi-iface[1].network=lan'];
+};
+module.exports.setAccessPointMode = function() {
+  return ['uci', 'set', 'wireless.@wifi-iface[1].mode=ap'];
 };
 module.exports.setAccessPointSSID = function(ssid) {
   return ['uci', 'set', 'wireless.@wifi-iface[1].ssid=' + ssid];

--- a/lib/tessel/commands.js
+++ b/lib/tessel/commands.js
@@ -88,6 +88,9 @@ module.exports.sysupgrade = function(path) {
 module.exports.getMemoryInfo = function() {
   return ['cat', '/proc/meminfo'];
 };
+module.exports.getAccessPointSSID = function() {
+  return ['uci', 'get', 'wireless.@wifi-iface[1].ssid'];
+};
 module.exports.setAccessPointSSID = function(ssid) {
   return ['uci', 'set', 'wireless.@wifi-iface[1].ssid=' + ssid];
 };

--- a/lib/tessel/tessel.js
+++ b/lib/tessel/tessel.js
@@ -115,3 +115,4 @@ require('./deploy');
 require('./erase');
 require('./wifi');
 require('./update');
+require('./access-point');

--- a/lib/tessel/wifi.js
+++ b/lib/tessel/wifi.js
@@ -81,6 +81,10 @@ Tessel.prototype.connectToNetwork = function(opts) {
         return self.connection.exec(commands.setNetworkPassword(password));
       })
       .then(function() {
+        // Then set the encryption
+        return self.connection.exec(commands.setNetworkEncryption('psk2'));
+      })
+      .then(function() {
         // Then make sure wireless is enabled
         return self.connection.exec(commands.turnOnWifi(true));
       })

--- a/test/unit/access-point.js
+++ b/test/unit/access-point.js
@@ -55,7 +55,7 @@ exports['Tessel.prototype.createAccessPoint'] = {
   },
 
   noPasswordNoSecurity: function(test) {
-    test.expect(7);
+    test.expect(8);
     var self = this;
     var creds = {
       ssid: 'test',
@@ -74,11 +74,12 @@ exports['Tessel.prototype.createAccessPoint'] = {
       .then(function() {
         test.equal(self.setAccessPointSSID.callCount, 1);
         test.equal(self.setAccessPointPassword.callCount, 0);
-        test.equal(self.setAccessPointSecurity.callCount, 0);
+        test.equal(self.setAccessPointSecurity.callCount, 1);
         test.equal(self.reconnectWifi.callCount, 1);
         test.equal(self.reconnectDnsmasq.callCount, 1);
         test.equal(self.reconnectDhcp.callCount, 1);
         test.ok(self.setAccessPointSSID.lastCall.calledWith(creds.ssid));
+        test.ok(self.setAccessPointSecurity.lastCall.calledWith('none'));
         test.done();
       })
       .catch(function(error) {

--- a/test/unit/access-point.js
+++ b/test/unit/access-point.js
@@ -1,0 +1,267 @@
+var sinon = require('sinon');
+var Tessel = require('../../lib/tessel/tessel');
+var commands = require('../../lib/tessel/commands');
+var logs = require('../../lib/logs');
+var TesselSimulator = require('../common/tessel-simulator');
+
+exports['Tessel.prototype.createAccessPoint'] = {
+  setUp: function(done) {
+    this.createAccessPoint = sinon.spy(Tessel.prototype, 'createAccessPoint');
+    this.logsInfo = sinon.stub(logs, 'info', function() {});
+    this.setAccessPointSSID = sinon.spy(commands, 'setAccessPointSSID');
+    this.setAccessPointPassword = sinon.spy(commands, 'setAccessPointPassword');
+    this.setAccessPointSecurity = sinon.spy(commands, 'setAccessPointSecurity');
+    this.commitWirelessCredentials = sinon.spy(commands, 'commitWirelessCredentials');
+    this.reconnectWifi = sinon.spy(commands, 'reconnectWifi');
+    this.reconnectDnsmasq = sinon.spy(commands, 'reconnectDnsmasq');
+    this.reconnectDhcp = sinon.spy(commands, 'reconnectDhcp');
+
+    this.tessel = TesselSimulator();
+
+    done();
+  },
+
+  tearDown: function(done) {
+    this.tessel.mockClose();
+    this.createAccessPoint.restore();
+    this.logsInfo.restore();
+    this.setAccessPointSSID.restore();
+    this.setAccessPointPassword.restore();
+    this.setAccessPointSecurity.restore();
+    this.commitWirelessCredentials.restore();
+    this.reconnectWifi.restore();
+    this.reconnectDnsmasq.restore();
+    this.reconnectDhcp.restore();
+    done();
+  },
+
+  noSSID: function(test) {
+    test.expect(1);
+
+    this.tessel.createAccessPoint({
+        ssid: undefined
+      })
+      .catch(function(error) {
+        test.ok(error);
+        test.done();
+      });
+  },
+
+  noPasswordWithSecurity: function(test) {
+    test.expect(1);
+
+    this.tessel.createAccessPoint({
+        ssid: 'test',
+        password: undefined,
+        security: 'psk2'
+      })
+      .catch(function(error) {
+        test.ok(error);
+        test.done();
+      });
+  },
+
+  noPasswordNoSecurity: function(test) {
+    test.expect(7);
+    var self = this;
+    var creds = {
+      ssid: 'test',
+      pass: undefined,
+      security: undefined
+    };
+
+    // Test is expecting two closes...;
+    self.tessel._rps.on('control', function() {
+      setImmediate(function() {
+        self.tessel._rps.emit('close');
+      });
+    });
+
+    this.tessel.createAccessPoint(creds)
+      .then(function() {
+        test.equal(self.setAccessPointSSID.callCount, 1);
+        test.equal(self.setAccessPointPassword.callCount, 0);
+        test.equal(self.setAccessPointSecurity.callCount, 0);
+        test.equal(self.reconnectWifi.callCount, 1);
+        test.equal(self.reconnectDnsmasq.callCount, 1);
+        test.equal(self.reconnectDhcp.callCount, 1);
+        test.ok(self.setAccessPointSSID.lastCall.calledWith(creds.ssid));
+        test.done();
+      })
+      .catch(function(error) {
+        test.fail(error);
+      });
+  },
+
+  properCredentials: function(test) {
+    test.expect(9);
+    var self = this;
+    var creds = {
+      ssid: 'test',
+      pass: 'test-password',
+      security: 'psk2'
+    };
+
+    // Test is expecting two closes...;
+    self.tessel._rps.on('control', function() {
+      setImmediate(function() {
+        self.tessel._rps.emit('close');
+      });
+    });
+
+    this.tessel.createAccessPoint(creds)
+      .then(function() {
+        test.equal(self.setAccessPointSSID.callCount, 1);
+        test.equal(self.setAccessPointPassword.callCount, 1);
+        test.equal(self.setAccessPointSecurity.callCount, 1);
+        test.equal(self.reconnectWifi.callCount, 1);
+        test.equal(self.reconnectDnsmasq.callCount, 1);
+        test.equal(self.reconnectDhcp.callCount, 1);
+        test.ok(self.setAccessPointSSID.lastCall.calledWith(creds.ssid));
+        test.ok(self.setAccessPointPassword.lastCall.calledWith(creds.pass));
+        test.ok(self.setAccessPointSecurity.lastCall.calledWith(creds.security));
+        test.done();
+      })
+      .catch(function(error) {
+        test.fail(error);
+      });
+  },
+
+  passwordNoSecurity: function(test) {
+    test.expect(9);
+    var self = this;
+    var creds = {
+      ssid: 'test',
+      pass: 'test-password',
+      security: undefined
+    };
+
+    // Test is expecting two closes...;
+    self.tessel._rps.on('control', function() {
+      setImmediate(function() {
+        self.tessel._rps.emit('close');
+      });
+    });
+
+    this.tessel.createAccessPoint(creds)
+      .then(function() {
+        test.equal(self.setAccessPointSSID.callCount, 1);
+        test.equal(self.setAccessPointPassword.callCount, 1);
+        test.equal(self.setAccessPointSecurity.callCount, 1);
+        test.equal(self.reconnectWifi.callCount, 1);
+        test.equal(self.reconnectDnsmasq.callCount, 1);
+        test.equal(self.reconnectDhcp.callCount, 1);
+        test.ok(self.setAccessPointSSID.lastCall.calledWith(creds.ssid));
+        test.ok(self.setAccessPointPassword.lastCall.calledWith(creds.pass));
+        test.ok(self.setAccessPointSecurity.lastCall.calledWith('psk2'));
+        test.done();
+      })
+      .catch(function(error) {
+        test.fail(error);
+      });
+  }
+};
+
+exports['Tessel.prototype.enableAccessPoint'] = {
+  setUp: function(done) {
+    this.enableAccessPoint = sinon.spy(Tessel.prototype, 'enableAccessPoint');
+    this.logsInfo = sinon.stub(logs, 'info', function() {});
+    this.turnAccessPointOn = sinon.spy(commands, 'turnAccessPointOn');
+    this.commitWirelessCredentials = sinon.spy(commands, 'commitWirelessCredentials');
+    this.reconnectWifi = sinon.spy(commands, 'reconnectWifi');
+    this.reconnectDnsmasq = sinon.spy(commands, 'reconnectDnsmasq');
+    this.reconnectDhcp = sinon.spy(commands, 'reconnectDhcp');
+
+    this.tessel = TesselSimulator();
+
+    done();
+  },
+
+  tearDown: function(done) {
+    this.tessel.mockClose();
+    this.enableAccessPoint.restore();
+    this.logsInfo.restore();
+    this.turnAccessPointOn.restore();
+    this.commitWirelessCredentials.restore();
+    this.reconnectWifi.restore();
+    this.reconnectDnsmasq.restore();
+    this.reconnectDhcp.restore();
+    done();
+  },
+
+  turnsOn: function(test) {
+    test.expect(4);
+    var self = this;
+
+    // Test is expecting two closes...;
+    self.tessel._rps.on('control', function() {
+      setImmediate(function() {
+        self.tessel._rps.emit('close');
+      });
+    });
+
+    this.tessel.enableAccessPoint()
+      .then(function() {
+        test.equal(self.turnAccessPointOn.callCount, 1);
+        test.equal(self.reconnectWifi.callCount, 1);
+        test.equal(self.reconnectDnsmasq.callCount, 1);
+        test.equal(self.reconnectDhcp.callCount, 1);
+        test.done();
+      })
+      .catch(function(error) {
+        test.fail(error);
+      });
+  }
+};
+
+exports['Tessel.prototype.disableAccessPoint'] = {
+  setUp: function(done) {
+    this.disableAccessPoint = sinon.spy(Tessel.prototype, 'disableAccessPoint');
+    this.logsInfo = sinon.stub(logs, 'info', function() {});
+    this.turnAccessPointOff = sinon.spy(commands, 'turnAccessPointOff');
+    this.commitWirelessCredentials = sinon.spy(commands, 'commitWirelessCredentials');
+    this.reconnectWifi = sinon.spy(commands, 'reconnectWifi');
+    this.reconnectDnsmasq = sinon.spy(commands, 'reconnectDnsmasq');
+    this.reconnectDhcp = sinon.spy(commands, 'reconnectDhcp');
+
+    this.tessel = TesselSimulator();
+
+    done();
+  },
+
+  tearDown: function(done) {
+    this.tessel.mockClose();
+    this.disableAccessPoint.restore();
+    this.logsInfo.restore();
+    this.turnAccessPointOff.restore();
+    this.commitWirelessCredentials.restore();
+    this.reconnectWifi.restore();
+    this.reconnectDnsmasq.restore();
+    this.reconnectDhcp.restore();
+    done();
+  },
+
+  turnsOn: function(test) {
+    test.expect(4);
+    var self = this;
+
+    // Test is expecting two closes...;
+    self.tessel._rps.on('control', function() {
+      setImmediate(function() {
+        self.tessel._rps.emit('close');
+      });
+    });
+
+    this.tessel.disableAccessPoint()
+      .then(function() {
+        test.equal(self.turnAccessPointOff.callCount, 1);
+        test.equal(self.reconnectWifi.callCount, 1);
+        test.equal(self.reconnectDnsmasq.callCount, 1);
+        test.equal(self.reconnectDhcp.callCount, 1);
+        test.done();
+      })
+      .catch(function(error) {
+        test.fail(error);
+      });
+  }
+};

--- a/test/unit/access-point.js
+++ b/test/unit/access-point.js
@@ -6,15 +6,16 @@ var TesselSimulator = require('../common/tessel-simulator');
 
 exports['Tessel.prototype.createAccessPoint'] = {
   setUp: function(done) {
-    this.createAccessPoint = sinon.spy(Tessel.prototype, 'createAccessPoint');
-    this.logsInfo = sinon.stub(logs, 'info', function() {});
-    this.setAccessPointSSID = sinon.spy(commands, 'setAccessPointSSID');
-    this.setAccessPointPassword = sinon.spy(commands, 'setAccessPointPassword');
-    this.setAccessPointSecurity = sinon.spy(commands, 'setAccessPointSecurity');
-    this.commitWirelessCredentials = sinon.spy(commands, 'commitWirelessCredentials');
-    this.reconnectWifi = sinon.spy(commands, 'reconnectWifi');
-    this.reconnectDnsmasq = sinon.spy(commands, 'reconnectDnsmasq');
-    this.reconnectDhcp = sinon.spy(commands, 'reconnectDhcp');
+    this.sandbox = sinon.sandbox.create();
+    this.createAccessPoint = this.sandbox.spy(Tessel.prototype, 'createAccessPoint');
+    this.logsInfo = this.sandbox.stub(logs, 'info', function() {});
+    this.setAccessPointSSID = this.sandbox.spy(commands, 'setAccessPointSSID');
+    this.setAccessPointPassword = this.sandbox.spy(commands, 'setAccessPointPassword');
+    this.setAccessPointSecurity = this.sandbox.spy(commands, 'setAccessPointSecurity');
+    this.commitWirelessCredentials = this.sandbox.spy(commands, 'commitWirelessCredentials');
+    this.reconnectWifi = this.sandbox.spy(commands, 'reconnectWifi');
+    this.reconnectDnsmasq = this.sandbox.spy(commands, 'reconnectDnsmasq');
+    this.reconnectDhcp = this.sandbox.spy(commands, 'reconnectDhcp');
 
     this.tessel = TesselSimulator();
 
@@ -23,15 +24,7 @@ exports['Tessel.prototype.createAccessPoint'] = {
 
   tearDown: function(done) {
     this.tessel.mockClose();
-    this.createAccessPoint.restore();
-    this.logsInfo.restore();
-    this.setAccessPointSSID.restore();
-    this.setAccessPointPassword.restore();
-    this.setAccessPointSecurity.restore();
-    this.commitWirelessCredentials.restore();
-    this.reconnectWifi.restore();
-    this.reconnectDnsmasq.restore();
-    this.reconnectDhcp.restore();
+    this.sandbox.restore();
     done();
   },
 
@@ -164,13 +157,14 @@ exports['Tessel.prototype.createAccessPoint'] = {
 
 exports['Tessel.prototype.enableAccessPoint'] = {
   setUp: function(done) {
-    this.enableAccessPoint = sinon.spy(Tessel.prototype, 'enableAccessPoint');
-    this.logsInfo = sinon.stub(logs, 'info', function() {});
-    this.turnAccessPointOn = sinon.spy(commands, 'turnAccessPointOn');
-    this.commitWirelessCredentials = sinon.spy(commands, 'commitWirelessCredentials');
-    this.reconnectWifi = sinon.spy(commands, 'reconnectWifi');
-    this.reconnectDnsmasq = sinon.spy(commands, 'reconnectDnsmasq');
-    this.reconnectDhcp = sinon.spy(commands, 'reconnectDhcp');
+    this.sandbox = sinon.sandbox.create();
+    this.enableAccessPoint = this.sandbox.spy(Tessel.prototype, 'enableAccessPoint');
+    this.logsInfo = this.sandbox.stub(logs, 'info', function() {});
+    this.turnAccessPointOn = this.sandbox.spy(commands, 'turnAccessPointOn');
+    this.commitWirelessCredentials = this.sandbox.spy(commands, 'commitWirelessCredentials');
+    this.reconnectWifi = this.sandbox.spy(commands, 'reconnectWifi');
+    this.reconnectDnsmasq = this.sandbox.spy(commands, 'reconnectDnsmasq');
+    this.reconnectDhcp = this.sandbox.spy(commands, 'reconnectDhcp');
 
     this.tessel = TesselSimulator();
 
@@ -179,13 +173,7 @@ exports['Tessel.prototype.enableAccessPoint'] = {
 
   tearDown: function(done) {
     this.tessel.mockClose();
-    this.enableAccessPoint.restore();
-    this.logsInfo.restore();
-    this.turnAccessPointOn.restore();
-    this.commitWirelessCredentials.restore();
-    this.reconnectWifi.restore();
-    this.reconnectDnsmasq.restore();
-    this.reconnectDhcp.restore();
+    this.sandbox.restore();
     done();
   },
 
@@ -216,13 +204,14 @@ exports['Tessel.prototype.enableAccessPoint'] = {
 
 exports['Tessel.prototype.disableAccessPoint'] = {
   setUp: function(done) {
-    this.disableAccessPoint = sinon.spy(Tessel.prototype, 'disableAccessPoint');
-    this.logsInfo = sinon.stub(logs, 'info', function() {});
-    this.turnAccessPointOff = sinon.spy(commands, 'turnAccessPointOff');
-    this.commitWirelessCredentials = sinon.spy(commands, 'commitWirelessCredentials');
-    this.reconnectWifi = sinon.spy(commands, 'reconnectWifi');
-    this.reconnectDnsmasq = sinon.spy(commands, 'reconnectDnsmasq');
-    this.reconnectDhcp = sinon.spy(commands, 'reconnectDhcp');
+    this.sandbox = sinon.sandbox.create();
+    this.disableAccessPoint = this.sandbox.spy(Tessel.prototype, 'disableAccessPoint');
+    this.logsInfo = this.sandbox.stub(logs, 'info', function() {});
+    this.turnAccessPointOff = this.sandbox.spy(commands, 'turnAccessPointOff');
+    this.commitWirelessCredentials = this.sandbox.spy(commands, 'commitWirelessCredentials');
+    this.reconnectWifi = this.sandbox.spy(commands, 'reconnectWifi');
+    this.reconnectDnsmasq = this.sandbox.spy(commands, 'reconnectDnsmasq');
+    this.reconnectDhcp = this.sandbox.spy(commands, 'reconnectDhcp');
 
     this.tessel = TesselSimulator();
 
@@ -231,13 +220,7 @@ exports['Tessel.prototype.disableAccessPoint'] = {
 
   tearDown: function(done) {
     this.tessel.mockClose();
-    this.disableAccessPoint.restore();
-    this.logsInfo.restore();
-    this.turnAccessPointOff.restore();
-    this.commitWirelessCredentials.restore();
-    this.reconnectWifi.restore();
-    this.reconnectDnsmasq.restore();
-    this.reconnectDhcp.restore();
+    this.sandbox.restore();
     done();
   },
 

--- a/test/unit/controller.js
+++ b/test/unit/controller.js
@@ -788,3 +788,59 @@ exports['Tessel.get'] = {
     }.bind(this));
   },
 };
+
+exports['controller.closeTesselConnections'] = {
+  setUp: function(done) {
+    this.sandbox = sinon.sandbox.create();
+    this.logsWarn = this.sandbox.stub(logs, 'warn', function() {});
+    this.logsInfo = this.sandbox.stub(logs, 'info', function() {});
+    this.logsBasic = this.sandbox.stub(logs, 'basic', function() {});
+
+    done();
+  },
+
+  tearDown: function(done) {
+    this.sandbox.restore();
+    done();
+  },
+
+  noSSID: function(test) {
+    test.expect(1);
+
+    controller.createAccessPoint({
+        ssid: undefined
+      })
+      .catch(function(error) {
+        test.ok(error);
+        test.done();
+      });
+  },
+
+  noPasswordWithSecurity: function(test) {
+    test.expect(1);
+
+    controller.createAccessPoint({
+        ssid: 'test',
+        password: undefined,
+        security: 'psk2'
+      })
+      .catch(function(error) {
+        test.ok(error);
+        test.done();
+      });
+  },
+
+  invalidSecurityOption: function(test) {
+    test.expect(1);
+
+    controller.createAccessPoint({
+        ssid: 'test',
+        password: undefined,
+        security: 'reallySecure'
+      })
+      .catch(function(error) {
+        test.ok(error);
+        test.done();
+      });
+  },
+};

--- a/test/unit/wifi.js
+++ b/test/unit/wifi.js
@@ -127,6 +127,7 @@ module.exports['Tessel.prototype.connectToNetwork'] = {
     this.logsInfo = sinon.stub(logs, 'info', function() {});
     this.setNetworkSSID = sinon.spy(commands, 'setNetworkSSID');
     this.setNetworkPassword = sinon.spy(commands, 'setNetworkPassword');
+    this.setNetworkEncryption = sinon.spy(commands, 'setNetworkEncryption');
     this.commitWirelessCredentials = sinon.spy(commands, 'commitWirelessCredentials');
     this.reconnectWifi = sinon.spy(commands, 'reconnectWifi');
     this.tessel = TesselSimulator();
@@ -140,13 +141,14 @@ module.exports['Tessel.prototype.connectToNetwork'] = {
     this.logsInfo.restore();
     this.setNetworkSSID.restore();
     this.setNetworkPassword.restore();
+    this.setNetworkEncryption.restore();
     this.commitWirelessCredentials.restore();
     this.reconnectWifi.restore();
     done();
   },
   noSSID: function(test) {
     var self = this;
-    test.expect(3);
+    test.expect(4);
     this.tessel.connectToNetwork({
         ssid: undefined,
         password: 'fish'
@@ -155,12 +157,13 @@ module.exports['Tessel.prototype.connectToNetwork'] = {
         test.ok(error);
         test.equal(self.setNetworkSSID.callCount, 0);
         test.equal(self.setNetworkPassword.callCount, 0);
+        test.equal(self.setNetworkEncryption.callCount, 0);
         test.done();
       });
   },
   noPassword: function(test) {
     var self = this;
-    test.expect(3);
+    test.expect(4);
     this.tessel.connectToNetwork({
         ssid: 'tank',
         password: undefined
@@ -169,12 +172,13 @@ module.exports['Tessel.prototype.connectToNetwork'] = {
         test.ok(error);
         test.equal(self.setNetworkSSID.callCount, 0);
         test.equal(self.setNetworkPassword.callCount, 0);
+        test.equal(self.setNetworkEncryption.callCount, 0);
         test.done();
       });
   },
   properCredentials: function(test) {
     var self = this;
-    test.expect(6);
+    test.expect(8);
     var creds = {
       ssid: 'tank',
       password: 'fish'
@@ -191,10 +195,12 @@ module.exports['Tessel.prototype.connectToNetwork'] = {
       .then(function() {
         test.equal(self.setNetworkSSID.callCount, 1);
         test.equal(self.setNetworkPassword.callCount, 1);
+        test.equal(self.setNetworkEncryption.callCount, 1);
         test.equal(self.commitWirelessCredentials.callCount, 1);
         test.equal(self.reconnectWifi.callCount, 1);
         test.ok(self.setNetworkSSID.lastCall.calledWith(creds.ssid));
         test.ok(self.setNetworkPassword.lastCall.calledWith(creds.password));
+        test.ok(self.setNetworkEncryption.lastCall.calledWith('psk2'));
         test.done();
       })
       .catch(function(error) {


### PR DESCRIPTION
Fixes https://github.com/tessel/t2-cli/issues/87

This configures a 2nd [`wifi-iface`](https://github.com/tessel/openwrt-tessel/blob/master/files/etc/config/wireless) with the options passed in through the cli, enables it, commits the configuration, and resets the `wifi`, `dnsmasq`, and `udhcpd`. 

TODO:
- [x] add tests
- [x] add command to trigger the access point `on` or `off`
