### PR TITLE
Alternative PR: Adding default key within controller.root

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -737,6 +737,12 @@ controller.root = function(opts) {
   opts.lan = true;
   // We must already be authorized
   opts.authorized = true;
+
+  // Set a default key if it is not setten by command line
+  if (!opts.key) {
+    opts.key = Tessel.LOCAL_AUTH_KEY;
+  }
+
   // Fetch a Tessel
   return controller.standardTesselCommand(opts, function(tessel) {
     logs.info('Starting SSH Session on Tessel. Type \'exit\' at the prompt to end.');


### PR DESCRIPTION
**It looks like the wrapper for controller.get doesn’t work like it
should what wasn’t covered by tests!**

There is no time to work on it now - I am 3 hours behind my day plan -
so I stop it now. Please merge one of the three PRs and open another
issue about right implementation of the wrapper.
> https://github.com/tessel/t2-cli/pull/498
> https://github.com/tessel/t2-cli/pull/501

also fixes https://github.com/tessel/t2-cli/issues/497
:smile: