### PR TITLE
Add tab completion for Grunt

### DIFF
--- a/.hooks/install
+++ b/.hooks/install
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Add grunt tab-completion if it doesn't exist already
+
+zshrc="$HOME/.zshrc"
+bashrc="$HOME/.bashrc"
+
+grunt_tab_check()
+{
+  gruntcount=`grep -c "grunt --completion=" $1`
+  if [ $gruntcount -eq 0 ]
+  then
+    if [ $1 == $zshrc ]
+    then
+      echo 'eval "$(grunt --completion=zsh)"' >> $1
+    elif [ $1 == $bashrc ]
+    then
+      echo 'eval "$(grunt --completion=bash)"' >> $1
+    fi
+    echo 'Grunt tab completion added.'
+  fi
+}
+
+if [ -e $zshrc ]
+then
+  grunt_tab_check $zshrc
+elif [ -e $bashrc ]
+then
+  grunt_tab_check $bashrc
+else
+  echo 'Grunt tab completion was not added to either a .zshrc or .bashrc file.'
+fi

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "./bin/tessel-2.js",
   "scripts": {
     "test": "grunt test",
+    "install": ".hooks/install",
     "postinstall": "t2 install-drivers || true"
   },
   "bin": {


### PR DESCRIPTION
Run a shell script as part of the npm install hook to add Grunt tab completion for Bash or Zsh users. :bookmark_tabs: Closes #119.