### PR TITLE
Prefer USB for simple operations

### DIFF
--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -35,11 +35,16 @@ function makeCommand(commandName) {
     })
     .option('lan', {
       flag: true,
-      help: 'Use LAN connection'
+      help: 'Use only a LAN connection'
     })
     .option('usb', {
       flag: true,
-      help: 'Use USB connection'
+      help: 'Use only a USB connection'
+    })
+    .option('lan_prefer', {
+      flag: true,
+      default: false,
+      help: 'Prefer a LAN connection if it\'s available, otherwise use USB'
     });
 }
 
@@ -94,7 +99,7 @@ makeCommand('restart')
   })
   .option('entryPoint', {
     position: 1,
-    help: 'The program entry point file to deploy to Tessel.',
+    help: 'The entry point file to deploy to Tessel'
   })
   .option('type', {
     default: 'ram',
@@ -110,7 +115,7 @@ makeCommand('run')
   .option('entryPoint', {
     position: 1,
     required: true,
-    help: 'The program entry point file to deploy to Tessel.'
+    help: 'The entry point file to deploy to Tessel'
   })
   .option('single', {
     flag: true,
@@ -124,17 +129,16 @@ makeCommand('run')
   })
   .option('slim', {
     flag: true,
-    default: true,
-    help: 'Deploy a single "bundle" file that contains that contains only the required files, excluding any files matched by non-negated rules in .tesselignore. Program is run from "slimPath" file.'
+    help: 'Bundle only the required modules'
   })
   .option('slimPath', {
-    default: '__tessel_program__.js',
-    help: 'Specify the name of the --slim bundle file.'
+    default: 'build.js'
   })
-  .option('full', {
+  // Overrides default lan_prefer because deploys require high bandwidth
+  .option('lan_prefer', {
     flag: true,
-    default: false,
-    help: 'Deploy all files in project including those not used by the program, excluding any files matched by non-negated rules in .tesselignore. Program is run from specified "entryPoint" file.'
+    default: true,
+    help: 'Prefer a LAN connection if it\'s available, otherwise use USB'
   })
   .help('Deploy a script to Tessel and run it with Node');
 
@@ -146,7 +150,7 @@ makeCommand('push')
   .option('entryPoint', {
     position: 1,
     required: true,
-    help: 'The program entry point file to deploy to Tessel.'
+    help: 'The entry point file to deploy to Tessel'
   })
   .option('single', {
     flag: true,
@@ -160,17 +164,10 @@ makeCommand('push')
   })
   .option('slim', {
     flag: true,
-    default: true,
-    help: 'Push a single "bundle" file that contains that contains only the required files, excluding any files matched by non-negated rules in .tesselignore. Program is run from "slimPath" file.'
+    help: 'Bundle only the required modules'
   })
   .option('slimPath', {
-    default: '__tessel_program__.js',
-    help: 'Specify the name of the --slim bundle file.'
-  })
-  .option('full', {
-    flag: true,
-    default: false,
-    help: 'Push all files in project including those not used by the program, excluding any files matched by non-negated rules in .tesselignore. Program is run from specified "entryPoint" file.'
+    default: 'build.js'
   })
   .help('Pushes the file/dir to Flash memory to be run anytime the Tessel is powered, runs the file immediately once the file is copied over');
 

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -239,17 +239,28 @@ Tessel.get = function(opts) {
         }
       }
 
+
+      function finishSearchEarly(tessel) {
+        // Remove this listener because we don't need to search for the Tessel
+        seeker.removeListener('end', searchComplete);
+        // Stop searching
+        seeker.stop();
+        // Send this Tessel back to the caller
+        logAndFinish(tessel);
+      }
+
       // When we find Tessels
       seeker.on('tessel', function(tessel) {
+        tessel.setLANConnectionPreference(opts.lanPrefer);
         // Check if this name matches the provided option (if any)
         // This speeds up development by immediately ending the search
         if (opts.name && opts.name === tessel.name) {
-          // Remove this listener because we don't need to search for the Tessel
-          seeker.removeListener('end', searchComplete);
-          // Stop searching
-          seeker.stop();
-          // Send this Tessel back to the caller
-          logAndFinish(tessel);
+          finishSearchEarly(tessel);
+        }
+        // If we just found a USB connection and should prefer it
+        else if (!opts.name && tessel.usbConnection !== undefined && !opts.lanPrefer) {
+          // Finish early with this Tessel
+          finishSearchEarly(tessel);
         }
         // Otherwise
         else {
@@ -265,7 +276,7 @@ Tessel.get = function(opts) {
         // The Tessels that we won't be using should have their connections closed
         var connectionsToClose = tessels;
         if (tessel) {
-          logs.info(sprintf('Connected to %s over %s', tessel.name, tessel.connection.connectionType));
+          logs.info(sprintf('Connected to %s.', tessel.name));
           connectionsToClose.splice(tessels.indexOf(tessel), 1);
           controller.closeTesselConnections(connectionsToClose)
             .then(function() {
@@ -707,6 +718,7 @@ controller.printAvailableUpdates = function() {
 
 controller.update = function(opts) {
   opts.authorized = true;
+  opts.lanPrefer = true;
   return controller.standardTesselCommand(opts, function(tessel) {
     return new Promise(function updateProcess(resolve, reject) {
       // If it's not connected via USB, we can't update it

--- a/lib/tessel/tessel.js
+++ b/lib/tessel/tessel.js
@@ -11,6 +11,7 @@ function Tessel(connection) {
 
   self.usbConnection = undefined;
   self.lanConnection = undefined;
+  self.lanPrefer = false;
 
 
   self.close = function() {
@@ -43,6 +44,10 @@ function Tessel(connection) {
     }
   };
 
+  self.setLANConnectionPreference = function(preferLan) {
+    self.lanPrefer = preferLan;
+  };
+
   // Add this physical connection to the Tessel
   self.addConnection(connection);
   // The human readable name of the device
@@ -55,8 +60,9 @@ function Tessel(connection) {
 
 Object.defineProperty(Tessel.prototype, 'connection', {
   get: function() {
-    // If we have an authorized LAN connection, prefer that
-    if (this.lanConnection && this.lanConnection.authorized) {
+
+    // If the user prefers LAN and we have an authorized LAN connection, prefer that
+    if (this.lanPrefer && this.lanConnection && this.lanConnection.authorized) {
       return this.lanConnection;
     }
     // If we have a USB connection, prefer that next

--- a/test/unit/bin-tessel-2.js
+++ b/test/unit/bin-tessel-2.js
@@ -20,17 +20,22 @@ var defaults = {
   },
   lan: {
     flag: true,
-    help: 'Use LAN connection',
+    help: 'Use only a LAN connection',
     name: 'lan',
     string: '--lan',
   },
   usb: {
     flag: true,
-    help: 'Use USB connection',
+    help: 'Use only a USB connection',
     name: 'usb',
     string: '--usb',
   },
-  key: Tessel.LOCAL_AUTH_KEY
+  key: Tessel.LOCAL_AUTH_KEY,
+  lan_prefer: {
+    flag: true,
+    default: false,
+    help: 'Prefer a LAN connection if it\'s available, otherwise use USB'
+  }
 };
 
 exports['Tessel (cli: makeCommand)'] = {
@@ -146,7 +151,8 @@ exports['Tessel (cli: update)'] = {
       version: 42,
       _: ['update'],
       timeout: 5,
-      key: Tessel.LOCAL_AUTH_KEY
+      key: Tessel.LOCAL_AUTH_KEY,
+      lan_prefer: false
     });
 
     cli(['update', '--list', ' ']);

--- a/test/unit/controller.js
+++ b/test/unit/controller.js
@@ -637,7 +637,10 @@ exports['Tessel.get'] = {
       name: 'samesies'
     });
 
-    Tessel.get(this.standardOpts)
+    var customOpts = this.standardOpts;
+    customOpts.lanPrefer = true;
+
+    Tessel.get(customOpts)
       .then(function() {
         test.equal(this.reconcileTessels.callCount, 1);
         test.equal(this.runHeuristics.callCount, 1);

--- a/test/unit/update.js
+++ b/test/unit/update.js
@@ -18,7 +18,8 @@ exports['controller.update'] = {
     this.logsBasic = this.sandbox.stub(logs, 'basic', function() {});
     this.tessel = TesselSimulator();
 
-    this.getTessel = this.sandbox.stub(Tessel, 'get', function() {
+    this.getTessel = this.sandbox.stub(Tessel, 'get', function(opts) {
+      this.tessel.setLANConnectionPreference(opts.lan_prefer);
       return Promise.resolve(this.tessel);
     }.bind(this));
 
@@ -122,9 +123,9 @@ exports['controller.update'] = {
     });
 
     var opts = {
-      version: '0.0.1'
+      version: '0.0.1',
+      lan_prefer: true
     };
-
     controller.update(opts)
       .then(function() {
         // We have to fetch the build list to figure out what the sha is of this version
@@ -156,7 +157,8 @@ exports['controller.update'] = {
     test.expect(1);
 
     var opts = {
-      version: '0.0.1'
+      version: '0.0.1',
+      lan_prefer: true
     };
 
     controller.update(opts)
@@ -239,7 +241,9 @@ exports['controller.update'] = {
       return Promise.resolve('ac4d8d8a5bfd671f7f174c2eaa258856bd82fe29');
     });
 
-    var opts = {};
+    var opts = {
+      lan_prefer: true
+    };
     controller.update(opts)
       .then(function() {
         // Make sure we checked what the Tessel version is currently at
@@ -295,7 +299,9 @@ exports['controller.update'] = {
       return Promise.resolve(binaries);
     });
 
-    var opts = {};
+    var opts = {
+      lan_prefer: true
+    };
     controller.update(opts)
       .then(function() {
         // Make sure we checked what the Tessel version is currently at
@@ -356,7 +362,9 @@ exports['controller.update'] = {
       return Promise.reject(new Error(errMessage));
     }.bind(this));
 
-    var opts = {};
+    var opts = {
+      lan_prefer: true
+    };
     controller.update(opts)
       .catch(function(err) {
         // We fetched only one build
@@ -407,7 +415,8 @@ exports['controller.update'] = {
     });
 
     var opts = {
-      force: true
+      force: true,
+      lan_prefer: true
     };
 
     controller.update(opts)
@@ -463,7 +472,8 @@ exports['controller.update'] = {
     });
 
     var opts = {
-      version: 'latest'
+      version: 'latest',
+      lan_prefer: true
     };
 
     controller.update(opts)
@@ -501,7 +511,8 @@ exports['controller.update'] = {
     });
 
     var opts = {
-      version: 'x.x.x'
+      version: 'x.x.x',
+      lan_prefer: true
     };
     controller.update(opts)
       .catch(function(message) {
@@ -546,7 +557,9 @@ exports['controller.update'] = {
       return Promise.resolve(binaries);
     });
 
-    var opts = {};
+    var opts = {
+      lan_prefer: true
+    };
     controller.update(opts)
       .then(function() {
         // It should attempt to fetch a build
@@ -600,7 +613,9 @@ exports['controller.update'] = {
       return Promise.resolve(binaries);
     });
 
-    var opts = {};
+    var opts = {
+      lan_prefer: true
+    };
     controller.update(opts)
       .then(function() {
         test.fail('It should throw an error if we get an unknown error');


### PR DESCRIPTION
I wrote this up on a plane ride back from the UK. It makes all the low data-rate operations execute over USB as soon as it's found (unless the `--lan` flag is provided). Fixes https://github.com/tessel/t2-cli/issues/406. `deploy` and `update` wait for a LAN connection to be found. This makes using the Tessel feel way faster to me.