### PR TITLE
remove self and bind

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -118,7 +118,7 @@ Tessel.list = function(opts) {
           .catch(function(err) {
             if (!(err instanceof controller.HeuristicAmbiguityError)) {
               return controller.closeTesselConnections(foundTessels)
-                .then(reject.bind(this, err));
+                .then(() => reject(err));
             }
           })
           .then(function() {
@@ -239,7 +239,7 @@ Tessel.get = function(opts) {
 
                 } else {
                   controller.closeTesselConnections(tessels)
-                    .then(reject.bind(this, err));
+                    .then(() => reject(err));
                 }
               });
           });

--- a/lib/dfu.js
+++ b/lib/dfu.js
@@ -90,32 +90,30 @@ DFU.prototype.dnloadChunk = function(blockNum, data, callback) {
 };
 
 DFU.prototype.dnload = function(data, callback, statuscb) {
-  var self = this;
   var pos = 0;
   var seq = 0;
-
-  function step() {
+  var step = () => {
 
     if (typeof statuscb === 'function') {
       statuscb(pos, data.length);
     }
 
-    self.dnloadChunk(seq, data.slice(pos, pos + self.transferSize), function(error) {
+    this.dnloadChunk(seq, data.slice(pos, pos + this.transferSize), (error) => {
       if (error) {
         console.log('chunk error', error);
         if (error) {
-          return self.handleError(error, callback);
+          return this.handleError(error, callback);
         }
       }
 
-      self.getStatus(function(error) {
+      this.getStatus((error) => {
         if (error) {
           console.log('status error', error);
           return callback(error);
         }
 
         seq += 1;
-        pos += self.transferSize;
+        pos += this.transferSize;
 
         if (pos < data.length) {
           step();
@@ -125,12 +123,12 @@ DFU.prototype.dnload = function(data, callback, statuscb) {
             statuscb(data.length, data.length);
           }
 
-          self.dnloadChunk(seq, new Buffer(0), function(error) {
+          this.dnloadChunk(seq, new Buffer(0), (error) => {
             if (error) {
               return callback(error);
             }
 
-            self.getStatus(function(error) {
+            this.getStatus((error) => {
               if (error) {
                 return callback(error);
               }
@@ -140,7 +138,8 @@ DFU.prototype.dnload = function(data, callback, statuscb) {
         }
       });
     });
-  }
+  };
+
   step();
 };
 
@@ -149,27 +148,25 @@ DFU.prototype.uploadChunk = function(blockNum, length, callback) {
 };
 
 DFU.prototype.upload = function(callback) {
-  var self = this;
   var buffers = [];
   var seq = 0;
-
-  function step() {
-    self.uploadChunk(seq, self.transferSize, function(error, data) {
-
+  var step = () => {
+    this.uploadChunk(seq, this.transferSize, (error, data) => {
       if (error) {
-        return self.handleError(error, callback);
+        return this.handleError(error, callback);
       }
 
       buffers.push(data);
 
-      if (data.length === self.transferSize) {
+      if (data.length === this.transferSize) {
         seq += 1;
         step();
       } else {
         callback(null, Buffer.concat(buffers));
       }
     });
-  }
+  };
+
   step();
 };
 

--- a/lib/discover.js
+++ b/lib/discover.js
@@ -23,13 +23,49 @@ function TesselSeeker() {
 util.inherits(TesselSeeker, Emitter);
 
 TesselSeeker.prototype.start = function(opts) {
-  var self = this;
-
   // Initialize the opts if it wasn't provided
   opts = opts || {};
 
   // An array of pending open connections
   var pendingOpen = [];
+
+  var connectionHandler = (conn) => {
+    var tessel = new Tessel(conn);
+    var opening = tessel.connection.open()
+      .then(() => {
+        if (opts.authorized !== undefined) {
+          if (tessel.connection.authorized !== opts.authorized) {
+            debug('Kicking ' + conn.host.slice(0, -6) + ' due to authorized filter: ' + opts.authorized);
+            return Promise.reject();
+          }
+        }
+        /*if (opts.authorized && !tessel.connection.authorized) {
+          debug('Kicking ' + conn.host.slice(0, -6) + ' due to authorized filter: ' + opts.authorized);
+          return;
+        }*/
+      })
+      .then(() => {
+        debug('Connection opened:', tessel.connection.host);
+        if (conn.connectionType === 'LAN' && !conn.authorized) {
+          tessel.name = conn.host.slice(0, -6);
+          this.emit('tessel', tessel);
+        } else {
+          debug('Fetching name:', tessel.connection.host);
+          return tessel.getName()
+            .then(() => {
+              this.emit('tessel', tessel);
+              return Promise.resolve();
+            });
+        }
+      }).catch(function(err) {
+        debug('Error opening device', err);
+        if (tessel.connection.connectionType === 'USB') {
+          logs.warn('Detected a Tessel that may be booting.');
+        }
+      });
+    // Push this Promise into the pending array
+    pendingOpen.push(opening);
+  };
 
   // If the user explicitly specified the usb flag,
   // then cli should not filter on authorization status.
@@ -47,78 +83,36 @@ TesselSeeker.prototype.start = function(opts) {
   if (opts.lan) {
     debug('Will scan for LAN devices');
     // Start the scan
-    self.lanScan = lan.startScan();
+    this.lanScan = lan.startScan();
     // When we get a connection, handle it
-    self.lanScan.on('connection', connectionHandler.bind(self));
+    this.lanScan.on('connection', connectionHandler);
   }
 
   // If the user has explicitly requested a USB search
   if (opts.usb) {
     debug('Will scan for USB devices');
     // Start the scan
-    self.usbScan = usb.startScan();
+    this.usbScan = usb.startScan();
     // When we get a connection, handle it
-    self.usbScan.on('connection', connectionHandler.bind(self));
-  }
-
-  function connectionHandler(conn) {
-    var tessel = new Tessel(conn);
-    var opening = tessel.connection.open()
-      .then(function() {
-        if (opts.authorized !== undefined) {
-          if (tessel.connection.authorized !== opts.authorized) {
-            debug('Kicking ' + conn.host.slice(0, -6) + ' due to authorized filter: ' + opts.authorized);
-            return Promise.reject();
-          } else {
-            return true;
-          }
-        } else {
-          return true;
-        }
-        /*if (opts.authorized && !tessel.connection.authorized) {
-          debug('Kicking ' + conn.host.slice(0, -6) + ' due to authorized filter: ' + opts.authorized);
-          return;
-        }*/
-      })
-      .then(function() {
-        debug('Connection opened:', tessel.connection.host);
-        if (conn.connectionType === 'LAN' && !conn.authorized) {
-          tessel.name = conn.host.slice(0, -6);
-          self.emit('tessel', tessel);
-        } else {
-          debug('Fetching name:', tessel.connection.host);
-          return tessel.getName()
-            .then(function() {
-              self.emit('tessel', tessel);
-              return Promise.resolve();
-            });
-        }
-      }).catch(function(err) {
-        debug('Error opening device', err);
-        if (tessel.connection.connectionType === 'USB') {
-          logs.warn('Detected a Tessel that may be booting.');
-        }
-      });
-    // Push this Promise into the pending array
-    pendingOpen.push(opening);
+    this.usbScan.on('connection', connectionHandler);
   }
 
   // If a timeout was provided
   if (opts.timeout && typeof opts.timeout === 'number') {
     // Set a timeout function
-    self.scanTimeout = setTimeout(function() {
+    this.scanTimeout = setTimeout(() => {
       debug('Timeout hit! Waiting for pending to finish...');
       // Once all the pending open commands complete
       Promise.all(pendingOpen)
         // Stop the scan (which emits 'end')
-        .then(function() {
+        .then(() => {
           debug('Done! Stopping.');
-          self.stop();
+          this.stop();
         });
     }, opts.timeout);
   }
 
-  return self;
+  return this;
 };
 
 TesselSeeker.prototype.stop = function() {
@@ -140,9 +134,7 @@ TesselSeeker.prototype.stop = function() {
     // Clear that timeout
     clearTimeout(this.scanTimeout);
     // Emit that this scan stopped
-    setImmediate(function() {
-      this.emit('end');
-    }.bind(this));
+    setImmediate(() => this.emit('end'));
   }
 
   return this;

--- a/lib/lan_connection.js
+++ b/lib/lan_connection.js
@@ -80,36 +80,34 @@ LAN.Connection.prototype.exec = function(command, options, callback) {
 };
 
 LAN.Connection.prototype.end = function() {
-  var self = this;
-  return new Promise(function(resolve) {
+  return new Promise((resolve) => {
     // End the SSH connection
-    self.ssh.end();
+    this.ssh.end();
     resolve();
   });
 };
 
 LAN.Connection.prototype.open = function() {
-  var self = this;
-  return new Promise(function(resolve) {
+  return new Promise((resolve) => {
     // Create a new SSH client connection object
-    self.ssh = new ssh.Client();
+    this.ssh = new ssh.Client();
     // Open up an SSH Connection
-    self.ssh.on('ready', function() {
-      debug('Device ready:', self.host);
+    this.ssh.on('ready', () => {
+      debug('Device ready:', this.host);
       // Tessel allows connection
-      self.authorized = true;
+      this.authorized = true;
       // Resolve with connection
-      resolve(self);
+      resolve(this);
     });
-    self.ssh.on('error', function() {
-      debug('Device open error:', self.host);
+    this.ssh.on('error', () => {
+      debug('Device open error:', this.host);
       // Tessel does not allow connection
-      self.authorized = false;
+      this.authorized = false;
       // Reject with error
-      resolve(self);
-    }).connect(self.auth);
-    self.ssh.once('close', function() {
-      self.closed = true;
+      resolve(this);
+    }).connect(this.auth);
+    this.ssh.once('close', () => {
+      this.closed = true;
     });
   });
 };
@@ -155,35 +153,33 @@ LAN.Scanner = function() {
 util.inherits(LAN.Scanner, Emitter);
 
 LAN.Scanner.prototype.start = function() {
-  var self = this;
-
-  global.setImmediate(function startScanning() {
-    self.browser = mdns.createBrowser('_tessel._tcp');
+  setImmediate(() => {
+    this.browser = mdns.createBrowser('_tessel._tcp');
 
     // When the browser becomes ready
-    self.browser.once('ready', function() {
+    this.browser.once('ready', () => {
       try {
         // Start discovering Tessels
-        self.browser.discover();
+        this.browser.discover();
       } catch (err) {
-        self.emit('error', err);
+        this.emit('error', err);
       }
     });
 
     // When the browser finds a new device
-    self.browser.on('update', function(data) {
+    this.browser.on('update', (data) => {
       try {
         debug('Device found:', data.fullname);
         // Check if it's a Tessel
-        if (self.discovered.indexOf(data) > -1) {
+        if (this.discovered.indexOf(data) > -1) {
           return;
         }
 
         var connection = new LAN.Connection(data);
 
-        self.emit('connection', connection);
+        this.emit('connection', connection);
       } catch (err) {
-        self.emit('error', err);
+        this.emit('error', err);
       }
     });
   });

--- a/lib/tessel/access-point.js
+++ b/lib/tessel/access-point.js
@@ -28,7 +28,7 @@ function commitAndClose(tessel, status, resolve) {
     .then(reconnectWifi)
     .then(reconnectDnsmasq)
     .then(reconnectDhcp)
-    .then(logs.info.bind(this, status))
+    .then((str) => logs.info(status, str))
     .then(resolve);
 }
 
@@ -55,13 +55,12 @@ Tessel.prototype.disableAccessPoint = function() {
 };
 
 Tessel.prototype.createAccessPoint = function(opts) {
-  var self = this;
   var ssid = opts.ssid;
   var password = opts.pass;
   var security = opts.security;
   var status = 'Created Access Point successfully.';
 
-  var setupAccessPoint = function() {
+  var setupAccessPoint = () => {
     if (password && !security) {
       security = 'psk2';
     }
@@ -73,29 +72,29 @@ Tessel.prototype.createAccessPoint = function(opts) {
       status += ' SSID: ' + ssid;
     }
 
-    var setSSID = function() {
-      return self.simpleExec(commands.setAccessPointSSID(ssid));
+    var setSSID = () => {
+      return this.simpleExec(commands.setAccessPointSSID(ssid));
     };
 
-    var setAccessPointPassword = function() {
-      return self.simpleExec(commands.setAccessPointPassword(password));
+    var setAccessPointPassword = () => {
+      return this.simpleExec(commands.setAccessPointPassword(password));
     };
 
-    var setAccessPointSecurity = function() {
-      self.simpleExec(commands.setAccessPointSecurity(security));
+    var setAccessPointSecurity = () => {
+      this.simpleExec(commands.setAccessPointSecurity(security));
     };
 
-    var turnAccessPointOn = function() {
-      return self.simpleExec(commands.turnAccessPointOn());
+    var turnAccessPointOn = () => {
+      return this.simpleExec(commands.turnAccessPointOn());
     };
 
-    var commitAndClosePromise = function() {
-      return new Promise(function(resolve) {
-        commitAndClose(self, status, resolve);
+    var commitAndClosePromise = () => {
+      return new Promise((resolve) => {
+        commitAndClose(this, status, resolve);
       });
     };
 
-    var setup = function() {
+    var setup = () => {
       if (password) {
         return setSSID(ssid)
           .then(setAccessPointPassword)
@@ -111,31 +110,31 @@ Tessel.prototype.createAccessPoint = function(opts) {
       .then(commitAndClosePromise);
   };
 
-  return self.simpleExec(commands.getAccessPointSSID())
-    .then(function() {
+  return this.simpleExec(commands.getAccessPointSSID())
+    .then(() => {
       // When an AP exists, change the status to
       // reflect an "update" vs. "create":
       status = 'Updated Access Point successfully.';
       return setupAccessPoint();
     })
-    .catch(function() {
-      var setAccessPoint = function() {
-        return self.simpleExec(commands.setAccessPoint())
-          .then(self.simpleExec.bind(self, commands.setAccessPointDevice()))
-          .then(self.simpleExec.bind(self, commands.setAccessPointNetwork()))
-          .then(self.simpleExec.bind(self, commands.setAccessPointMode()));
+    .catch(() => {
+      var setAccessPoint = () => {
+        return this.simpleExec(commands.setAccessPoint())
+          .then(() => this.simpleExec(commands.setAccessPointDevice()))
+          .then(() => this.simpleExec(commands.setAccessPointNetwork()))
+          .then(() => this.simpleExec(commands.setAccessPointMode()));
       };
 
-      var setLanNetwork = function() {
-        return self.simpleExec(commands.setLanNetwork())
-          .then(self.simpleExec.bind(self, commands.setLanNetworkIfname()))
-          .then(self.simpleExec.bind(self, commands.setLanNetworkProto()))
-          .then(self.simpleExec.bind(self, commands.setLanNetworkIP()))
-          .then(self.simpleExec.bind(self, commands.setLanNetworkNetmask()));
+      var setLanNetwork = () => {
+        return this.simpleExec(commands.setLanNetwork())
+          .then(() => this.simpleExec(commands.setLanNetworkIfname()))
+          .then(() => this.simpleExec(commands.setLanNetworkProto()))
+          .then(() => this.simpleExec(commands.setLanNetworkIP()))
+          .then(() => this.simpleExec(commands.setLanNetworkNetmask()));
       };
 
-      var commitNetwork = function() {
-        return self.simpleExec(commands.commitNetwork());
+      var commitNetwork = () => {
+        return this.simpleExec(commands.commitNetwork());
       };
 
       return setAccessPoint()

--- a/lib/tessel/deploy.js
+++ b/lib/tessel/deploy.js
@@ -94,10 +94,9 @@ var binaryModulesUsed = new Map();
 */
 
 Tessel.prototype.memoryInfo = function() {
-  var self = this;
-  return new Promise(function(resolve, reject) {
-    return actions.execRemoteCommand(self, 'getMemoryInfo')
-      .then(function(response) {
+  return new Promise((resolve, reject) => {
+    return actions.execRemoteCommand(this, 'getMemoryInfo')
+      .then((response) => {
         if (!response || !response.length) {
           return reject('Could not read device memory information.');
         }
@@ -124,51 +123,50 @@ Tessel.prototype.memoryInfo = function() {
     param opts: unused so far
 */
 Tessel.prototype.deployScript = function(opts) {
-  var self = this;
   // Only an _explicit_ `true` will set push mode
   var isPush = opts.push === true;
 
-  return new Promise(function(resolve, reject) {
+  return new Promise((resolve, reject) => {
     // Stop running any existing scripts
-    return actions.execRemoteCommand(self, 'stopRunningScript')
-      .then(function() {
+    return actions.execRemoteCommand(this, 'stopRunningScript')
+      .then(() => {
         var prom;
 
         if (opts.single) {
           // Always be sure the appropriate dir is created
-          prom = actions.execRemoteCommand(self, 'createFolder', Tessel.REMOTE_RUN_PATH);
+          prom = actions.execRemoteCommand(this, 'createFolder', Tessel.REMOTE_RUN_PATH);
         } else {
           // Delete any code that was previously at this file path
-          prom = actions.execRemoteCommand(self, 'deleteFolder', Tessel.REMOTE_RUN_PATH);
+          prom = actions.execRemoteCommand(this, 'deleteFolder', Tessel.REMOTE_RUN_PATH);
           // Create the folder again
-          prom = prom.then(function() {
-            return actions.execRemoteCommand(self, 'createFolder', Tessel.REMOTE_RUN_PATH);
+          prom = prom.then(() => {
+            return actions.execRemoteCommand(this, 'createFolder', Tessel.REMOTE_RUN_PATH);
           });
 
           // If we are pushing code
           if (opts.push) {
             // Delete any old flash folder
-            prom = prom.then(function() {
-                return actions.execRemoteCommand(self, 'deleteFolder', Tessel.REMOTE_PUSH_PATH);
+            prom = prom.then(() => {
+                return actions.execRemoteCommand(this, 'deleteFolder', Tessel.REMOTE_PUSH_PATH);
               })
               // Create a new flash folder
-              .then(function() {
-                return actions.execRemoteCommand(self, 'createFolder', Tessel.REMOTE_PUSH_PATH);
+              .then(() => {
+                return actions.execRemoteCommand(this, 'createFolder', Tessel.REMOTE_PUSH_PATH);
               });
           }
         }
 
         // Bundle and send tarred code to T2
-        return prom.then(function() {
-            return actions.sendBundle(self, opts);
+        return prom.then(() => {
+            return actions.sendBundle(this, opts);
           })
-          .then(function(script) {
+          .then((script) => {
             if (isPush) {
               // Push the script into flash
-              return actions.pushScript(self, script, opts).then(resolve);
+              return actions.pushScript(this, script, opts).then(resolve);
             } else {
               // Push the code into ram
-              return actions.runScript(self, script, opts).then(resolve);
+              return actions.runScript(this, script, opts).then(resolve);
             }
           });
       })
@@ -177,26 +175,25 @@ Tessel.prototype.deployScript = function(opts) {
 };
 
 Tessel.prototype.restartScript = function(opts) {
-  var self = this;
   var isPush = opts.type === 'flash';
   var filepath = isPush ? Tessel.REMOTE_PUSH_PATH : Tessel.REMOTE_RUN_PATH;
 
-  return new Promise(function(resolve, reject) {
-    return self.simpleExec(commands.readFile(filepath + opts.entryPoint))
-      .then(function() {
+  return new Promise((resolve, reject) => {
+    return this.simpleExec(commands.readFile(filepath + opts.entryPoint))
+      .then(() => {
         if (isPush) {
           // Start the script from flash memory
-          return actions.startPushedScript(self, opts.entryPoint, opts)
+          return actions.startPushedScript(this, opts.entryPoint, opts)
             .then(resolve).catch(reject);
         } else {
           // Start the script in RAM
-          return actions.runScript(self, filepath, opts)
+          return actions.runScript(this, filepath, opts)
             .then(resolve).catch(reject);
         }
       })
-      .catch(function(error) {
+      .catch((error) => {
         if (error.message.indexOf('No such file or directory') !== -1) {
-          error = '"' + opts.entryPoint + '" not found on ' + self.name;
+          error = '"' + opts.entryPoint + '" not found on ' + this.name;
         }
 
         return reject(error);

--- a/lib/tessel/erase.js
+++ b/lib/tessel/erase.js
@@ -10,20 +10,18 @@ var logs = require('../logs');
 var Tessel = require('./tessel');
 
 Tessel.prototype.eraseScript = function() {
-  var self = this;
-
   logs.info('Erasing files from Flash...');
-  return self.simpleExec(commands.stopRunningScript())
-    .then(function stopped() {
-      return self.simpleExec(commands.disablePushedScript());
+  return this.simpleExec(commands.stopRunningScript())
+    .then(() => {
+      return this.simpleExec(commands.disablePushedScript());
     })
-    .then(function disabled() {
-      return self.simpleExec(commands.deleteFolder(Tessel.REMOTE_PUSH_PATH))
+    .then(() => {
+      return this.simpleExec(commands.deleteFolder(Tessel.REMOTE_PUSH_PATH))
         .then(function erased() {
           logs.info('Files erased.');
         });
     })
-    .catch(function(error) {
+    .catch((error) => {
       // If we get a notice that the command failed
       if (error.message.indexOf('Command failed') !== -1) {
         // Let the user know what went wrong

--- a/lib/tessel/name.js
+++ b/lib/tessel/name.js
@@ -20,30 +20,28 @@ Tessel.isValidName = function(value) {
 
 Tessel.prototype.getName = function() {
   return this.simpleExec(commands.getHostname())
-    .then(function nameFound(name) {
+    .then((name) => {
       // Remove any trailing newlines and set the internal variable
       this.name = name.replace(/^\s+|\s+$/g, '');
       // Return the name
       return this.name;
-    }.bind(this));
+    });
 };
 
 Tessel.prototype.setName = function(name) {
-  var self = this;
-
-  return new Promise(function(resolve, reject) {
+  return new Promise((resolve, reject) => {
     if (!Tessel.isValidName(name)) {
       return reject('Invalid name.');
     }
     // Write the new hostname to the device
-    return self.simpleExec(commands.setHostname(name))
-      .then(function hostnameSet() {
+    return this.simpleExec(commands.setHostname(name))
+      .then(() => {
         // Commit the new hostname
-        return self.simpleExec(commands.commitHostname());
+        return this.simpleExec(commands.commitHostname());
       })
-      .then(function hostnameCommitted() {
+      .then(() => {
         // Write the new name to the kernel hostname as well (so it reports the proper name in the terminal)
-        return self.connection.exec(commands.openStdinToFile('/proc/sys/kernel/hostname'), (err, remoteProc) => {
+        return this.connection.exec(commands.openStdinToFile('/proc/sys/kernel/hostname'), (err, remoteProc) => {
           if (err) {
             return reject(err);
           } else {
@@ -52,8 +50,8 @@ Tessel.prototype.setName = function(name) {
         });
       })
       // Reset MDNS so it advertises with the new name
-      .then(function kernelWritten() {
-        return self.resetMDNS()
+      .then(() => {
+        return this.resetMDNS()
           .then(resolve);
       })
       .catch(reject);
@@ -61,20 +59,19 @@ Tessel.prototype.setName = function(name) {
 };
 
 Tessel.prototype.rename = function(opts) {
-  var self = this;
-  return new Promise(function(resolve, reject) {
+  return new Promise((resolve, reject) => {
 
     // If we are resetting this name to default
     if (opts.reset) {
       // Get the mac address from the device
-      return self._getMACAddress()
-        .then(function(addr) {
+      return this._getMACAddress()
+        .then((addr) => {
 
           // Create the name with the default prefix
           var defaultName = defaultNamePrefix + addr;
 
           // Set the new name
-          return self.setName(defaultName)
+          return this.setName(defaultName)
             .then(function() {
               logs.info('Reset the name of the device to', defaultName);
               resolve();
@@ -86,8 +83,8 @@ Tessel.prototype.rename = function(opts) {
         return reject('Invalid name');
       }
 
-      self.getName()
-        .then(function(oldName) {
+      this.getName()
+        .then((oldName) => {
           // Don't set the new name if it's the same as the old name
           if (oldName === opts.newName) {
             logs.warn('Name of device is already', oldName);
@@ -95,7 +92,7 @@ Tessel.prototype.rename = function(opts) {
             return resolve();
           } else {
             // Set the name with the provided arg
-            return self.setName(opts.newName)
+            return this.setName(opts.newName)
               .then(function() {
                 logs.info('Changed name of device', oldName, 'to', opts.newName);
                 resolve();

--- a/lib/tessel/provision.js
+++ b/lib/tessel/provision.js
@@ -48,28 +48,20 @@ Tessel.isProvisioned = function() {
 };
 
 Tessel.prototype.provisionTessel = function() {
-  var self = this;
-  return new Promise(function(resolve, reject) {
-    if (self.connection.connectionType === 'USB') {
-      // Check if local .tessel file has keypair, if not, put it there
-      return actions.setupLocal(authKey)
-        .then(function() {
-          return actions.authTessel(self, authKey)
-            .then(function() {
-              resolve();
-            })
-            .catch(function(err) {
-              if (err instanceof AlreadyAuthenticatedError) {
-                logs.info(err.message);
-                resolve();
-              } else {
-                reject();
-              }
-            });
-        });
-    } else {
-      reject('Tessel must be connected with USB to use this command.');
-    }
+  if (this.connection.connectionType !== 'USB') {
+    return Promise.reject('Tessel must be connected with USB to use this command.');
+  }
+
+  // Check if local .tessel file has keypair, if not, put it there
+  return actions.setupLocal(authKey).then(() => {
+    return actions.authTessel(this, authKey)
+      .catch(function(err) {
+        if (err instanceof AlreadyAuthenticatedError) {
+          logs.info(err.message);
+        } else {
+          throw err;
+        }
+      });
   });
 };
 
@@ -106,15 +98,13 @@ actions.setupLocal = function(keyFile) {
       // Put SSH keys for Tessel in that folder
       // Set the permission to 0600 (decimal 384)
       // owner can read and write
+      var fileOptions = {
+        encoding: 'utf8',
+        mode: 384
+      };
       async.parallel([
-          fs.writeFile.bind(this, keyFile + '.pub', publicKey, {
-            encoding: 'utf8',
-            mode: 384
-          }),
-          fs.writeFile.bind(this, keyFile, privateKey, {
-            encoding: 'utf8',
-            mode: 384
-          }),
+          (cb) => fs.writeFile(keyFile + '.pub', publicKey, fileOptions, cb),
+          (cb) => fs.writeFile(keyFile, privateKey, fileOptions, cb),
         ],
         function(err) {
           if (err) {

--- a/lib/tessel/tessel.js
+++ b/lib/tessel/tessel.js
@@ -3,59 +3,57 @@
     param connection: the Connection object that represents the physical comm bus
 */
 function Tessel(connection) {
-  var self = this;
-
   if (connection === undefined) {
     throw new Error('Cannot create a Tessel with an undefined connection type');
   }
 
-  self.usbConnection = undefined;
-  self.lanConnection = undefined;
-  self.lanPrefer = false;
+  this.usbConnection = undefined;
+  this.lanConnection = undefined;
+  this.lanPrefer = false;
 
 
-  self.close = function() {
+  this.close = () => {
     // If this tessel has been closed already
-    if (self.closed) {
+    if (this.closed) {
       // Just resolve
       return Promise.resolve();
       // Otherwise
     } else {
       // Mark as having been closed
-      self.closed = true;
+      this.closed = true;
     }
 
     // Kill all of this Tessel's remote processes
-    return self.connection.end();
+    return this.connection.end();
   };
 
-  self.addConnection = function(connection) {
+  this.addConnection = (connection) => {
     // Set the connection var so we have an abstract interface to relay comms
     switch (connection.connectionType) {
       case 'USB':
         connection.authorized = true;
-        self.usbConnection = connection;
+        this.usbConnection = connection;
         break;
       case 'LAN':
-        self.lanConnection = connection;
+        this.lanConnection = connection;
         break;
       default:
         throw new Error('Invalid connection provided! Must be USB or LAN.');
     }
   };
 
-  self.setLANConnectionPreference = function(preferLan) {
-    self.lanPrefer = preferLan;
+  this.setLANConnectionPreference = (preferLan) => {
+    this.lanPrefer = preferLan;
   };
 
   // Add this physical connection to the Tessel
-  self.addConnection(connection);
+  this.addConnection(connection);
   // The human readable name of the device
-  self.name = undefined;
+  this.name = undefined;
   // The unique serial number of the device
-  self.serialNumber = undefined;
+  this.serialNumber = undefined;
   // Whether or not this connection has been ended
-  self.closed = false;
+  this.closed = false;
 }
 
 Object.defineProperty(Tessel.prototype, 'connection', {

--- a/lib/tessel/update.js
+++ b/lib/tessel/update.js
@@ -27,72 +27,61 @@ Tessel.prototype.fetchCurrentBuildInfo = function() {
 };
 
 Tessel.prototype.update = function(newImage) {
-  var self = this;
-  return new Promise(function(resolve, reject) {
-    if (!Buffer.isBuffer(newImage.openwrt) || !Buffer.isBuffer(newImage.firmware)) {
-      return reject('Invalid update binaries.');
-    } else {
-      return self.updateOpenWRT(newImage.openwrt)
-        .then(self.updateFirmware.bind(self, newImage.firmware))
-        .then(resolve, reject);
-    }
-  });
+  if (!Buffer.isBuffer(newImage.openwrt) || !Buffer.isBuffer(newImage.firmware)) {
+    return Promise.reject('Invalid update binaries.');
+  }
+
+  return this.updateOpenWRT(newImage.openwrt)
+    .then(() => this.updateFirmware(newImage.firmware));
 };
 
 Tessel.prototype.updateOpenWRT = function(image) {
-  var self = this;
-  return new Promise(function(resolve, reject) {
-    logs.info('Updating OpenWRT (1/2)');
+  logs.info('Updating OpenWRT (1/2)');
 
-    // Write the new image to a file in the /tmp dir
-    return self.connection.exec(commands.openStdinToFile(updatePath))
-      .then(function(remoteProc) {
-        // When we finish writing the image
-        remoteProc.once('close', function() {
-          // Begin the sysupgrade
-          logs.info('Starting OpenWRT update. Please do not remove power from Tessel.');
-          // The USBDaemon will cut out or the SSH command will close
-          self.connection.exec(commands.sysupgrade(updatePath))
-            .then(function(remoteProc) {
-
-              // This is the best way I've figured out to tell
-              // when the update is complete. I realize that tying completion
-              // of the CLI command to random text output by OpenWRT might not
-              // be the best thing...
-              remoteProc.stdout.on('data', function(d) {
-                if (d.toString().indexOf('Upgrade completed') !== -1) {
-                  resolve();
-                  return;
-                }
-              });
-            });
-        });
+  // Write the new image to a file in the /tmp dir
+  return this.connection.exec(commands.openStdinToFile(updatePath))
+    .then((remoteProc) => {
+      return new Promise(function(resolve) {
         logs.info('Transferring image of size', (image.length / 1e6).toFixed(2), 'MB');
+        // When we finish writing the image
+        remoteProc.once('close', resolve);
         // Write the image
         remoteProc.stdin.end(image);
-      })
-      .catch(reject);
-  });
+      });
+    })
+    .then(() => {
+      // Begin the sysupgrade
+      logs.info('Starting OpenWRT update. Please do not remove power from Tessel.');
+      // The USBDaemon will cut out or the SSH command will close
+      return this.connection.exec(commands.sysupgrade(updatePath));
+    })
+    .then((remoteProc) => {
+      // This is the best way I've figured out to tell
+      // when the update is complete. I realize that tying completion
+      // of the CLI command to random text output by OpenWRT might not
+      // be the best thing...
+      return new Promise(function(resolve) {
+        remoteProc.stdout.on('data', function(d) {
+          if (d.toString().includes('Upgrade completed')) {
+            resolve();
+          }
+        });
+      });
+    });
 };
 
 Tessel.prototype.updateFirmware = function(image) {
-  var self = this;
   logs.info('Updating firwmare (2/2)');
-  return new Promise(function(resolve, reject) {
-    // This must be USB connection
+  // This must be USB connection
 
-    var connection = self.usbConnection;
+  var connection = this.usbConnection;
 
-    if (!connection) {
-      return reject('Must have Tessel connected over USB to complete update. Aborting update.');
-    }
+  if (!connection) {
+    return Promise.reject('Must have Tessel connected over USB to complete update. Aborting update.');
+  }
 
-    return connection.enterBootloader()
-      .then(function executeFlash(dfu) {
-        return self.writeFlash(dfu, image)
-          .then(resolve, reject);
-      });
-  });
+  return connection.enterBootloader()
+    .then((dfu) => this.writeFlash(dfu, image));
 };
 
 Tessel.prototype.writeFlash = function(dfu, image) {

--- a/lib/usb/usb_daemon.js
+++ b/lib/usb/usb_daemon.js
@@ -11,7 +11,6 @@ var USBProcess = require('./usb_process');
 var MAX_PROCESS_ID = 255;
 
 function USBDaemon() {
-  var self = this;
   // Make sure we only have a singleton instance
   if (USBDaemon.prototype._singletonInstance) {
     return USBDaemon.prototype._singletonInstance;
@@ -29,42 +28,43 @@ function USBDaemon() {
   out packets. The daemon will interpret those parsed
   packets to create, destroy, and modify processes
   */
-  this.register = function(connection) {
+  this.register = (connection) => {
     // Create a connection entry for the Daemon table
     // Includes data parser and processes hash
     var entry = new ConnectionEntry();
 
     // Set the entry in the table
-    self.entries[connection.serialNumber] = entry;
+    this.entries[connection.serialNumber] = entry;
 
     // Pass off all data from this USB connection to the protocol parser
     connection.pipe(entry.parser);
 
     // Set up listeners for the various parser events
-    self._startListening(entry);
+    this._startListening(entry);
   };
 
   /* Deregister a connection with the daemon. This will
   close all existing connections locally and remotely.
   */
-  this.deregister = function(connection, callback) {
+  this.deregister = (connection, callback) => {
     // Find the Daemon table entry for this connection
-    var entry = self.getEntryForConnection(connection);
+    var entry = this.getEntryForConnection(connection);
     // Get an array of process ids
     var pids = Object.keys(entry.processes);
     // Iterate through the process ids
-    async.eachSeries(pids, function(pid, cb) {
+    async.eachSeries(pids, (pid, cb) => {
         // Access the remot process
         var proc = entry.processes[pid];
         // If it exists
         if (proc) {
           // Close it
-          self.closeProcess(entry, proc, cb);
+          this.closeProcess(entry, proc, cb);
         }
+        // FIXME: If proc is false, the `cb` callback will never get called!
       },
-      function(err) {
+      (err) => {
         // Remove this entry from the table
-        delete self.entries[entry];
+        delete this.entries[entry];
         // Call the callback
         if (typeof callback === 'function') {
           callback(err);
@@ -73,9 +73,9 @@ function USBDaemon() {
   };
 
   /* Start up a new remote process on Tessel */
-  this.openProcess = function(connection, callback) {
+  this.openProcess = (connection, callback) => {
     // Grab the corresponding entry for this connection
-    var entry = self.getEntryForConnection(connection);
+    var entry = this.getEntryForConnection(connection);
     // If it doesn't exist, return an error
     if (!entry) {
       return callback && callback(new Error('This USB Connection was never registered with the daemon...'));
@@ -116,7 +116,7 @@ function USBDaemon() {
 
   /* Internal method to listen to parser events and disburse
   them to the process as necessary */
-  this._startListening = function(entry) {
+  this._startListening = (entry) => {
     // When we get a command that a remote process has exited
     entry.parser.on('EXIT-STATUS', function(packet) {
       // Grab the process that died remotely
@@ -218,15 +218,15 @@ function USBDaemon() {
   };
 
   /* Internal method to retrieve process details for a given connection */
-  this.getEntryForConnection = function(connection) {
-    return self.entries[connection.serialNumber];
+  this.getEntryForConnection = (connection) => {
+    return this.entries[connection.serialNumber];
   };
 
   /* Internal method to retrieve the next available process id */
-  this._nextID = function() {
+  this._nextID = () => {
 
     // Get all currently used ids, what's the first available?
-    var usedIDs = self.getIDsInUse();
+    var usedIDs = this.getIDsInUse();
     var prev;
     var cur;
 
@@ -261,10 +261,10 @@ function USBDaemon() {
     }
   };
 
-  this.getIDsInUse = function() {
+  this.getIDsInUse = () => {
     var usedIDs = [];
-    for (var i in self.entries) {
-      var entry = self.entries[i];
+    for (var i in this.entries) {
+      var entry = this.entries[i];
       for (var j in entry.processes) {
         usedIDs.push(entry.processes[j].id);
       }

--- a/lib/usb/usb_process.js
+++ b/lib/usb/usb_process.js
@@ -20,7 +20,6 @@ var MAX_BUFFER_SIZE = 32768;
 
 // A process is running remotely on the Tessel and data is piped in over USB
 function USBProcess(id, daemon) {
-  var self = this;
   // The numerical identifer for this process
   this.id = id;
 
@@ -39,113 +38,113 @@ function USBProcess(id, daemon) {
   this.exitedWithError = false;
 
   // 4 remote process streams
-  this.control = new RemoteWritableStream(self, daemon, protocol.controlWrite, protocol.controlClose);
-  this.stdin = new RemoteWritableStream(self, daemon, protocol.stdinWrite, protocol.stdinClose);
-  this.stdout = new RemoteReadableStream(self, daemon, protocol.stdoutAck);
-  this.stderr = new RemoteReadableStream(self, daemon, protocol.stderrAck);
+  this.control = new RemoteWritableStream(this, daemon, protocol.controlWrite, protocol.controlClose);
+  this.stdin = new RemoteWritableStream(this, daemon, protocol.stdinWrite, protocol.stdinClose);
+  this.stdout = new RemoteReadableStream(this, daemon, protocol.stdoutAck);
+  this.stderr = new RemoteReadableStream(this, daemon, protocol.stderrAck);
 
   // Once the process is killed
-  self.once('death', function(data) {
+  this.once('death', (data) => {
     // This process is no longer running
-    self.active = false;
+    this.active = false;
     // Close the input streams because the remote proc can't handle data
-    self.control.end();
-    self.stdin.end();
+    this.control.end();
+    this.stdin.end();
 
     // Close the process
-    self.closeProcessIfReady();
+    this.closeProcessIfReady();
 
     // Check for a non-zero exit code
     var exitCode = parseInt(data.arg);
-    debug('death for', self.commandString, exitCode);
-    if (exitCode !== 0 && !self.forceKill) {
-      self.exitedWithError = true;
+    debug('death for', this.commandString, exitCode);
+    if (exitCode !== 0 && !this.forceKill) {
+      this.exitedWithError = true;
     }
   });
 
   // Tell the USBDaemon to close the remote process
-  self.close = function() {
+  this.close = () => {
     // Write the close command
-    daemon.write(protocol.closeProcess(self.id));
+    daemon.write(protocol.closeProcess(this.id));
 
     // Mark this process as closed
-    self.closed = true;
+    this.closed = true;
   };
 
   // Send a signal to the remote process
-  self.kill = function(signal) {
+  this.kill = (signal) => {
     // Mark our boolean
-    self.forceKill = true;
+    this.forceKill = true;
     // Write the signal command
-    daemon.write(protocol.killProcess(self.id, signal));
+    daemon.write(protocol.killProcess(this.id, signal));
   };
 
   // Checks if this process is ready to be closed
   // and closes it if it can
-  self.closeProcessIfReady = function() {
+  this.closeProcessIfReady = () => {
     // If this process hasn't been closed before
     // and all of the streams are closed
-    if (!self.active && !self.closed && self.stdout.closed && self.stderr.closed) {
+    if (!this.active && !this.closed && this.stdout.closed && this.stderr.closed) {
       // Close this process
-      self.close();
+      this.close();
     }
   };
 
   // When any of the streams complete, check if the process is ready to close
-  self.stdout.once('end', self.closeProcessIfReady);
-  self.stderr.once('end', self.closeProcessIfReady);
+  this.stdout.once('end', () => this.closeProcessIfReady());
+  this.stderr.once('end', () => this.closeProcessIfReady());
 
   // This function is primarily intended for compatibility with the ssh2 stream API
-  self.stdout.signal = function(signalToSend) {
+  this.stdout.signal = (signalToSend) => {
     switch (signalToSend) {
       case 'KILL':
-        self.kill(9);
+        this.kill(9);
         break;
       case 'SIGINT':
-        self.kill(2);
+        this.kill(2);
+        break;
     }
   };
 
   // Tell the remote daemon that this process was created
-  daemon.write(protocol.newProcess(self.id));
+  daemon.write(protocol.newProcess(this.id));
   // Tell the remote daemon that we can start receiving outbound data
-  self.stdout.ack(MAX_BUFFER_SIZE);
-  self.stderr.ack(MAX_BUFFER_SIZE);
+  this.stdout.ack(MAX_BUFFER_SIZE);
+  this.stderr.ack(MAX_BUFFER_SIZE);
 }
 
 util.inherits(USBProcess, EventEmitter);
 
 // A wrapper on the Node Writable Stream to encapsulate stdin & control stream functionality
 function RemoteWritableStream(process, daemon, writeHeaderFunc, closeHeaderFunc) {
-  var self = this;
   // Inherit from Writable Streams
-  stream.Writable.call(self);
+  stream.Writable.call(this);
   // The id of the process that this is a stream of
-  self.process = process;
+  this.process = process;
   // The daemon to write data to
-  self.daemon = daemon;
+  this.daemon = daemon;
   // The amount of credit allocated to the stream (backpressure)
-  self.credit = 0;
+  this.credit = 0;
   // An array of backpressure entries
-  self.backPressure = new Array(0);
+  this.backPressure = new Array(0);
   // A flag indicating whether this stream has passed EOF
-  self.closed = false;
+  this.closed = false;
 
   // The function to generate the header necessary for a write
-  self.writeHeaderFunc = writeHeaderFunc;
+  this.writeHeaderFunc = writeHeaderFunc;
   // The function to generate the header necessary to close the stream
-  self.closeHeaderFunc = closeHeaderFunc;
+  this.closeHeaderFunc = closeHeaderFunc;
   // When the drain event is called, continue draining back pressured packets
-  self.on('drain', self._drainBackPressure);
+  this.on('drain', () => this._drainBackPressure());
   // When the stream has finished
-  self.once('finish', function closeRemote() {
+  this.once('finish', () => {
     // If the parent process is not already closed
-    if (!self.process.closed) {
+    if (!this.process.closed) {
       // Tell the remote daemon that we are done
-      self.daemon.write(closeHeaderFunc(self.process.id));
+      this.daemon.write(closeHeaderFunc(this.process.id));
     }
     // Mark the flag for this stream
-    self.closed = true;
+    this.closed = true;
   });
 }
 
@@ -191,42 +190,41 @@ RemoteWritableStream.prototype.ack = function(data, dataLength) {
 // packets are larger than the maximum USB packet size and that this stream
 // doesn't write more data to the remote process than it can handle
 RemoteWritableStream.prototype._drainBackPressure = function() {
-  var self = this;
   // If we can write data to the remote pipe and we have data to write
-  while (self.credit && self.backPressure.length) {
+  while (this.credit && this.backPressure.length) {
     // Get the first entry
-    var entry = self.backPressure[0];
+    var entry = this.backPressure[0];
     // Set the data to write to the daemon
     var chunk = entry.buffer;
 
     // If we are attempting to write more bytes than the socket can handle
-    if (chunk.length > self.credit) {
+    if (chunk.length > this.credit) {
       // Slice the chunk that will be sent
-      chunk = chunk.slice(0, self.credit);
+      chunk = chunk.slice(0, this.credit);
     }
 
     // Cut that off the front of the remaining bytes in the entry
     entry.buffer = entry.buffer.slice(chunk.length);
 
     // Split the chunk into smaller packets
-    var indices = self._packetize(MAX_DATA_PACKET_SIZE, chunk);
+    var indices = this._packetize(MAX_DATA_PACKET_SIZE, chunk);
 
     // For each packet
-    indices.forEach(function(index) {
+    indices.forEach((index) => {
       // Slice out the data packet
       var buffer = chunk.slice(index.start, index.end);
       // Create a header for the write
-      var header = self.writeHeaderFunc(self.process.id, buffer.length);
+      var header = this.writeHeaderFunc(this.process.id, buffer.length);
       // Compact our header and data into one packet
       var compact_buffer = Buffer.concat([header, buffer]);
       // Send over the data to the control stream
-      self.daemon.write(compact_buffer);
+      this.daemon.write(compact_buffer);
     });
 
     // If we sent all of the remaining bytes of this write
     if (entry.buffer.length === 0) {
       // Remove it from back pressure
-      self.backPressure.shift();
+      this.backPressure.shift();
       // Call the callback if provided
       if (typeof entry.callback === 'function') {
         entry.callback();
@@ -265,26 +263,25 @@ RemoteWritableStream.prototype._packetize = function(chunkSizes, inputBuffer) {
 
 // A wrapper on the Node Readable Stream to encapsulate stdout & stderr stream functionality
 function RemoteReadableStream(process, daemon, ackHeaderFunc) {
-  var self = this;
   // Inherit from Readable Streams
-  stream.Readable.call(self);
+  stream.Readable.call(this);
   // The id of the process of this stream
-  self.process = process;
+  this.process = process;
   // The daemon to write data to
-  self.daemon = daemon;
+  this.daemon = daemon;
   // The function we use to generate acknowledgement packets
-  self.ackHeaderFunc = ackHeaderFunc;
+  this.ackHeaderFunc = ackHeaderFunc;
   // The amount of backpressure credit on this stream
-  self.credit = 0;
+  this.credit = 0;
   // A flag indicating whether this stream was closed
-  self.closed = false;
+  this.closed = false;
 
   // This puts the stream into 'flowing mode'
   // so that the stream emits ('end') events without 'data' listeners
-  self.resume();
+  this.resume();
 
   // When we receive data from the daemon, we handle it
-  self.on('incoming', self.handleIncoming);
+  this.on('incoming', (data) => this.handleIncoming(data));
 }
 
 util.inherits(RemoteReadableStream, stream.Readable);

--- a/lib/usb_connection.js
+++ b/lib/usb_connection.js
@@ -74,7 +74,7 @@ USB.Connection.prototype.exec = function(command, options, callback) {
       proc.control.end(command);
 
       // Once the command has been written, call the callback with the resulting process
-      proc.control.once('finish', callback.bind(this, null, proc));
+      proc.control.once('finish', () => callback(null, proc));
     }
   });
 };
@@ -95,72 +95,76 @@ USB.Connection.prototype._read = function() {
 };
 
 USB.Connection.prototype._receiveMessages = function() {
-  var self = this;
   // Default transfer size
   var transferSize = 4096;
   // Start polling
-  self.epIn.startPoll(2, transferSize);
+  this.epIn.startPoll(2, transferSize);
   // When we get data, push it into the stream
-  self.epIn.on('data', self.push.bind(self));
+  this.epIn.on('data', (data) => this.push(data));
 };
 
 USB.Connection.prototype.open = function() {
-  var self = this;
-  return new Promise(function(resolve, reject) {
-    // Try to open connection
-    try {
-      self.device.open();
-    } catch (e) {
-      if (e.message === 'LIBUSB_ERROR_ACCESS' && process.platform === 'linux') {
-        logs.err('Please run `sudo t2 install-drivers` to fix device permissions.\n(Error: could not open USB device.)');
+  // Try to open connection
+  try {
+    this.device.open();
+  } catch (e) {
+    if (e.message === 'LIBUSB_ERROR_ACCESS' && process.platform === 'linux') {
+      logs.err('Please run `sudo t2 install-drivers` to fix device permissions.\n(Error: could not open USB device.)');
+    }
+    // Reject if error
+    return Promise.reject(e);
+  }
+
+  // Try to initialize interface
+  this.intf = this.device.interface(0);
+  try {
+    this.intf.claim();
+  } catch (e) {
+    // Reject if error
+    return Promise.reject(e);
+  }
+
+  // Set interface settings
+  return this.setAltSetting()
+    .then(() => {
+      this.epIn = this.intf.endpoints[0];
+      this.epOut = this.intf.endpoints[1];
+      if (!this.epIn || !this.epOut) {
+        return Promise.reject(new Error('Device endpoints were not able to be loaded'));
       }
-      // Reject if error
-      return reject(e, self);
-    }
 
-    // Try to initialize interface
-    self.intf = self.device.interface(0);
-    try {
-      self.intf.claim();
-    } catch (e) {
-      // Reject if error
-      return reject(e, self);
-    }
-    // Set interface settings
-    return self.setAltSetting()
-      .then(() => {
-        self.epIn = self.intf.endpoints[0];
-        self.epOut = self.intf.endpoints[1];
-        if (!self.epIn || !self.epOut) {
-          return reject(new Error('Device endpoints were not able to be loaded'), self);
-        }
-
-        // Map desciptions
-        self.device.getStringDescriptor(self.device.deviceDescriptor.iSerialNumber, function(error, data) {
-          if (error) {
-            return reject(error, self);
+      // Map desciptions
+      return new Promise((resolve, reject) => {
+        this.device.getStringDescriptor(this.device.deviceDescriptor.iSerialNumber, function(err, data) {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(data);
           }
-
-          self.serialNumber = data;
-          // Register this connection with daemon (keeps track of active remote processes)
-          Daemon.register(self);
-
-          // If the USB Pipe isn't enabled on the other end (ie it is booting)
-          self.epIn.on('error', function(err) {
-            // Close the device resources
-            self._close();
-            // Catch the error and return if we haven't already
-            return reject(err);
-          });
-
-          // Start receiving messages
-          self._receiveMessages();
-          // If all is well, resolve the promise with the valid connection
-          return resolve(self);
         });
-      })
-      .catch(reject);
-  });
+      });
+    })
+    .then((data) => {
+      this.serialNumber = data;
+      // Register this connection with daemon (keeps track of active remote processes)
+      Daemon.register(this);
+
+      return new Promise((resolve, reject) => {
+        // If the USB Pipe isn't enabled on the other end (ie it is booting)
+        this.epIn.on('error', (err) => {
+          // Close the device resources
+          this._close();
+          // Catch the error and return if we haven't already
+          return reject(err);
+        });
+
+        // Start receiving messages
+        this._receiveMessages();
+
+        // If all is well, resolve the promise with the valid connection
+        resolve(this);
+      });
+    });
 };
 
 USB.Connection.prototype.setAltSetting = function() {
@@ -184,12 +188,11 @@ USB.Connection.prototype.setAltSetting = function() {
 };
 
 USB.Connection.prototype.end = function() {
-  var self = this;
-  return new Promise(function(resolve, reject) {
+  return new Promise((resolve, reject) => {
     // Tell the USB daemon to end all processes active
     // on account of this connection
-    Daemon.deregister(self, function(err) {
-      self._close();
+    Daemon.deregister(this, (err) => {
+      this._close();
       if (err) {
         reject(err);
       } else {
@@ -200,74 +203,90 @@ USB.Connection.prototype.end = function() {
 };
 
 USB.Connection.prototype._close = function(callback) {
-  var self = this;
-
-  if (self.closed) {
+  if (this.closed) {
     return callback && callback();
   }
 
-  self.closed = true;
-  self.epIn.stopPoll(function() {
-    self.intf.release(true, function attempt() {
+  this.closed = true;
+  this.epIn.stopPoll(() => {
+    var attempt = () => {
       try {
-        self.device.close();
+        this.device.close();
       } catch (e) {
         setTimeout(attempt, 100);
+        // FIXME: I really think that there should be an return here, else the
+        //        callback will get called for every attempt!
       }
       if (typeof callback === 'function') {
         callback();
       }
-    });
+    };
+
+    this.intf.release(true, attempt);
   });
 };
 
 // Returns a device in DFU mode
 USB.Connection.prototype.enterBootloader = function() {
-  var self = this;
-  return new Promise(function(resolve, reject) {
-    // Stop trying to read this endpoint
-    self.epIn.stopPoll(function() {
-      // Tell the Daemon to kill any remote processes associated with this connection
-      Daemon.deregister(self, function startBootloader(err) {
-        if (err) {
-          return reject(err);
-        }
-        // Tell the mcu to go into bootloader mode
-        self.device.controlTransfer(VENDOR_REQ_OUT, REQ_BOOT, 0, 0, new Buffer(0), function(err) {
+  return Promise.resolve()
+    .then(() => {
+      return new Promise((resolve) => {
+        this.epIn.stopPoll(resolve);
+      });
+    })
+    .then(() => {
+      return new Promise((resolve, reject) => {
+        Daemon.deregister(this, function(err) {
           if (err) {
             reject(err);
           } else {
-            // Wait for it to tenter the mode
-            return self._waitUntilInBootloader()
-              .then(function createDFU(device) {
-                // Find the DFU interface
-                var dfu = new DFU(device, 0);
-                // Claim the USB device
-                dfu.claim(function(err) {
-                  if (err) {
-                    return reject(err);
-                  } else {
-                    // Return the DFU device
-                    resolve(dfu);
-                  }
-                });
-              }, reject);
+            resolve();
+          }
+        });
+      });
+    })
+    .then(() => {
+      // Tell the mcu to go into bootloader mode
+      return new Promise((resolve, reject) => {
+        this.device.controlTransfer(VENDOR_REQ_OUT, REQ_BOOT, 0, 0, new Buffer(0), function(err) {
+          if (err) {
+            reject(err);
+          } else {
+            resolve();
+          }
+        });
+      });
+    })
+    .then(() => {
+      // Wait for it to tenter the mode
+      return this._waitUntilInBootloader();
+    })
+    .then((device) => {
+      return new Promise(function(resolve, reject) {
+        // Find the DFU interface
+        var dfu = new DFU(device, 0);
+
+        // Claim the USB device
+        dfu.claim(function(err) {
+          if (err) {
+            return reject(err);
+          } else {
+            // Return the DFU device
+            resolve(dfu);
           }
         });
       });
     });
-  });
 };
 
 // Waits until it finds a USB device that is a Tessel with a bootloader
 // and returns that USB device
 USB.Connection.prototype._waitUntilInBootloader = function() {
-  var self = this;
   var retryCount = 10;
   var retryTimeout = 250;
-  return new Promise(function(resolve, reject) {
-    function retry() {
-      return self._findBootedDeviceBySerialNumber(self.device.deviceDescriptor.iSerialNumber)
+  return new Promise((resolve, reject) => {
+    var retry = () => {
+      this._findBootedDeviceBySerialNumber(this.device.deviceDescriptor.iSerialNumber)
         // A  Tessel was found!
         .then(function(bootedDevice) {
           // Make sure it's in the proper mode
@@ -282,7 +301,7 @@ USB.Connection.prototype._waitUntilInBootloader = function() {
             reject(err);
           }
         });
-    }
+    };
 
     setTimeout(retry, retryTimeout);
   });
@@ -337,7 +356,7 @@ function startScan() {
   if (scanner === undefined) {
     scanner = new USB.Scanner();
 
-    setImmediate(scanner.start.bind(scanner));
+    setImmediate(() => scanner.start());
   }
 
   return scanner;
@@ -357,19 +376,18 @@ USB.Scanner = function() {};
 util.inherits(USB.Scanner, Emitter);
 
 USB.Scanner.prototype.start = function() {
-  var self = this;
+  var deviceInspector = (device) => {
+    if ((device.deviceDescriptor.idVendor === TESSEL_VID) && (device.deviceDescriptor.idProduct === TESSEL_PID)) {
+      debug('Device found.');
+      var connection = new USB.Connection(device);
+      this.emit('connection', connection);
+    }
+  };
+
   if (haveusb) {
     usb.getDeviceList().forEach(deviceInspector);
 
     usb.on('attach', deviceInspector);
-  }
-
-  function deviceInspector(device) {
-    if ((device.deviceDescriptor.idVendor === TESSEL_VID) && (device.deviceDescriptor.idProduct === TESSEL_PID)) {
-      debug('Device found.');
-      var connection = new USB.Connection(device);
-      self.emit('connection', connection);
-    }
   }
 };
 


### PR DESCRIPTION
This removes the use of `self` and `bind`, and replaces it with the awesome fat arrow (`=>`).

I have also updated some of the functions where there was a lot of unnecessary wrapping with `new Promise`, but not all of the places. I wanted this pull request to focus on only `self` and `bind`.

I have also marked three `FIXME`s in the code, again it didn't seem right to fix it in this pull request; and in some cases I wanted the original author to maybe clarify the intent. I think we should merge with them in, and then fix them later.

I would appreciate a fast pull here since this will probably need manual rebasing as soon as anything else lands :)

ping @johnnyman727, I saw that you where online, would you like to review? Thanks :+1: 

edit: also, I need to go to bed right away, sorry about that, I'll check this first thing in the morning!

edit2: note to self to update this comment when landing, https://github.com/tessel/t2-cli/issues/470#issuecomment-160171309