### PR TITLE
t2 ap warn about credentials are not changed

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -717,6 +717,9 @@ controller.createAccessPoint = function(opts) {
 
 controller.enableAccessPoint = function(opts) {
   opts.authorized = true;
+  if (opts.ssid) {
+    logs.warn('Credentials are not changed when switching on/off the accesspoint!');
+  }
   return controller.standardTesselCommand(opts, function(tessel) {
     return tessel.enableAccessPoint();
   });
@@ -724,6 +727,9 @@ controller.enableAccessPoint = function(opts) {
 
 controller.disableAccessPoint = function(opts) {
   opts.authorized = true;
+  if (opts.ssid) {
+    logs.warn('Credentials are not changed when switching on/off the accesspoint!');
+  }
   return controller.standardTesselCommand(opts, function(tessel) {
     return tessel.disableAccessPoint();
   });


### PR DESCRIPTION
Warn about credentials are not changed when switching AP on/off

> Credentials are not changed when switching on/off the accesspoint!

fixes https://github.com/tessel/t2-cli/issues/507
