### PR TITLE
Ap no cred warn

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -737,6 +737,12 @@ controller.root = function(opts) {
   opts.lan = true;
   // We must already be authorized
   opts.authorized = true;
+
+  // Set a default key if it is not setten by command line
+  if (!opts.key) {
+    opts.key = Tessel.LOCAL_AUTH_KEY;
+  }
+
   // Fetch a Tessel
   return controller.standardTesselCommand(opts, function(tessel) {
     logs.info('Starting SSH Session on Tessel. Type \'exit\' at the prompt to end.');

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -717,6 +717,9 @@ controller.createAccessPoint = function(opts) {
 
 controller.enableAccessPoint = function(opts) {
   opts.authorized = true;
+  if (opts.ssid) {
+    logs.warn('Credentials are not changed when switching on/off the accesspoint!');
+  }
   return controller.standardTesselCommand(opts, function(tessel) {
     return tessel.enableAccessPoint();
   });
@@ -724,6 +727,9 @@ controller.enableAccessPoint = function(opts) {
 
 controller.disableAccessPoint = function(opts) {
   opts.authorized = true;
+  if (opts.ssid) {
+    logs.warn('Credentials are not changed when switching on/off the accesspoint!');
+  }
   return controller.standardTesselCommand(opts, function(tessel) {
     return tessel.disableAccessPoint();
   });
@@ -737,11 +743,6 @@ controller.root = function(opts) {
   opts.lan = true;
   // We must already be authorized
   opts.authorized = true;
-
-  // Set a default key if it is not setten by command line
-  if (!opts.key) {
-    opts.key = Tessel.LOCAL_AUTH_KEY;
-  }
 
   // Fetch a Tessel
   return controller.standardTesselCommand(opts, function(tessel) {


### PR DESCRIPTION
Warn about credentials are not changed when switching AP on/off

> Credentials are not changed when switching on/off the accesspoint!