### PR TITLE
ssid not required for ap --trigger

### DIFF
--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -299,7 +299,6 @@ makeCommand('version')
 makeCommand('ap')
   .option('ssid', {
     abbr: 'n',
-    required: true,
     help: 'Name of the network.'
   })
   .option('pass', {


### PR DESCRIPTION
Fixes #528 

