### PR TITLE
package: update engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,8 +79,6 @@
   },
   "preferGlobal": true,
   "engines": {
-    "node": ">0.12.0",
-    "iojs": ">= 1.0.0"
-  },
-  "engine-strict": true
+    "node": ">=4.2.0"
+  }
 }


### PR DESCRIPTION
Update the required version of Node.js to 4.2 (the current LTS release, "Argon") as per discussion in #470.

I also removed the `engine-strict` because 1) it's called `engineStrict` so it wasn't used and 2) [it's deprecated](https://docs.npmjs.com/files/package.json#enginestrict) and isn't respected anymore.

*@rwaldron: In the other issue you wrote 4.2.1, but I couldn't see anything in the changelog between 4.2.0 and 4.2.1 that would indicate that we really don't work on 4.2.0. I think that we should either say "the latest LTS" (4.3.1) or "any version of the current LTS" (4.2.0). Did I miss anything?*