### PR TITLE
[WIP] Close connections on SIGINT during Tessel.get or Tessel.list

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -41,6 +41,15 @@ Tessel.list = function(opts) {
       // Keep a list of all the Tessels we discovered
       var foundTessels = [];
 
+      // The user has aborted, we need to close any open connections
+      process.once('SIGINT', function() {
+        // Stop searching for new Tessels
+        seeker.stop()
+          // Close any opened Tessel connections
+          .then(() => controller.closeTesselConnections(foundTessels))
+          .then(resolve);
+      });
+
       // Options for  Tessel discovery
       var seekerOpts = {
         timeout: opts.timeout * 1000,
@@ -140,6 +149,15 @@ Tessel.get = function(opts) {
       logs.info('Looking for your Tessel...');
       // Collection variable as more Tessels are found
       var tessels = [];
+
+      // The user has aborted, we need to close any open connections
+      process.once('SIGINT', function() {
+        // Stop searching for new Tessels
+        seeker.stop()
+          // Close any opened Tessel connections
+          .then(() => controller.closeTesselConnections(tessels))
+          .then(resolve);
+      });
 
       // Store the amount of time to look for Tessel in seconds
       var seekerOpts = {

--- a/lib/discover.js
+++ b/lib/discover.js
@@ -6,6 +6,7 @@ var Emitter = events.EventEmitter;
 
 // Third Party Dependencies
 var debug = require('debug')('discovery');
+var async = require('async');
 
 // Internal
 var lan = require('./lan_connection');
@@ -29,7 +30,10 @@ TesselSeeker.prototype.start = function(opts) {
   opts = opts || {};
 
   // An array of pending open connections
-  var pendingOpen = [];
+  self.pendingOpenPromises = [];
+  // An array of Tessels that haven't completed being opened
+  // We keep this around to ensure they are closed on SIGINT
+  self.unopenedTessels = [];
 
   // If the user explicitly specified the usb flag,
   // then cli should not filter on authorization status.
@@ -62,9 +66,16 @@ TesselSeeker.prototype.start = function(opts) {
   }
 
   function connectionHandler(conn) {
+    // Create a new Tessel object
     var tessel = new Tessel(conn);
+    // Push it into our array
+    self.unopenedTessels.push(tessel);
+    // Attempt to open the Tessel
     var opening = tessel.connection.open()
       .then(function() {
+        // Remove it from the array
+        self.unopenedTessels.splice(self.unopenedTessels.indexOf(tessel), 1);
+        // If it's not authorized, don't emit it
         if (opts.authorized !== undefined) {
           if (tessel.connection.authorized !== opts.authorized) {
             debug('Kicking ' + conn.host.slice(0, -6) + ' due to authorized filter: ' + opts.authorized);
@@ -100,7 +111,7 @@ TesselSeeker.prototype.start = function(opts) {
         }
       });
     // Push this Promise into the pending array
-    pendingOpen.push(opening);
+    self.pendingOpenPromises.push(opening);
   }
 
   // If a timeout was provided
@@ -109,11 +120,13 @@ TesselSeeker.prototype.start = function(opts) {
     self.scanTimeout = setTimeout(function() {
       debug('Timeout hit! Waiting for pending to finish...');
       // Once all the pending open commands complete
-      Promise.all(pendingOpen)
+      Promise.all(self.pendingOpenPromises)
         // Stop the scan (which emits 'end')
         .then(function() {
-          debug('Done! Stopping.');
-          self.stop();
+          self.stop()
+            .then(function() {
+              debug('Done! Stopping.');
+            });
         });
     }, opts.timeout);
   }
@@ -135,17 +148,25 @@ TesselSeeker.prototype.stop = function() {
     this.usbScan = undefined;
   }
 
+  // This Promise will catch the chance that we're closing between the
+  // time when a device's .open function is called and when that device resolves
+  var closeUnopenedTesselsPromise = new Promise((resolve) => {
+    // For each unopened Tessel
+    async.each(this.unopenedTessels, function closingIter(t, callback) {
+      // Close the Tessel and call the callback when complete
+      t.close()
+        .then(callback);
+    }, resolve);
+  });
+
   // If a timeout was provided
   if (this.scanTimeout) {
     // Clear that timeout
     clearTimeout(this.scanTimeout);
-    // Emit that this scan stopped
-    setImmediate(function() {
-      this.emit('end');
-    }.bind(this));
   }
 
-  return this;
+  // Once we finish closing unopened Tessels, emit an end
+  return closeUnopenedTesselsPromise.then(() => this.emit('end'));
 };
 
 module.exports.TesselSeeker = TesselSeeker;

--- a/lib/tessel/tessel.js
+++ b/lib/tessel/tessel.js
@@ -25,8 +25,22 @@ function Tessel(connection) {
       self.closed = true;
     }
 
-    // Kill all of this Tessel's remote processes
-    return self.connection.end();
+    // Promise place holders in case the connections don't exist
+    var usbEndPromise = Promise.resolve();
+    var lanEndPromise = Promise.resolve();
+    // If we have a USB Connection
+    if (self.usbConnection) {
+      // End that connection
+      usbEndPromise = self.usbConnection.end();
+    }
+    // If we have a LAN Connection
+    if (self.lanConnection) {
+      // End that connection as well
+      lanEndPromise = self.lanConnection.end();
+    }
+
+    // Kill all of this Tessel's remote connections (and their processes)
+    return usbEndPromise.then(lanEndPromise);
   };
 
   self.addConnection = function(connection) {

--- a/lib/usb_connection.js
+++ b/lib/usb_connection.js
@@ -32,6 +32,7 @@ var TESSEL_VID = 0x1209;
 var TESSEL_PID = 0x7551;
 var REQ_BOOT = 0xBB;
 var USB = {};
+const USB_UNRESPONSIVE_TIMEOUT = 1000;
 
 USB.Connection = function(device) {
   Duplex.call(this);
@@ -64,8 +65,15 @@ USB.Connection.prototype.exec = function(command) {
         // Write the bash command
         proc.control.end(command);
 
+        var unresponsive = setTimeout(function() {
+          self._close(() => reject('No response from Tessel over USB. Connection closed.'));
+        }, USB_UNRESPONSIVE_TIMEOUT);
+
         // Once the command has been written, call the callback with the resulting process
-        proc.control.once('finish', resolve.bind(self, proc));
+        proc.control.once('finish', function commandWritten() {
+          clearTimeout(unresponsive);
+          return resolve(proc);
+        });
       }
     });
   });
@@ -162,11 +170,10 @@ USB.Connection.prototype.end = function() {
     // Tell the USB daemon to end all processes active
     // on account of this connection
     Daemon.deregister(self, function(err) {
-      self._close();
       if (err) {
         reject(err);
       } else {
-        resolve();
+        self._close(resolve);
       }
     });
   });

--- a/test/unit/controller.js
+++ b/test/unit/controller.js
@@ -507,6 +507,40 @@ exports['Tessel.list'] = {
       this.activeSeeker.emit('tessel', lan);
     }.bind(this));
   },
