### PR TITLE
Access Point Refactor && Update

### DIFF
--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -315,20 +315,26 @@ makeCommand('ap')
     abbr: 's',
     help: 'Encryption to use on network (i.e. wep, psk, psk2, wpa, wpa2).'
   })
-  .option('trigger', {
-    position: 1,
-    help: 'Trigger, i.e. on OR off, the access point'
+  .option('off', {
+    flag: true,
+    help: 'Disable the access point'
+  })
+  .option('on', {
+    flag: true,
+    help: 'Enable the access point'
   })
   .help('Configure the Tessel as an access point')
   .callback(function(opts) {
-    if (opts.trigger) {
-      if (opts.trigger === 'on') {
+    if (opts.on || opts.off) {
+      if (opts.on) {
         callControllerWith('enableAccessPoint', opts);
       } else {
         callControllerWith('disableAccessPoint', opts);
       }
-    } else {
+    } else if (opts.ssid) {
       callControllerWith('createAccessPoint', opts);
+    } else {
+      callControllerWith('getAccessPointInfo', opts);
     }
   });
 

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -716,28 +716,47 @@ controller.createAccessPoint = function(opts) {
       }
 
       if (security && securityOptions.indexOf(security) < 0) {
-        reject(security + ' is not a valid security option. Please choose on of the following: ' + securityOptions.join(', '));
+        reject(`${security} is not a valid security option. Please choose on of the following: ${securityOptions.join(', ')}`);
       }
       resolve();
     })
     .then(function() {
-      return controller.standardTesselCommand(opts, function(tessel) {
-        return tessel.createAccessPoint(opts);
-      });
+      return controller.standardTesselCommand(opts, (tessel) => tessel.createAccessPoint(opts));
     });
 };
 
 controller.enableAccessPoint = function(opts) {
   opts.authorized = true;
-  return controller.standardTesselCommand(opts, function(tessel) {
-    return tessel.enableAccessPoint();
-  });
+  return controller.standardTesselCommand(opts, (tessel) => tessel.enableAccessPoint());
 };
 
 controller.disableAccessPoint = function(opts) {
   opts.authorized = true;
+  return controller.standardTesselCommand(opts, (tessel) => tessel.disableAccessPoint());
+};
+
+controller.getAccessPointInfo = function(opts) {
+  opts.authorized = true;
   return controller.standardTesselCommand(opts, function(tessel) {
-    return tessel.disableAccessPoint();
+    return tessel.getAccessPointInfo()
+      .then((ap) => {
+        if (ap.ssid) {
+          logs.info(`SSID: ${ap.ssid}`);
+
+          if (ap.key || ap.encryption !== 'none') {
+            logs.info(`Password: ${ap.key}`);
+          }
+
+          logs.info(`Security: ${ap.encryption}`);
+          logs.info(`IP Address: ${ap.ip}`);
+          logs.info(`State: ${(!Number(ap.disabled) ? 'Enabled' : 'Disabled')}`);
+        } else {
+          logs.info(`${tessel.name} is not configured as an access point (run "t2 ap --help" to learn more)`);
+        }
+      })
+      .catch((error) => {
+        throw error;
+      });
   });
 };
 

--- a/lib/tessel/access-point.js
+++ b/lib/tessel/access-point.js
@@ -10,47 +10,70 @@ var logs = require('../logs');
 var Tessel = require('./tessel');
 
 
-function commitAndClose(tessel, status, resolve) {
+function commitAndClose(tessel, status, resolve, reject) {
 
-  var reconnectWifi = function() {
-    return tessel.simpleExec(commands.reconnectWifi());
-  };
+  var reconnectWifi = () => tessel.simpleExec(commands.reconnectWifi());
 
-  var reconnectDnsmasq = function() {
-    return tessel.simpleExec(commands.reconnectDnsmasq());
-  };
+  var reconnectDnsmasq = () => tessel.simpleExec(commands.reconnectDnsmasq());
 
-  var reconnectDhcp = function() {
-    return tessel.simpleExec(commands.reconnectDhcp());
-  };
+  var reconnectDhcp = () => tessel.simpleExec(commands.reconnectDhcp());
 
   return tessel.simpleExec(commands.commitWirelessCredentials())
     .then(reconnectWifi)
     .then(reconnectDnsmasq)
     .then(reconnectDhcp)
     .then((str) => logs.info(status, str))
-    .then(resolve);
+    .then(resolve)
+    .catch(reject);
 }
 
 Tessel.prototype.enableAccessPoint = function() {
   var status = 'Access Point successfully enabled.';
 
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     return this.simpleExec(commands.turnAccessPointOn())
-      .then(() => {
-        return commitAndClose(this, status, resolve);
-      });
+      .then(() => commitAndClose(this, status, resolve, reject));
   });
 };
 
 Tessel.prototype.disableAccessPoint = function() {
   var status = 'Access Point successfully disabled.';
 
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     return this.simpleExec(commands.turnAccessPointOff())
-      .then(() => {
-        return commitAndClose(this, status, resolve);
-      });
+      .then(() => commitAndClose(this, status, resolve, reject));
+  });
+};
+
+Tessel.prototype.getAccessPointInfo = function() {
+  var info;
+
+  return new Promise((resolve, reject) => {
+    return this.simpleExec(commands.getAccessPointConfig())
+      .then((config) => {
+        const props = ['ssid', 'key', 'encryption', 'disabled'];
+        const values = props.map((prop) => {
+          const regex = new RegExp(`${prop}='(.+)'`);
+          const value = regex.exec(config);
+
+          return value ? value[1] : null;
+        });
+
+        info = {
+          ssid: values[0],
+          key: values[1],
+          encryption: values[2],
+          disabled: values[3]
+        };
+
+        return this.simpleExec(commands.getAccessPointIP());
+      })
+      .then((ip) => {
+        info.ip = ip.replace('\n', '').trim();
+
+        resolve(info);
+      })
+      .catch(reject);
   });
 };
 
