### PR TITLE
Adds output silencing option

### DIFF
--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -42,6 +42,12 @@ function makeCommand(commandName) {
       flag: true,
       default: false,
       help: 'Prefer a LAN connection when available, otherwise use USB.'
+    })
+    .option('output', {
+      default: true,
+      choices: [true, false],
+      abbr: 'o',
+      help: 'Enable or disable writing command output to stdout/stderr. Useful for CLI API consumers.'
     });
 }
 

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -24,22 +24,40 @@ var responses = {
 
 // Wrapper function for Tessel.list to set SSH key path
 controller.list = function(opts) {
-  return controller.keyHelper(opts, Tessel.list);
+  return controller.defaultHelpers(opts, Tessel.list);
 };
 
 // Wrapper function for Tessel.get to set SSH key path
 controller.get = function(opts) {
-  return controller.keyHelper(opts, Tessel.get);
+  return controller.defaultHelpers(opts, Tessel.get);
 };
 
-controller.keyHelper = function(opts, next) {
+// Calls any helpers for the get and list codepaths
+controller.defaultHelpers = function(opts, next) {
+  // First disable output if necessary
+  return controller.outputHelper(opts)
+    // Then make sure our SSH Key path is updated
+    .then(() => controller.keyHelper(opts))
+    // before continuing to the next function
+    .then(() => next(opts));
+};
+
+controller.keyHelper = function(opts) {
   var keyPromise = Promise.resolve();
   if (opts.key) {
     // Set the default SSH key path before we search
     keyPromise = provision.setDefaultKey(opts.key);
   }
+  return keyPromise;
+};
 
-  return keyPromise.then(() => next(opts));
+controller.outputHelper = function(opts) {
+  // If the user doesn't want output
+  if (opts.output === false) {
+    // Turn off the logs
+    logs.disable();
+  }
+  return Promise.resolve();
 };
 
 controller.setupLocal = function(opts) {

--- a/lib/logs.js
+++ b/lib/logs.js
@@ -5,25 +5,43 @@ var util = require('util');
 var colors = require('colors');
 
 // Internal
-// ...
+var disabled = false;
+
+function disable() {
+  disabled = true;
+}
+
+function enable() {
+  disabled = false;
+}
 
 function warn() {
-  console.error(colors.yellow('WARN'), util.format.apply(util, arguments));
+  if (!disabled) {
+    console.error(colors.yellow('WARN'), util.format.apply(util, arguments));
+  }
 }
 
 function err() {
-  console.error(colors.red('ERR!'), util.format.apply(util, arguments));
+  if (!disabled) {
+    console.error(colors.red('ERR!'), util.format.apply(util, arguments));
+  }
 }
 
 function info() {
-  console.error(colors.grey('INFO'), util.format.apply(util, arguments));
+  if (!disabled) {
+    console.error(colors.grey('INFO'), util.format.apply(util, arguments));
+  }
 }
 
 function basic() {
-  console.log(util.format.apply(util, arguments));
+  if (!disabled) {
+    console.log(util.format.apply(util, arguments));
+  }
 }
 
 exports.warn = warn;
 exports.err = err;
 exports.info = info;
 exports.basic = basic;
+exports.disable = disable;
+exports.enable = enable;


### PR DESCRIPTION
This is useful for consumers of the API exposed by the CLI (in an upcoming PR) because if you're using it programmatically, you likely don't want to clutter your output with all the things the CLI reports.

Part of the disintegration of #555 and needed for the test rig.