### PR TITLE
drop bluebird

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -7,7 +7,6 @@ var _ = require('lodash');
 var async = require('async');
 var colors = require('colors');
 var inquirer = require('inquirer');
-var Promise = require('bluebird');
 var sprintf = require('sprintf-js').sprintf;
 
 // Internal
@@ -414,7 +413,7 @@ controller.runHeuristics = function(opts, tessels) {
   var LAN_CONN_PRIORITY = 3;
 
   // For each of the Tessels found
-  return Promise.reduce(tessels, function(collector, tessel) {
+  return Promise.resolve(tessels.reduce(function(collector, tessel) {
       // Create an object to keep track of what priority this Tessel has
       // The lower the priority, the more likely the user wanted this Tessel
       var entry = {
@@ -426,36 +425,27 @@ controller.runHeuristics = function(opts, tessels) {
       if (opts.name && opts.name === tessel.name) {
         // Set it to the highest priority
         entry.priority = NAME_OPTION_PRIORITY;
-        // Store the entry
-        collector.push(entry);
-        return collector;
+        return collector.concat([entry]);
       }
 
       // If an environment variable was set and it equals this Tessel
       if (process.env.TESSEL && process.env.TESSEL === tessel.name) {
         // Mark the priority level
         entry.priority = ENV_OPTION_PRIORITY;
-        // Store the entry
-        collector.push(entry);
-        return collector;
+        return collector.concat([entry]);
       }
 
       // If this has a USB connection
       if (tessel.usbConnection) {
         // Mark the priority
         entry.priority = USB_CONN_PRIORITY;
-        // Store the entry
-        collector.push(entry);
-        return collector;
+        return collector.concat([entry]);
       }
 
       // This is a LAN connection so give it the lowest priority
       entry.priority = LAN_CONN_PRIORITY;
-      // Store the entry
-      collector.push(entry);
-      return collector;
-
-    }, [])
+      return collector.concat([entry]);
+    }, []))
     .then(function selectTessel(collector) {
       var usbFound = false;
       var lanFound = false;

--- a/lib/init.js
+++ b/lib/init.js
@@ -1,16 +1,13 @@
 // System Objects
 var path = require('path');
-var fs;
+var fs = require('fs');
 
 // Third Party Dependencies
-var Promise = require('bluebird');
 var PZ = require('promzard').PromZard;
 var NPM = require('npm');
 
 // Internal
 // ...
-
-fs = Promise.promisifyAll(require('fs'));
 
 var packageJson = path.resolve('./package.json');
 var pkg, ctx, options;
@@ -20,22 +17,17 @@ function loadNpm() {
   return new Promise(function(resolve, reject) {
     NPM.load(function(error, npm) {
       if (error) {
-        reject(error);
-        return;
+        return reject(error);
       }
       // It then returns a npm object with functions
       resolve(npm);
-      return;
     });
   });
 }
 
 function getNpmConfig(npm) {
-  return new Promise(function(resolve) {
-    // Always resolve, we don't care if there isn't an npm config.
-    var npmConfig = npm.config.list || {};
-    resolve(npmConfig);
-  });
+  // Always resolve, we don't care if there isn't an npm config.
+  return Promise.resolve(npm.config.list || {});
 }
 
 function buildJSON(npmConfig) {
@@ -136,6 +128,33 @@ function generateSample() {
   });
 }
 
+function readPackageJson() {
+  return new Promise(function(resolve, reject) {
+    fs.readFile(packageJson, 'utf8', function(err, data) {
+      if (err) {
+        return reject(err);
+      }
+
+      resolve(data);
+    });
+  });
+}
+
+function writePackageJson(data) {
+  return new Promise(function(resolve, reject) {
+    fs.writeFile(packageJson, data, function(err) {
+      if (err) {
+        return reject(err);
+      }
+
+      resolve();
+    });
+  });
+}
+
+function prettyPrintJson(data) {
+  return JSON.stringify(data, null, 2);
+}
 
 module.exports = function(opts) {
   // Set interactive boolean off of CLI flags
@@ -143,7 +162,7 @@ module.exports = function(opts) {
 
   console.log('Initializing tessel repository...');
 
-  fs.readFileAsync(packageJson, 'utf8')
+  readPackageJson()
     .then(function(data) {
 
       // Try to parse current package JSON
@@ -172,14 +191,9 @@ module.exports = function(opts) {
     .then(loadNpm)
     .then(getNpmConfig)
     .then(buildJSON)
-    .then(function(data) {
-      // Stringify and write package.json data
-      // 2 spaces for indents is standard.
-      return fs.writeFileAsync(packageJson, JSON.stringify(data, null, 2));
-    })
-    .then(function() {
-      return fs.readFileAsync(packageJson);
-    })
+    .then(prettyPrintJson)
+    .then(writePackageJson)
+    .then(readPackageJson)
     .then(JSON.parse)
     .then(getDependencies)
     .then(npmInstall)

--- a/lib/lan_connection.js
+++ b/lib/lan_connection.js
@@ -9,7 +9,6 @@ var Emitter = events.EventEmitter;
 var debug = require('debug')('discovery:lan');
 var fs = require('fs-extra');
 var mdns = require('mdns-js');
-var Promise = require('bluebird');
 var shellescape = require('shell-escape');
 var ssh = require('ssh2');
 

--- a/lib/usb_connection.js
+++ b/lib/usb_connection.js
@@ -1,7 +1,6 @@
 // System Objects
 var util = require('util');
 var stream = require('stream');
-var Promise = require('bluebird');
 var events = require('events');
 
 var Duplex = stream.Duplex;

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   "dependencies": {
     "async": "^1.4.2",
     "bindings": "^1.2.1",
-    "bluebird": "^2.9.6",
     "browserify": "^11.2.0",
     "colors": "^1.1.0",
     "common-tags": "0.0.1",


### PR DESCRIPTION
*related to #490*

This drop the dependency on Bluebird and uses only the builtin `Promise` instead.