+
+  receiveSIGINTMultipleEmitted: function(test) {
+    test.expect(4);
+
+    var usb = newTessel({
+      sandbox: this.sandbox,
+      type: 'USB',
+      name: 'foo'
+    });
+
+    var lan = newTessel({
+      sandbox: this.sandbox,
+      authorized: true,
+      type: 'LAN',
+      name: 'bar'
+    });
+
+    Tessel.list(this.standardOpts)
+      .then(function() {
+        test.equal(this.closeTesselConnections.callCount, 1);
+        test.equal(Array.isArray(this.closeTesselConnections.args[0]), true);
+        test.equal(usb.close.callCount, 1);
+        test.equal(lan.close.callCount, 1);
+        test.done();
+      }.bind(this));
+
+    // We must emit the Tessel sometime after list is called
+    // but before the seeker stops searching
+    setImmediate(function() {
+      this.activeSeeker.emit('tessel', usb);
+      this.activeSeeker.emit('tessel', lan);
+      process.emit('SIGINT');
+    }.bind(this));
+  },
 };
 
 exports['Tessel.get'] = {

--- a/test/unit/discover.js
+++ b/test/unit/discover.js
@@ -132,7 +132,8 @@ exports['TesselSeeker.prototype.stop'] = {
 
   stop: function(test) {
     test.expect(1);
-    test.equal(this.seeker.stop(), this.seeker);
+    // seeker.stop returns a promise
+    test.equal(typeof this.seeker.stop(), 'object');
     test.done();
   },
 


### PR DESCRIPTION
Currently, if the user aborts a script during `t2 list` or at the beginning of any other command that fetches a Tessel (ie `.Tessel.get` is in process), the script will exit without terminating the USB Connection. On Linux, the OS automatically releasing any interfaces when the parent process dies (source: @kevinmehall) but that does not seem to be the case with OSX. That means we need to be extra sure that we close the USB connection regardless of whether the script ends 'naturally' or not.

If we do not end the connections, the USB Daemon on Tessel 2 will keep all of those processes spawned and the next time the CLI tries to open a process, it will likely fail because it will try to create a new process id of a process that's already running (from the last time).

This PR adds checks:
- within `Tessel.get`
- within `Tessel.list`
- for any Tessel that we've discovered but whose `.open` command has not yet completed
- for any USB connection that we've opened but is currently unresponsive (usually because there was an issue with the USB Daemon)

Currently working on tests.