### PR TITLE
Support "bare_returns" for CJS modules

### DIFF
--- a/lib/tessel/deploy.js
+++ b/lib/tessel/deploy.js
@@ -819,9 +819,32 @@ actions.project = function(options) {
 };
 
 actions.compress = function(source) {
-  return uglify.minify(source.toString(), {
-    fromString: true
-  }).code;
+  source = typeof source === 'string' ? source : source.toString();
+
+  var content = uglify.parse(source, actions.compress.options);
+
+  content.figure_out_scope();
+  content = content.transform(uglify.Compressor({
+    warnings: false
+  }));
+
+  var code = uglify.OutputStream();
+  content.print(code);
+
+  return code.toString();
+};
+
+actions.compress.options = {
+  fromString: true,
+  bare_returns: true,
+  spidermonkey: false,
+  outSourceMap: null,
+  sourceRoot: null,
+  inSourceMap: null,
+  warnings: false,
+  mangle: {},
+  output: null,
+  compress: {}
 };
 
 if (global.IS_TEST_ENV) {


### PR DESCRIPTION
This is necessary for CommonJS modules that take advantage of CJS's implied IIFE wrapper that allows for "bare returns" (returns that appear out of a function, which are actually inside a wrapper function when the module is evaluated). The option is not forwarded when using the provided `minify` function.