### PR TITLE
Allows LAN deploys to close the process properly

### DIFF
--- a/lib/lan_connection.js
+++ b/lib/lan_connection.js
@@ -40,7 +40,7 @@ LAN.Connection = function(opts) {
   }
 };
 
-LAN.Connection.prototype.exec = function(command) {
+LAN.Connection.prototype.exec = function(command, options) {
   var self = this;
   return new Promise(function(resolve, reject) {
 
@@ -56,8 +56,11 @@ LAN.Connection.prototype.exec = function(command) {
     // Turn an array of args into a string to execute over SSH
     command = self._processArgsForTransport(command);
 
+    // Set default options if none provided
+    options = options || {};
+
     // Execute the bash command
-    self.ssh.exec(command, function(err, godStream) {
+    self.ssh.exec(command, options, function(err, godStream) {
       if (err) {
         return reject(err);
       }

--- a/lib/tessel/deploy.js
+++ b/lib/tessel/deploy.js
@@ -560,7 +560,9 @@ actions.runScript = function(t, filepath, entryPoint, opts) {
 
   logs.info('Running %s...', opts.slim ? 'bundled project' : entryPoint);
   return new Promise(function(resolve) {
-    return t.connection.exec(commands.runScript(filepath, actualEntryPointName))
+    return t.connection.exec(commands.runScript(filepath, actualEntryPointName), {
+        pty: true
+      })
       .then(function(remoteProcess) {
 
         // When the stream closes

--- a/test/unit/deploy.js
+++ b/test/unit/deploy.js
@@ -182,7 +182,8 @@ exports['Tessel.prototype.deployScript'] = {
   },
 
   runScript: function(test) {
-    test.expect(10);
+    test.expect(11);
+    this.exec = sandbox.spy(this.tessel.connection, 'exec');
     deployTestCode(this.tessel, test, {
       push: false,
       single: false
@@ -197,6 +198,8 @@ exports['Tessel.prototype.deployScript'] = {
       test.equal(this.setExecutablePermissions.callCount, 0);
       test.equal(this.startPushedScript.callCount, 0);
       test.equal(this.end.callCount, 1);
+      // Ensure that the last call (to run Node) sets pty to true
+      test.equal(this.exec.lastCall.args[1].pty, true);
       test.done();
     }.bind(this));
   },


### PR DESCRIPTION
Adding the `exec` option of `pty=true` to a LAN connection `exec` makes it possible for it to kill the spawned processes if the connection closes.

I would have liked to just made this a default option on all execs but when I tried that, I started getting syntax errors reported in the JavaScript of my blinky test file on Tessel. I don't really understand what pseudo-tty does but it seems to have negative impacts in some cases.