@@ -58,7 +81,7 @@ Tessel.prototype.createAccessPoint = function(opts) {
   var ssid = opts.ssid;
   var password = opts.pass;
   var security = opts.security;
-  var status = 'Created Access Point successfully.';
+  var status = 'Created Access Point successfully. ';
 
   var setupAccessPoint = () => {
     if (password && !security) {
@@ -66,33 +89,21 @@ Tessel.prototype.createAccessPoint = function(opts) {
     }
 
     if (password && security) {
-      status += ' SSID: ' + ssid + ', password ' + password + ', security mode: ' + security;
+      status += `SSID:  ${ssid}, password ${password}, security mode: ${security}`;
     } else if (!password && !security) {
       security = 'none';
-      status += ' SSID: ' + ssid;
+      status += `SSID: ${ssid}`;
     }
 
-    var setSSID = () => {
-      return this.simpleExec(commands.setAccessPointSSID(ssid));
-    };
+    var setSSID = () => this.simpleExec(commands.setAccessPointSSID(ssid));
 
-    var setAccessPointPassword = () => {
-      return this.simpleExec(commands.setAccessPointPassword(password));
-    };
+    var setAccessPointPassword = () => this.simpleExec(commands.setAccessPointPassword(password));
 
-    var setAccessPointSecurity = () => {
-      this.simpleExec(commands.setAccessPointSecurity(security));
-    };
+    var setAccessPointSecurity = () => this.simpleExec(commands.setAccessPointSecurity(security));
 
-    var turnAccessPointOn = () => {
-      return this.simpleExec(commands.turnAccessPointOn());
-    };
+    var turnAccessPointOn = () => this.simpleExec(commands.turnAccessPointOn());
 
-    var commitAndClosePromise = () => {
-      return new Promise((resolve) => {
-        commitAndClose(this, status, resolve);
-      });
-    };
+    var commitAndClosePromise = () => new Promise((resolve, reject) => commitAndClose(this, status, resolve, reject));
 
     var setup = () => {
       if (password) {
@@ -114,7 +125,7 @@ Tessel.prototype.createAccessPoint = function(opts) {
     .then(() => {
       // When an AP exists, change the status to
       // reflect an "update" vs. "create":
-      status = 'Updated Access Point successfully.';
+      status = 'Updated Access Point successfully. ';
       return setupAccessPoint();
     })
     .catch(() => {
@@ -133,9 +144,7 @@ Tessel.prototype.createAccessPoint = function(opts) {
           .then(() => this.simpleExec(commands.setLanNetworkNetmask()));
       };
 
-      var commitNetwork = () => {
-        return this.simpleExec(commands.commitNetwork());
-      };
+      var commitNetwork = () => this.simpleExec(commands.commitNetwork());
 
       return setAccessPoint()
         .then(setLanNetwork)

--- a/lib/tessel/commands.js
+++ b/lib/tessel/commands.js
@@ -142,6 +142,12 @@ module.exports.turnAccessPointOn = function() {
 module.exports.turnAccessPointOff = function() {
   return ['uci', 'set', 'wireless.@wifi-iface[1].disabled=1'];
 };
+module.exports.getAccessPointConfig = function() {
+  return ['uci', 'show', 'wireless.@wifi-iface[1]'];
+};
+module.exports.getAccessPointIP = function() {
+  return ['uci', 'get', 'network.lan.ipaddr'];
+};
 module.exports.reconnectDnsmasq = function() {
   return ['/etc/init.d/dnsmasq', 'restart'];
 };

--- a/lib/tessel/wifi.js
+++ b/lib/tessel/wifi.js
@@ -48,7 +48,7 @@ Tessel.prototype.getWifiInfo = function() {
         var network = JSON.parse(resultsJSON);
 
         if (network.ssid === undefined) {
-          var msg = this.name + ' is not connected to Wi-Fi (run "t2 wifi -l" to see available networks)';
+          var msg = `${this.name} is not connected to Wi-Fi (run "t2 wifi -l" to see available networks)`;
           return Promise.reject(msg);
         }
       } catch (err) {

--- a/lib/tessel/wifi.js
+++ b/lib/tessel/wifi.js
@@ -48,7 +48,7 @@ Tessel.prototype.getWifiInfo = function() {
         var network = JSON.parse(resultsJSON);
 
         if (network.ssid === undefined) {
-          var msg = this.name + ' is not connected to Wi-Fi (run "tessel wifi -l" to see available networks)';
+          var msg = this.name + ' is not connected to Wi-Fi (run "t2 wifi -l" to see available networks)';
           return Promise.reject(msg);
         }
       } catch (err) {


### PR DESCRIPTION
Fixes #536 

So the new method of toggling an access point is using `t2 ap --on/--off`, just like `t2 wifi --on/--off`.

This PR also add functionality similar to `t2 wifi`, i.e.,

```
Nicks-MBP:tessel-test hipsterbrown$ t2 ap
INFO Looking for your Tessel...
INFO Connected to tessel-router.
INFO SSID: RouterName
INFO Password: APPassword
INFO Security: psk2
INFO IP Address: 192.168.1.101
INFO State: Enabled
```