### PR TITLE
wait for close, allow multiple opens

### DIFF
--- a/lib/usb_connection.js
+++ b/lib/usb_connection.js
@@ -192,15 +192,15 @@ USB.Connection.prototype.setAltSetting = function() {
 };
 
 USB.Connection.prototype.end = function() {
+  var self = this;
   return new Promise((resolve, reject) => {
     // Tell the USB daemon to end all processes active
     // on account of this connection
-    Daemon.deregister(this, (err) => {
-      this._close();
+    Daemon.deregister(self, function(err) {
       if (err) {
         reject(err);
       } else {
-        resolve();
+        self._close(resolve());
       }
     });
   });

--- a/lib/usb_connection.js
+++ b/lib/usb_connection.js
@@ -111,6 +111,7 @@ USB.Connection.prototype.open = function() {
   // Try to open connection
   try {
     this.device.open();
+    this.closed = false;
   } catch (e) {
     if (e.message === 'LIBUSB_ERROR_ACCESS' && process.platform === 'linux') {
       logs.err('Please run `sudo t2 install-drivers` to fix device permissions.\n(Error: could not open USB device.)');
@@ -192,37 +193,40 @@ USB.Connection.prototype.setAltSetting = function() {
 };
 
 USB.Connection.prototype.end = function() {
-  var self = this;
   return new Promise((resolve, reject) => {
     // Tell the USB daemon to end all processes active
     // on account of this connection
-    Daemon.deregister(self, function(err) {
+    Daemon.deregister(this, (err) => {
       if (err) {
         reject(err);
       } else {
-        self._close(resolve());
+        this._close(resolve);
       }
     });
   });
 };
 
 USB.Connection.prototype._close = function(callback) {
+
+  if (typeof callback !== 'function') {
+    callback = function() {};
+  }
+
   if (this.closed) {
-    return callback && callback();
+    setImmediate(callback);
+    return;
   }
 
   this.closed = true;
+
   this.epIn.stopPoll(() => {
     var attempt = () => {
       try {
         this.device.close();
+        callback();
       } catch (e) {
         setTimeout(attempt, 100);
-        // FIXME: I really think that there should be an return here, else the
-        //        callback will get called for every attempt!
-      }
-      if (typeof callback === 'function') {
-        callback();
+        return;
       }
     };
 


### PR DESCRIPTION
This PR fixes to minor things:
* The `_close` function was being called but no callback was provided to ensure it completes
* You could not open and close a USB connection more than once

This is part of the disintegration of #555 and is needed for the test rig.