### PR TITLE
t2 run/push: explicit compression

### DIFF
--- a/lib/tessel/deploy.js
+++ b/lib/tessel/deploy.js
@@ -3,6 +3,7 @@ var path = require('path');
 var zlib = require('zlib');
 
 // Third Party Dependencies
+var acorn = require('acorn');
 var bindings = require('bindings');
 var tags = require('common-tags');
 var fs = require('fs-extra');
@@ -832,30 +833,72 @@ actions.project = function(options) {
 actions.compress = function(source) {
   source = typeof source === 'string' ? source : source.toString();
 
-  var content = uglify.parse(source, actions.compress.options);
+  var mangle = {
+    sort: true,
+    toplevel: true
+  };
 
-  content.figure_out_scope();
-  content = content.transform(uglify.Compressor({
-    warnings: false
+  var ast;
+
+  try {
+    // Attempt to use acorn, this will provide
+    // better support for modern Ecma-262
+    // (but unfortunately, not perfect)
+    ast = uglify.AST_Node.from_mozilla_ast(
+      acorn.parse(source, {
+        allowImportExportEverywhere: true,
+        allowReturnOutsideFunction: true,
+        ecmaVersion: 7,
+      })
+    );
+    // However, if it fails, also try uglify...
+  } catch (error) {
+
+    // If uglify lands _better_ ES6 support sooner,
+    // this will handle that
+    ast = uglify.parse(source, {
+      bare_returns: true,
+      fromString: true,
+      warnings: false,
+    });
+    // Otherwise the whole thing is a failure.
+
+    throw new Error(error);
+  }
+
+  ast.figure_out_scope();
+  ast = ast.transform(uglify.Compressor({
+    // ------
+    booleans: true,
+    cascade: true,
+    conditionals: true,
+    comparisons: true,
+    evaluate: true,
+    hoist_funs: true,
+    hoist_vars: true,
+    if_return: true,
+    join_vars: true,
+    loops: true,
+    properties: true,
+    screw_ie8: true,
+    sequences: true,
+    unsafe: true,
+    // ------
+    keep_fargs: false,
+    keep_fnames: false,
+    warnings: false,
+    drop_console: false,
   }));
 
-  var code = uglify.OutputStream();
-  content.print(code);
+  ast.figure_out_scope(mangle);
+  ast.compute_char_frequency(mangle);
+  ast.mangle_names(mangle);
 
-  return code.toString();
-};
+  var stream = uglify.OutputStream();
 
-actions.compress.options = {
-  fromString: true,
-  bare_returns: true,
-  spidermonkey: false,
-  outSourceMap: null,
-  sourceRoot: null,
-  inSourceMap: null,
-  warnings: false,
-  mangle: {},
-  output: null,
-  compress: {}
+  ast.print(stream);
+
+  return stream.toString();
 };
 
 if (global.IS_TEST_ENV) {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "sinon": "^1.14.1"
   },
   "dependencies": {
+    "acorn": "^3.0.2",
     "async": "^1.4.2",
     "bindings": "^1.2.1",
     "browserify": "^11.2.0",

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -29,6 +29,7 @@
     "Emitter": true,
     "Duplex": true,
     "_": true,
+    "acorn": true,
     "async": true,
     "bindings": true,
     "Project": true,

--- a/test/common/bootstrap.js
+++ b/test/common/bootstrap.js
@@ -12,6 +12,7 @@ global.Duplex = stream.Duplex;
 
 
 // Third Party Dependencies
+global.acorn = require('acorn');
 global.async = require('async');
 global.bindings = require('bindings');
 global.fs = require('fs-extra');


### PR DESCRIPTION
- Attempt to use acorn.parse first
- Fallback to uglify.parse
- explicitly define all parser, compressor, and mangling options
  - improves compression