### PR TITLE
Cleanup: directly access provision.setupLocal, eliminate useless file. Fixes gh-549

### DIFF
--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -9,7 +9,6 @@ var parser = require('nomnom').script('t2');
 // Internal
 var controller = require('../lib/controller');
 var init = require('../lib/init');
-var key = require('../lib/key');
 var logs = require('../lib/logs');
 var drivers = require('./tessel-install-drivers');
 
@@ -241,7 +240,7 @@ makeCommand('wifi')
 
 parser.command('key')
   .callback(function(opts) {
-    key(opts)
+    controller.setupLocal(opts)
       .then(function() {
         logs.info('Key successfully generated.');
       })

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -43,6 +43,11 @@ controller.keyHelper = function(opts, next) {
   return keyPromise.then(() => next(opts));
 };
 
+controller.setupLocal = function(opts) {
+  return provision.setupLocal(opts);
+};
+
+
 Tessel.list = function(opts) {
 
   return new Promise(function(resolve, reject) {

--- a/lib/key.js
+++ b/lib/key.js
@@ -1,5 +1,0 @@
-var provision = require('./tessel/provision');
-
-module.exports = function() {
-  return provision.setupLocal();
-};


### PR DESCRIPTION
There may be more to this, pending further information reporting to #549 