### PR TITLE
Jon fix wifi

### DIFF
--- a/lib/tessel/wifi.js
+++ b/lib/tessel/wifi.js
@@ -178,7 +178,6 @@ Tessel.prototype.setWiFiState = function(enable) {
             }
           });
         } else {
-          this.connection.end();
           logState();
           resolve();
         }

--- a/lib/tessel/wifi.js
+++ b/lib/tessel/wifi.js
@@ -158,20 +158,13 @@ Tessel.prototype.setWiFiState = function(enable) {
             // End the connection
             remoteProcess.close();
           }, Tessel.__wifiConnectionTimeout);
-          remoteProcess.stdout.once('data', function(data) {
+          remoteProcess.stdout.on('data', function(data) {
             if (data.indexOf('signal') > -1) {
               logs.info('Successfully connected!');
               clearTimeout(timeout);
               result = {
                 type: 'resolve',
                 message: '' // resolve doesn't report messages
-              };
-              remoteProcess.close();
-            } else {
-              clearTimeout(timeout);
-              result = {
-                type: 'reject',
-                message: 'Unable to connect. Please check your wifi credentials and try again.'
               };
               remoteProcess.close();
             }


### PR DESCRIPTION
I ran into an issue where sometimes the output from the function that would check the state of the wifi connection would not come all at once. In that case, the CLI would get the first packet which wouldn't contain the keyword that indicates success so it would immediately fail rather than wait for more data. This fixes that.

Also, this had an old `tessel.connection.end` lying around that messes up using the CLI API when you want to run multiple execs on a Tessel.

Part of the disintegration of #555 and needed for the test rig.