### PR TITLE
[WIP] Allow deploys of Rust scripts

### DIFF
--- a/lib/tessel/commands.js
+++ b/lib/tessel/commands.js
@@ -28,6 +28,9 @@ module.exports.untarStdin = function(filepath) {
 module.exports.runScript = function(filepath, relpath) {
   return ['node', filepath + relpath];
 };
+module.exports.runRustExecutable = function(filepath) {
+    return [filepath];
+}
 module.exports.openStdinToFile = function(filepath) {
   return ['dd', 'of=' + filepath];
 };

--- a/lib/tessel/deploy.js
+++ b/lib/tessel/deploy.js
@@ -1,5 +1,6 @@
 // System Objects
 var path = require('path');
+var http = require('http');
 
 // Third Party Dependencies
 var browserify = require('browserify');
@@ -11,6 +12,7 @@ var Ignore = require('fstream-ignore');
 var Reader = require('fstream').Reader;
 var tar = require('tar');
 var uglify = require('uglify-js');
+require('toml-require').install();
 
 // Internal
 var commands = require('./commands');
@@ -18,6 +20,9 @@ var logs = require('../logs');
 var Tessel = require('./tessel');
 
 var PUSH_START_SCRIPT_NAME = 'start';
+
+// Server providing cross compilation for Rust
+var RUST_COMPILATION_SERVER = '127.0.0.1:8080/rust-compile';
 
 // Used to store local functionality and allow
 // exporting those definitions for testing.
@@ -109,7 +114,6 @@ Tessel.prototype.memoryInfo = function() {
 };
 /*
   Run a script on a Tessel
-    param opts: unused so far
 */
 Tessel.prototype.deployScript = function(opts) {
   var self = this;
@@ -146,7 +150,8 @@ Tessel.prototype.deployScript = function(opts) {
               return actions.pushScript(self, script, opts).then(resolve);
             } else {
               // Push the code into ram
-              return actions.runScript(self, filepath, script, opts).then(resolve);
+              return actions.runRustScript(self, filepath, script, opts).then(resolve);
+            //   return actions.runScript(self, filepath, script, opts).then(resolve);
             }
           });
       })
@@ -186,6 +191,125 @@ actions.execRemoteCommand = function(tessel, command, filepath) {
   return tessel.simpleExec(commands[command](filepath))
     .catch(function() {});
 };
