### PR TITLE
Mime types include list

### DIFF
--- a/lib/tessel/deploy-lists.js
+++ b/lib/tessel/deploy-lists.js
@@ -1,6 +1,7 @@
 module.exports = {
   includes: [
     'negotiator/**/*.js',
-    'socket.io-client/socket.io.js'
+    'socket.io-client/socket.io.js',
+    'mime/types/*.types'
   ]
 };

--- a/lib/tessel/wifi.js
+++ b/lib/tessel/wifi.js
@@ -65,7 +65,7 @@ Tessel.prototype.getWifiInfo = function() {
 
 function safeQualityExprEvaluation(expr) {
   var parsed = /(\d.*)(?:\/)(\d.*)/.exec(expr);
-  var isNumber = parsed === null && typeof +expr === 'number' && !Number.isNaN(+expr);
+  var isNumber = parsed === null && typeof + expr === 'number' && !Number.isNaN(+expr);
 
   // If the expression doesn't match "\d.*/\d.*",
   // but IS a number, then return the number. Otherwise,

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -48,6 +48,7 @@
     "Tessel": true,
     "commands": true,
     "deploy": true,
+    "deployLists": true,
     "provision": true,
     "controller": true,
     "discover": true,

--- a/test/common/bootstrap.js
+++ b/test/common/bootstrap.js
@@ -40,6 +40,7 @@ global.Tessel = require('../../lib/tessel/tessel');
 global.commands = require('../../lib/tessel/commands');
 global.deploy = require('../../lib/tessel/deploy');
 global.provision = require('../../lib/tessel/provision');
+global.deployLists = require('../../lib/tessel/deploy-lists');
 
 // ./lib/*
 global.controller = require('../../lib/controller');

--- a/test/unit/deploy-lists.js
+++ b/test/unit/deploy-lists.js
@@ -1,0 +1,24 @@
+// Test dependencies are required and exposed in common/bootstrap.js
+
+exports['deploy-lists'] = {
+  setUp: function(done) {
+    done();
+  },
+
+  tearDown: function(done) {
+    done();
+  },
+
+  checkIncludes: function(test) {
+    test.expect(1);
+
+    var includes = [
+      'negotiator/**/*.js',
+      'socket.io-client/socket.io.js',
+      'mime/types/*.types'
+    ];
+
+    test.deepEqual(deployLists.includes, includes);
+    test.done();
+  }
+};

--- a/test/unit/deploy.js
+++ b/test/unit/deploy.js
@@ -480,8 +480,8 @@ exports['deploy.tarBundle'] = {
 
       // One call for .tesselinclude
       // One call for the single rule found within
-      // Two calls for the deploy lists
-      test.equal(this.globSync.callCount, 3);
+      // Three calls for the deploy lists
+      test.equal(this.globSync.callCount, 4);
 
       // addIgnoreRules might be called many times, but we only
       // care about tracking the call that's explicitly made by
@@ -800,7 +800,7 @@ exports['deploy.tarBundle'] = {
       resolvedEntryPoint: entryPoint,
       slim: true,
     }).then(function(bundle) {
-      test.equal(this.globSync.callCount, 10);
+      test.equal(this.globSync.callCount, 11);
 
       /*
         All .tesselignore rules are negated by all .tesselinclude rules:
@@ -882,7 +882,7 @@ exports['deploy.tarBundle'] = {
       target: path.normalize(target),
       full: true,
     }).then(function(bundle) {
-      test.equal(this.globSync.callCount, 6);
+      test.equal(this.globSync.callCount, 7);
 
       // addIgnoreRules might be called many times, but we only
       // care about tracking the call that's explicitly made by
@@ -960,7 +960,7 @@ exports['deploy.tarBundle'] = {
       resolvedEntryPoint: entryPoint,
       slim: true,
     }).then(function(bundle) {
-      test.equal(this.globSync.callCount, 7);
+      test.equal(this.globSync.callCount, 8);
 
       /*
         There are NO .tesselignore rules, but there are .tesselinclude rules:
@@ -1046,7 +1046,7 @@ exports['deploy.tarBundle'] = {
       target: path.normalize(target),
       full: true,
     }).then(function(bundle) {
-      test.equal(this.globSync.callCount, 6);
+      test.equal(this.globSync.callCount, 7);
 
       // addIgnoreRules might be called many times, but we only
       // care about tracking the call that's explicitly made by
@@ -1133,7 +1133,7 @@ exports['deploy.tarBundle'] = {
       resolvedEntryPoint: entryPoint,
       slim: true,
     }).then(function(bundle) {
-      test.equal(this.globSync.callCount, 8);
+      test.equal(this.globSync.callCount, 9);
 
       /*
         There are NO .tesselignore rules, but there are .tesselinclude rules:
@@ -1217,7 +1217,7 @@ exports['deploy.tarBundle'] = {
       target: path.normalize(target),
       full: true,
     }).then(function(bundle) {
-      test.equal(this.globSync.callCount, 6);
+      test.equal(this.globSync.callCount, 7);
 
       // addIgnoreRules might be called many times, but we only
       // care about tracking the call that's explicitly made by


### PR DESCRIPTION
Fixes #521 

`lib/tessel/wifi.js` was formatted after running `grunt`. 