### PR TITLE
Corrections to syntax error handling in compress operation. Fixes gh-583

### DIFF
--- a/lib/tessel/deploy.js
+++ b/lib/tessel/deploy.js
@@ -973,6 +973,7 @@ actions.compress = function(source) {
   };
 
   var ast;
+  var errors = [];
 
   try {
     // Attempt to use acorn, this will provide
@@ -986,18 +987,23 @@ actions.compress = function(source) {
       })
     );
     // However, if it fails, also try uglify...
-  } catch (error) {
+  } catch (acornError) {
+    errors.push(`Acorn Parser: ${acornError.message}`);
 
-    // If uglify lands _better_ ES6 support sooner,
-    // this will handle that
-    ast = uglify.parse(source, {
-      bare_returns: true,
-      fromString: true,
-      warnings: false,
-    });
-    // Otherwise the whole thing is a failure.
+    try {
+      // If uglify lands _better_ ES6 support sooner,
+      // this will handle that
+      ast = uglify.parse(source, {
+        bare_returns: true,
+        fromString: true,
+        warnings: false,
+      });
+    } catch (uglifyError) {
+      errors.push(`Uglify Parser: ${uglifyError.message}`);
 
-    throw new Error(error);
+      // Otherwise the whole thing is a failure.
+      throw new SyntaxError(errors.join('\n'));
+    }
   }
 
   ast.figure_out_scope();


### PR DESCRIPTION
The correct algorithm:

1. Let ast be a.parse(source)
2. If ast is a syntax error (e), let m be e.message
    1. Set the value of ast to u.parse(source)
        1. If ast is a syntax error (e), append e.message to m.
            1. throw new SyntaxError(m)