+
+actions.findRustProject = function(opts) {
+    return new Promise(function(resolve, reject) {
+        var single = opts.single;
+        var file = opts.entryPoint;
+        var home = process.env[(process.platform === 'win32') ? 'USERPROFILE' : 'HOME'];
+        var checkCargoToml = false;
+        var isDirectory = false;
+
+        // Addresses an encountered edge case where
+        // paths wouldn't resolve correctly:
+        //
+        // > fs.realpathSync("~/foo");
+        // Error: ENOENT, no such file or directory '/Users/me/foo/~'
+        // > path.dirname("~/foo")
+        // '~'
+        // > path.resolve("~/foo")
+        // '/Users/me/foo/~/foo'
+        //
+        //  ...And so on...
+        //
+        if (/^~/.test(file)) {
+          file = file.replace(/^~/, home);
+        }
+
+        try {
+          // This will throw if the file or directory doesn't
+          // exist. The cost of the try/catch is negligible.
+          isDirectory = fs.lstatSync(file).isDirectory();
+        } catch (error) {
+          reject(error.message);
+        }
+
+        if (isDirectory && single) {
+          return reject('You can only push a single file, not a directory');
+        }
+
+        if (isDirectory) {
+          file = path.join(file, 'src/main.rs');
+          checkCargoToml = true;
+        }
+
+        var pushdir = fs.realpathSync(path.dirname(file));
+        var relpath = '';
+
+        if (!single) {
+          while (path.dirname(pushdir) !== pushdir &&
+            !fs.existsSync(path.join(pushdir, 'Cargo.toml'))) {
+            relpath = path.join(path.basename(pushdir), relpath);
+            pushdir = path.dirname(pushdir);
+          }
+
+          if (path.dirname(pushdir) === pushdir) {
+            reject('Invalid project directory');
+          }
+        }
+
+        var program = path.join(pushdir, relpath, path.basename(file));
+        var cargoToml = '';
+        var basename = '';
+
+        if (checkCargoToml && !single) {
+          cargoToml = require(path.join(pushdir, 'Cargo.toml'));
+
+          if (cargoToml.package) {
+            basename = path.basename(program);
+            program = cargoToml.package.name;
+          }
+        }
+
+        resolve({
+          pushdir: pushdir,
+          program: program,
+          entryPoint: path.join(relpath, path.basename(program)),
+        });
+    });
+}
+
+actions.remoteRustCompilation = function(project) {
+    logs.info("Compiling Rust code...");
+    return new Promise(function(resolve, reject) {
+
+        var buffers = [];
+
+        var post_options = {
+          host: '127.0.0.1',
+          port: '8080',
+          path: '/rust-compile',
+          method: 'POST',
+          headers: {
+              'Content-Type': 'application/octet-stream',
+              'X-BINARY-NAME': project.program,
+              'X-PROJECT-FOLDER': path.basename(project.pushdir),
+          }
+        };
+
+        // Set up the request
+        var post_req = http.request(post_options, function(res) {
+            res.on('data', function(chunk) {
+                buffers.push(chunk);
+            })
+            .on('error', function(e) {
+                return reject(e);
+            })
+            .on('end', function() {
+                resolve(Buffer.concat(buffers));
+            })
+        });
+
+        var outgoingPacker = tar.Pack({ noProprietary: true })
+          .on('error', reject)
+
+          // This must be a "directory"
+        Reader({ path: project.pushdir, type: "Directory" })
+          .on('error', reject)
+          .pipe(outgoingPacker)
+          .pipe(post_req)
+    });
+}
 
 actions.findProject = function(opts) {
   return new Promise(function(resolve, reject) {
@@ -267,37 +391,42 @@ actions.findProject = function(opts) {
 actions.sendBundle = function(tessel, filepath, opts) {
   return new Promise(function(resolve, reject) {
     // Execute the remote untar process command
-    return tessel.connection.exec(commands.untarStdin(filepath))
+    var rustExecutableName = 'rust_executable';
+    return tessel.connection.exec(commands.openStdinToFile(filepath + rustExecutableName))
       // Once the process starts running
       .then(function(remoteProcess) {
-        actions.findProject(opts).then(function(project) {
+        actions.findRustProject(opts).then(function(project) {
           opts.target = path.resolve(process.cwd(), project.pushdir);
           opts.resolvedEntryPoint = project.entryPoint;
 
-          actions.tarBundle(opts).then(function(bundle) {
-            // RAM or Flash for log
-            var memtype;
-            if (opts.push) {
-              memtype = 'Flash';
-            } else {
-              memtype = 'RAM';
-            }
+        //   return actions.tarBundle(opts).then(function(bundle) {
+             return actions.remoteRustCompilation(project)
+              .then(function(bundle) {
+                  // RAM or Flash for log
+                  var memtype;
+                  if (opts.push) {
+                    memtype = 'Flash';
+                  } else {
+                    memtype = 'RAM';
+                  }
 
-            // Log write
-            logs.info('Writing project to %s on %s (%d kB)...', memtype, tessel.name, bundle.length / 1000);
+                  // Log write
+                  logs.info('Writing project to %s on %s (%d kB)...', memtype, tessel.name, bundle.length / 1000);
 
-            tessel.receive(remoteProcess).then(function() {
-              logs.info('Deployed.');
-              if (opts.slim) {
-                resolve(opts.slimPath);
-              } else {
-                resolve(project.entryPoint);
-              }
-            }).catch(reject);
+                  tessel.receive(remoteProcess).then(function() {
+                    logs.info('Deployed.');
+                    if (opts.slim) {
+                      resolve(rustExecutableName);
+                    } else {
+                      resolve(rustExecutableName);
+                    }
+                  }).catch(reject);
 
-            // Write the code bundle to the hardware
-            remoteProcess.stdin.end(bundle);
-          }).catch(reject);
+                  // Write the code bundle to the hardware
+                  remoteProcess.stdin.end(bundle);
+                // }).catch(reject);
+              });
+
         }).catch(reject);
       });
   });
@@ -382,7 +511,6 @@ actions.glob = {
     }, []);
   }
 };
-
 
 actions.tarBundle = function(opts) {
   var target = opts.target || process.cwd();
@@ -572,6 +700,25 @@ actions.runScript = function(t, filepath, entryPoint, opts) {
       });
   });
 };
+
+actions.runRustScript = function(t, filepath, executableName, opts) {
+    var absoluteExecutablePath = path.join(filepath, executableName);
+    return new Promise(function(resolve) {
+        return t.connection.exec(commands.setExecutablePermissions(absoluteExecutablePath))
+        .then(t.receive)
+        .then(function() {
+            logs.info("Running Rust Executable...");
+            return t.connection.exec(commands.runRustExecutable(absoluteExecutablePath))
+            .then(function(remoteProcess) {
+                remoteProcess.stderr.pipe(process.stderr);
+                remoteProcess.stdout.pipe(process.stdout);
+
+                // Resolve when the process completes
+                remoteProcess.once('close', resolve);
+            })
+        })
+    })
+}
 
 actions.pushScript = function(t, entryPoint, opts) {
   var actualEntryPointName = opts.slim ? opts.slimPath : entryPoint;

--- a/lib/tessel/tessel.js
+++ b/lib/tessel/tessel.js
@@ -90,11 +90,11 @@ Tessel.prototype.receive = function(remote) {
 
   return new Promise(function(resolve, reject) {
     remote.once('close', function() {
-      if (error) {
-        return reject(new Error(error));
-      } else {
+    //   if (error) {
+        // return reject(new Error(error));
+    //   } else {
         return resolve(received);
-      }
+    //   }
     });
   });
 };

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "stream-to-buffer": "^0.1.0",
     "tar": "^2.1.1",
     "tar-stream": "^1.3.0",
+    "toml-require": "^1.1.0",
     "uglify-js": "^2.5.0",
     "url-join": "0.0.1",
     "usb": "1.1.1",


### PR DESCRIPTION
This is my initial brute force method of working through what it will be like to deploy Rust. There is a lot of cleanup/refactoring to do because this currently destroys JavaScript deployment and will probably not pass Grunt's tests. I just wanted to see how far I could get in a day.

To Test:
* Start up [a Rust compilation server VM](https://github.com/tessel/rust-compilation-server#install) 
* Create a Rust project on your host machine (not your VM). `cargo new hello --bin` should work well for that.
* Plug in your Tessel and make sure it finishes booting
* Check out this branch of the CLI
* From within your Rust project (the `hello` directory), run `t2 run .`. You should get output like this:
```
➜  hello git:(master) ✗ t2 run .
INFO Looking for your Tessel...
INFO Connected to Hen.
INFO Compiling Rust code...
INFO Writing project to RAM on Hen (295.535 kB)...
INFO Deployed.
INFO Running Rust Executable...
Hello, world!
```

TODO:
- [ ] Tests
- [ ] Get the cross compilation tools and express server on a long-living public IP Address
- [ ] Add automatic language detection to the CLI
- [ ] Refactor the code so it's easy to swap in code bundling, optional compilation, deployment, and initialization for different languages in the CLI
- [ ] Fix grunt complaints