### PR TITLE
Temporarily fixes code deploy to flash

### DIFF
--- a/lib/tessel/commands.js
+++ b/lib/tessel/commands.js
@@ -22,6 +22,9 @@ module.exports.deleteFolder = function(filepath) {
 module.exports.createFolder = function(filepath) {
   return ['mkdir', '-p', filepath];
 };
+module.exports.moveFolder = function(source, destination) {
+  return ['mv', source, destination];
+};
 module.exports.untarStdin = function(filepath) {
   return ['tar', '-x', '-C', filepath];
 };

--- a/lib/tessel/deploy.js
+++ b/lib/tessel/deploy.js
@@ -117,28 +117,38 @@ Tessel.prototype.deployScript = function(opts) {
   var isPush = opts.push === true;
 
   return new Promise(function(resolve, reject) {
-    var filepath = isPush ? Tessel.REMOTE_PUSH_PATH : Tessel.REMOTE_RUN_PATH;
-
     // Stop running any existing scripts
-    return actions.execRemoteCommand(self, 'stopRunningScript', filepath)
+    return actions.execRemoteCommand(self, 'stopRunningScript')
       .then(function() {
         var prom;
 
         if (opts.single) {
           // Always be sure the appropriate dir is created
-          prom = actions.execRemoteCommand(self, 'createFolder', filepath);
+          prom = actions.execRemoteCommand(self, 'createFolder', Tessel.REMOTE_RUN_PATH);
         } else {
           // Delete any code that was previously at this file path
-          prom = actions.execRemoteCommand(self, 'deleteFolder', filepath);
+          prom = actions.execRemoteCommand(self, 'deleteFolder', Tessel.REMOTE_RUN_PATH);
           // Create the folder again
           prom = prom.then(function() {
-            return actions.execRemoteCommand(self, 'createFolder', filepath);
+            return actions.execRemoteCommand(self, 'createFolder', Tessel.REMOTE_RUN_PATH);
           });
+
+          // If we are pushing code
+          if (opts.push) {
+            // Delete any old flash folder
+            prom = prom.then(function() {
+                return actions.execRemoteCommand(self, 'deleteFolder', Tessel.REMOTE_PUSH_PATH);
+              })
+              // Create a new flash folder
+              .then(function() {
+                return actions.execRemoteCommand(self, 'createFolder', Tessel.REMOTE_PUSH_PATH);
+              });
+          }
         }
 
         // Bundle and send tarred code to T2
         return prom.then(function() {
-            return actions.sendBundle(self, filepath, opts);
+            return actions.sendBundle(self, opts);
           })
           .then(function(script) {
             if (isPush) {
@@ -146,7 +156,7 @@ Tessel.prototype.deployScript = function(opts) {
               return actions.pushScript(self, script, opts).then(resolve);
             } else {
               // Push the code into ram
-              return actions.runScript(self, filepath, script, opts).then(resolve);
+              return actions.runScript(self, script, opts).then(resolve);
             }
           });
       })
@@ -264,10 +274,10 @@ actions.findProject = function(opts) {
   });
 };
 
-actions.sendBundle = function(tessel, filepath, opts) {
+actions.sendBundle = function(tessel, opts) {
   return new Promise(function(resolve, reject) {
     // Execute the remote untar process command
-    return tessel.connection.exec(commands.untarStdin(filepath))
+    return tessel.connection.exec(commands.untarStdin(Tessel.REMOTE_RUN_PATH))
       // Once the process starts running
       .then(function(remoteProcess) {
         actions.findProject(opts).then(function(project) {
@@ -555,12 +565,12 @@ actions.tarBundle = function(opts) {
   }
 };
 
-actions.runScript = function(t, filepath, entryPoint, opts) {
+actions.runScript = function(t, entryPoint, opts) {
   var actualEntryPointName = opts.slim ? opts.slimPath : entryPoint;
 
   logs.info('Running %s...', opts.slim ? 'bundled project' : entryPoint);
   return new Promise(function(resolve) {
-    return t.connection.exec(commands.runScript(filepath, actualEntryPointName), {
+    return t.connection.exec(commands.runScript(Tessel.REMOTE_RUN_PATH, actualEntryPointName), {
         pty: true
       })
       .then(function(remoteProcess) {
@@ -594,7 +604,7 @@ actions.writeToFile = function(t, entryPoint) {
       // If it was opened successfully
       .then(function(remoteProcess) {
         // When the remote process finishes
-        remoteProcess.stdin.once('finish', function() {
+        remoteProcess.once('close', function() {
           // Set the perimissions on the file to be executable
           return t.connection.exec(commands.setExecutablePermissions(shellScriptPath))
             .then(function(remoteProcess) {
@@ -609,7 +619,7 @@ actions.writeToFile = function(t, entryPoint) {
 
         var shellScript = tags.stripIndent `
           #!/bin/sh
-          cd /app
+          cd /app/remote-script
           exec node ${entryPoint}
         `;
         remoteProcess.stdin.end(new Buffer(shellScript.trim()));
@@ -620,12 +630,16 @@ actions.writeToFile = function(t, entryPoint) {
 actions.startPushedScript = function(tessel, entryPoint, opts) {
   return new Promise(function(resolve) {
     // Once it has been written, run the script with Node
-    return tessel.connection.exec(commands.startPushedScript())
-      .then(function(remoteProcess) {
-        return tessel.receive(remoteProcess).then(function() {
-          logs.info('Running %s...', opts.slim ? 'bundled project' : entryPoint);
-          return resolve();
-        });
+    return tessel.connection.exec(commands.moveFolder(Tessel.REMOTE_RUN_PATH, Tessel.REMOTE_PUSH_PATH))
+      .then(tessel.receive)
+      .then(function() {
+        return tessel.connection.exec(commands.startPushedScript())
+          .then(function(remoteProcess) {
+            return tessel.receive(remoteProcess).then(function() {
+              logs.info('Running %s...', opts.slim ? 'bundled project' : entryPoint);
+              return resolve();
+            });
+          });
       });
   });
 };

--- a/lib/usb/usb_process.js
+++ b/lib/usb/usb_process.js
@@ -5,6 +5,7 @@ var util = require('util');
 
 // Third Party
 var protocol = require('usb-daemon-parser');
+var debug = require('debug')('usb_process');
 
 // Internal
 // ...
@@ -54,6 +55,7 @@ function USBProcess(id, daemon) {
 
     // Check for a non-zero exit code
     var exitCode = parseInt(data.arg);
+    debug('death for', self.commandString, exitCode);
     if (exitCode !== 0 && !self.forceKill) {
       self.emit('error', new Error('Error upon remote process exit: ' + exitCode));
     }
@@ -149,6 +151,14 @@ util.inherits(RemoteWritableStream, stream.Writable);
 
 // The underlying function for .write calls on the Node stream
 RemoteWritableStream.prototype._write = function(chunk, enc, callback) {
+  // Purely for debugging purposes
+  // If this is a control Stream
+  if (this.writeHeaderFunc === protocol.controlWrite) {
+    // Save the string we're writing for debugging
+    this.process.commandString = chunk.toString();
+    debug('Opening process for', this.process.commandString);
+  }
+
   // Add this chunk to the backpressure array
   this.backPressure.push({
     buffer: chunk,

--- a/test/unit/deploy.js
+++ b/test/unit/deploy.js
@@ -232,8 +232,9 @@ exports['Tessel.prototype.deployScript'] = {
     }, function deployed(err) {
       test.ifError(err);
       test.equal(this.stopRunningScript.callCount, 1);
-      test.equal(this.deleteFolder.callCount, 1);
-      test.equal(this.createFolder.callCount, 1);
+      // Delete and create both the flash and ram folders
+      test.equal(this.deleteFolder.callCount, 2);
+      test.equal(this.createFolder.callCount, 2);
       test.equal(this.untarStdin.callCount, 1);
       test.equal(this.runScript.callCount, 0);
       test.equal(this.openStdinToFile.callCount, 1);
@@ -269,7 +270,7 @@ exports['Tessel.prototype.deployScript'] = {
 
     var shellScript = tags.stripIndent `
       #!/bin/sh
-      cd /app
+      cd /app/remote-script
       exec node index.js
     `;
     this.end.restore();
@@ -291,7 +292,7 @@ exports['Tessel.prototype.deployScript'] = {
 
     var shellScript = tags.stripIndent `
       #!/bin/sh
-      cd /app
+      cd /app/remote-script
       exec node __tessel_program__.js
     `;
     this.end.restore();


### PR DESCRIPTION
For some reason, USB writes to Flash storage would freeze after about 100k. This does not happen if the deploy is slower. I'm not sure why but it appears to be a race condition in the USB Daemon.

This PR is certainly not ideal, but it will be a faster patch than trying to figure out a race condition in C code. All it does is write code to RAM first regardless of `push` or `run`, then copy it into Flash if it was a `push` prior to running it.

Suggestions/thoughts are welcomed.

Fixes #495.