### PR TITLE
When `--single|-s` flag is present, do not traverse upward for package.json. Fixes gh-442

### DIFF
--- a/lib/tessel/deploy.js
+++ b/lib/tessel/deploy.js
@@ -226,14 +226,16 @@ actions.findProject = function(opts) {
     var pushdir = fs.realpathSync(path.dirname(file));
     var relpath = '';
 
-    while (path.dirname(pushdir) !== pushdir &&
-      !fs.existsSync(path.join(pushdir, 'package.json'))) {
-      relpath = path.join(path.basename(pushdir), relpath);
-      pushdir = path.dirname(pushdir);
-    }
+    if (!single) {
+      while (path.dirname(pushdir) !== pushdir &&
+        !fs.existsSync(path.join(pushdir, 'package.json'))) {
+        relpath = path.join(path.basename(pushdir), relpath);
+        pushdir = path.dirname(pushdir);
+      }
 
-    if (path.dirname(pushdir) === pushdir) {
-      reject('Invalid project directory');
+      if (path.dirname(pushdir) === pushdir) {
+        reject('Invalid project directory');
+      }
     }
 
     var program = path.join(pushdir, relpath, path.basename(file));

--- a/test/unit/deploy.js
+++ b/test/unit/deploy.js
@@ -1434,6 +1434,29 @@ exports['deploy.findProject'] = {
       test.done();
     });
   },
+
+  noPackageJsonSingle: function(test) {
+    test.expect(1);
+
+    var pushdir = path.normalize('test/unit/fixtures/project-no-package.json/');
+    var entryPoint = path.normalize('test/unit/fixtures/project-no-package.json/index.js');
+    var slimPath = '__tessel_program__.js';
+
+    var opts = {
+      entryPoint: entryPoint,
+      slimPath: slimPath,
+      single: true,
+      slim: true,
+    };
+
+    deploy.findProject(opts).then(function(project) {
+      // Without the `single` flag, this would've continued upward
+      // until it found a directory with a package.json.
+      test.ok(project.pushdir, fs.realpathSync(path.dirname(pushdir)));
+      test.done();
+    });
+  },
+
 };
 
 function deployTestCode(tessel, test, opts, callback) {

--- a/test/unit/fixtures/project-no-package.json/index.js
+++ b/test/unit/fixtures/project-no-package.json/index.js
@@ -1,0 +1,8 @@
+var tessel = require('tessel');
+
+tessel.led[2].on();
+
+setInterval(function() {
+  tessel.led[2].toggle();
+  tessel.led[3].toggle();
+}, 100);


### PR DESCRIPTION
cc @johnnyman727 