### PR TITLE
Speeds up USB communication

### DIFF
--- a/lib/usb/usb_process.js
+++ b/lib/usb/usb_process.js
@@ -10,10 +10,12 @@ var protocol = require('usb-daemon-parser');
 // ...
 
 
-// The largest packet we can send over USB
-var MAX_PACKET_SIZE = 255;
+// The largest packet allowed is 255 bytes
+// We make the data 251 bytes so we can concat
+// the 4 header bytes to it and use only 1 packet
+var MAX_DATA_PACKET_SIZE = 4092;
 // The size of the back pressure buffers
-var MAX_BUFFER_SIZE = 4096;
+var MAX_BUFFER_SIZE = 32768;
 
 // A process is running remotely on the Tessel and data is piped in over USB
 function USBProcess(id, daemon) {
@@ -195,16 +197,18 @@ RemoteWritableStream.prototype._drainBackPressure = function() {
     entry.buffer = entry.buffer.slice(chunk.length);
 
     // Split the chunk into smaller packets
-    var indices = self._packetize(MAX_PACKET_SIZE, chunk);
+    var indices = self._packetize(MAX_DATA_PACKET_SIZE, chunk);
 
     // For each packet
     indices.forEach(function(index) {
       // Slice out the data packet
       var buffer = chunk.slice(index.start, index.end);
-      // Send the header for our control write
-      self.daemon.write(self.writeHeaderFunc(self.process.id, buffer.length));
+      // Create a header for the write
+      var header = self.writeHeaderFunc(self.process.id, buffer.length);
+      // Compact our header and data into one packet
+      var compact_buffer = Buffer.concat([header, buffer]);
       // Send over the data to the control stream
-      self.daemon.write(buffer);
+      self.daemon.write(compact_buffer);
     });
 
     // If we sent all of the remaining bytes of this write
@@ -288,13 +292,15 @@ RemoteReadableStream.prototype.ack = function(numToAck) {
   // Add the number to the credit count
   this.credit += numToAck;
   // Allocate a buffer for the data
-  var b = new Buffer(4);
+  var ackAmountBuf = new Buffer(4);
   // Write the number as an unsigned 32 but int into the buffer
-  b.writeUInt32LE(numToAck, 0);
-  // Write the header
-  this.daemon.write(this.ackHeaderFunc(this.process.id, b));
-  // Write the data
-  this.daemon.write(b);
+  ackAmountBuf.writeUInt32LE(numToAck, 0);
+  // Create a header for this ack
+  var header = this.ackHeaderFunc(this.process.id, ackAmountBuf);
+  // Combine the header and the ack amount
+  var packet = Buffer.concat([header, ackAmountBuf]);
+  // Write the entire packet
+  this.daemon.write(packet);
 };
 
 // A function to close the stream

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "uglify-js": "^2.5.0",
     "url-join": "0.0.1",
     "usb": "1.1.1",
-    "usb-daemon-parser": "0.0.1"
+    "usb-daemon-parser": "0.0.2"
   },
   "preferGlobal": true,
   "engines": {


### PR DESCRIPTION
By combining headers and data into a single packet, we can dramatically reduce the number of packets sent and roundtrips between the CLI->mcu->spid->usbd and back.

eg. Instead of sending a 4 byte header and then 255 bytes of data, concatenate the 4 header bytes with 251 data bytes.

This also increases the maximum write sizes to the coprocessor.

Initial benchmarks indicate a 2.83x speed increase.

Depends on https://github.com/tessel/t2-firmware/pull/130 and https://github.com/tessel/usb-daemon-parser/pull/2.