### PR TITLE
Alternative PR: Adding default key for makeCommand (sqashed commits)

### DIFF
--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -24,6 +24,7 @@ function makeCommand(commandName) {
     .option('key', {
       required: false,
       metavar: 'PRIVATEKEY',
+      default: controller.LOCAL_AUTH_KEY,
       abbr: 'i',
       help: 'SSH key for authorization with your Tessel'
     })

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -967,3 +967,4 @@ module.exports = controller;
 // Shared exports
 module.exports.listTessels = controller.list;
 module.exports.getTessel = controller.get;
+module.exports.LOCAL_AUTH_KEY = Tessel.LOCAL_AUTH_KEY;

--- a/test/unit/bin-tessel-2.js
+++ b/test/unit/bin-tessel-2.js
@@ -510,8 +510,8 @@ exports['Tessel (cli: list)'] = {
       test.ok(this.controllerList.calledOnce);
       // Ensure it did not have a key option
       test.ok(this.controllerList.lastCall.args[0].key === controller.LOCAL_AUTH_KEY);
-      // Tessel list should have been called afterwards
-      test.ok(this.tesselList.called);
+      // We should not try to set the keypath if not specifically requested
+      test.ok(this.setDefaultKey.called);
       test.done();
     }.bind(this));
   },

--- a/test/unit/bin-tessel-2.js
+++ b/test/unit/bin-tessel-2.js
@@ -501,7 +501,7 @@ exports['Tessel (cli: list)'] = {
 
   listStandard: function(test) {
 
-    test.expect(4);
+    test.expect(3);
 
     cli(['list', '--timeout', '0.001']);
 
@@ -510,8 +510,6 @@ exports['Tessel (cli: list)'] = {
       test.ok(this.controllerList.calledOnce);
       // Ensure it did not have a key option
       test.ok(this.controllerList.lastCall.args[0].key === controller.LOCAL_AUTH_KEY);
-      // We should not try to set the keypath if not specifically requested
-      test.ok(this.setDefaultKey.called);
       // Tessel list should have been called afterwards
       test.ok(this.tesselList.called);
       test.done();

--- a/test/unit/bin-tessel-2.js
+++ b/test/unit/bin-tessel-2.js
@@ -501,16 +501,14 @@ exports['Tessel (cli: list)'] = {
 
   listStandard: function(test) {
 
-    test.expect(3);
+    test.expect(2);
 
     cli(['list', '--timeout', '0.001']);
 
     setImmediate(function() {
       // Ensure controller list was called
       test.ok(this.controllerList.calledOnce);
-      // Ensure it did not have a key option
-      test.ok(this.controllerList.lastCall.args[0].key === controller.LOCAL_AUTH_KEY);
-      // We should not try to set the keypath if not specifically requested
+      // keypath should be set by default value
       test.ok(this.setDefaultKey.called);
       test.done();
     }.bind(this));

--- a/test/unit/bin-tessel-2.js
+++ b/test/unit/bin-tessel-2.js
@@ -148,6 +148,7 @@ exports['Tessel (cli: update)'] = {
       version: 42,
       _: ['update'],
       timeout: 5,
+      key: controller.LOCAL_AUTH_KEY,
       lanPrefer: false
     });
 
@@ -508,9 +509,9 @@ exports['Tessel (cli: list)'] = {
       // Ensure controller list was called
       test.ok(this.controllerList.calledOnce);
       // Ensure it did not have a key option
-      test.ok(this.controllerList.lastCall.args[0].key === undefined);
+      test.ok(this.controllerList.lastCall.args[0].key === controller.LOCAL_AUTH_KEY);
       // We should not try to set the keypath if not specifically requested
-      test.ok(!this.setDefaultKey.called);
+      test.ok(this.setDefaultKey.called);
       // Tessel list should have been called afterwards
       test.ok(this.tesselList.called);
       test.done();
@@ -521,8 +522,7 @@ exports['Tessel (cli: list)'] = {
 
     test.expect(4);
 
-    var keyPath = './FAKE_KEY';
-
+    var keyPath = controller.LOCAL_AUTH_KEY;
     cli(['list', '--timeout', '0.001', '-i', keyPath]);
 
     setImmediate(function() {
@@ -531,6 +531,7 @@ exports['Tessel (cli: list)'] = {
       test.ok(this.controllerList.calledOnce);
       // It was called with the keypath
       test.ok(this.controllerList.lastCall.args[0].key === keyPath);
+
       // We did try to set the key path
       test.ok(this.setDefaultKey.called);
       // It was called with the key path


### PR DESCRIPTION
Edited: squashed commits…

@johnnyman727 instead of https://github.com/tessel/t2-cli/pull/498/

you could merge this one.

I fixed the tests for the list command.

In every case one of the both PRs is necessary because the issue
https://github.com/tessel/t2-cli/issues/497 is given.

Your decision what you merge. Simple close the other one when you
merged :smile: