### PR TITLE
Fixes update listing and upgrading

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -7,6 +7,7 @@ var async = require('async');
 var colors = require('colors');
 var inquirer = require('inquirer');
 var sprintf = require('sprintf-js').sprintf;
+var semver = require('semver');
 
 // Internal
 var discover = require('./discover');
@@ -846,7 +847,6 @@ controller.update = function(opts) {
           return versionFromSHA.then(function(currentVersionInfo) {
             var build = updates.findBuild(builds, 'version', version);
             var verifiedVersion;
-
             // If the update is forced or this version was requested,
             // and a valid build exists for the version provided.
             if (version && build) {
@@ -872,7 +872,7 @@ controller.update = function(opts) {
               }
 
               // Check if the current build is the same or newer if this isn't a forced update
-              if (!opts.force && currentVersionInfo.version >= verifiedVersion) {
+              if (!opts.force && semver.gte(currentVersionInfo.version, verifiedVersion)) {
                 // If it's not, close the Tessel connection and print the error message
                 var message = tessel.name + ' is already on the latest firmware version (' + currentVersionInfo.version + '). You can force an update with "t2 update --force".';
 

--- a/lib/tessel/update.js
+++ b/lib/tessel/update.js
@@ -38,29 +38,26 @@ Tessel.prototype.update = function(newImage) {
 Tessel.prototype.updateOpenWRT = function(image) {
   logs.info('Updating OpenWRT (1/2)');
 
-  // Write the new image to a file in the /tmp dir
-  return this.connection.exec(commands.openStdinToFile(updatePath))
-    .then((remoteProc) => {
-      return new Promise(function(resolve) {
-        logs.info('Transferring image of size', (image.length / 1e6).toFixed(2), 'MB');
-        // When we finish writing the image
-        remoteProc.once('close', resolve);
-        // Write the image
-        remoteProc.stdin.end(image);
-      });
-    })
-    .then(() => {
+  return new Promise((resolve, reject) => {
+    // Write the new image to a file in the /tmp dir
+    this.connection.exec(commands.openStdinToFile(updatePath), (err, remoteProc) => {
+      if (err) {
+        return reject(err);
+      }
+
+      logs.info('Transferring image of size', (image.length / 1e6).toFixed(2), 'MB');
+      // When we finish writing the image
+      remoteProc.once('close', resolve);
+      // Write the image
+      remoteProc.stdin.end(image);
+    });
+  })
+  .then(() => {
+    return new Promise((resolve) => {
       // Begin the sysupgrade
       logs.info('Starting OpenWRT update. Please do not remove power from Tessel.');
       // The USBDaemon will cut out or the SSH command will close
-      return this.connection.exec(commands.sysupgrade(updatePath));
-    })
-    .then((remoteProc) => {
-      // This is the best way I've figured out to tell
-      // when the update is complete. I realize that tying completion
-      // of the CLI command to random text output by OpenWRT might not
-      // be the best thing...
-      return new Promise(function(resolve) {
+      this.connection.exec(commands.sysupgrade(updatePath), (err, remoteProc) => {
         remoteProc.stdout.on('data', function(d) {
           if (d.toString().includes('Upgrade completed')) {
             resolve();
@@ -68,6 +65,7 @@ Tessel.prototype.updateOpenWRT = function(image) {
         });
       });
     });
+  });
 };
 
 Tessel.prototype.updateFirmware = function(image) {

--- a/lib/tessel/update.js
+++ b/lib/tessel/update.js
@@ -39,33 +39,33 @@ Tessel.prototype.updateOpenWRT = function(image) {
   logs.info('Updating OpenWRT (1/2)');
 
   return new Promise((resolve, reject) => {
-    // Write the new image to a file in the /tmp dir
-    this.connection.exec(commands.openStdinToFile(updatePath), (err, remoteProc) => {
-      if (err) {
-        return reject(err);
-      }
+      // Write the new image to a file in the /tmp dir
+      this.connection.exec(commands.openStdinToFile(updatePath), (err, remoteProc) => {
+        if (err) {
+          return reject(err);
+        }
 
-      logs.info('Transferring image of size', (image.length / 1e6).toFixed(2), 'MB');
-      // When we finish writing the image
-      remoteProc.once('close', resolve);
-      // Write the image
-      remoteProc.stdin.end(image);
-    });
-  })
-  .then(() => {
-    return new Promise((resolve) => {
-      // Begin the sysupgrade
-      logs.info('Starting OpenWRT update. Please do not remove power from Tessel.');
-      // The USBDaemon will cut out or the SSH command will close
-      this.connection.exec(commands.sysupgrade(updatePath), (err, remoteProc) => {
-        remoteProc.stdout.on('data', function(d) {
-          if (d.toString().includes('Upgrade completed')) {
-            resolve();
-          }
+        logs.info('Transferring image of size', (image.length / 1e6).toFixed(2), 'MB');
+        // When we finish writing the image
+        remoteProc.once('close', resolve);
+        // Write the image
+        remoteProc.stdin.end(image);
+      });
+    })
+    .then(() => {
+      return new Promise((resolve) => {
+        // Begin the sysupgrade
+        logs.info('Starting OpenWRT update. Please do not remove power from Tessel.');
+        // The USBDaemon will cut out or the SSH command will close
+        this.connection.exec(commands.sysupgrade(updatePath), (err, remoteProc) => {
+          remoteProc.stdout.on('data', function(d) {
+            if (d.toString().includes('Upgrade completed')) {
+              resolve();
+            }
+          });
         });
       });
     });
-  });
 };
 
 Tessel.prototype.updateFirmware = function(image) {

--- a/lib/update-fetch.js
+++ b/lib/update-fetch.js
@@ -8,6 +8,7 @@ var ProgressBar = require('progress');
 var request = require('request');
 var streamToBuffer = require('stream-to-buffer');
 var urljoin = require('url-join');
+var semver = require('semver');
 
 // Internal
 var logs = require('./logs');
@@ -32,17 +33,24 @@ function requestBuildList() {
       }
 
       var outcome = reviewResponse(response);
-
+      var builds;
       // If there wasn't an issue with the request
       if (outcome.success) {
         // Resolve with the parsed data
         try {
-          resolve(JSON.parse(body));
+          builds = JSON.parse(body);
         }
         // If the parse failed, reject
         catch (err) {
           reject(err);
         }
+
+        // Sort the builds by semver version
+        builds.sort((a, b) => {
+          return semver.gt(a.version, b.version);
+        });
+
+        return resolve(builds);
       } else {
         reject(outcome.reason);
       }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "progress": "^1.1.8",
     "promzard": "^0.3.0",
     "request": "^2.60.0",
+    "semver": "^5.1.0",
     "shell-escape": "^0.2.0",
     "sprintf-js": "^1.0.2",
     "ssh2": "^0.4.2",


### PR DESCRIPTION
Fixes #564. Builds were being parsed out of order leading to `t2 update` trying to place something other than the latest build on the device. It also fixes an issue where `connection.exec` was trying to be used as a Promise.