### PR TITLE
Removes calls to process.close

### DIFF
--- a/lib/tessel/wifi.js
+++ b/lib/tessel/wifi.js
@@ -149,15 +149,21 @@ Tessel.prototype.setWiFiState = function(enable) {
           return reject(err);
         }
         if (enable) {
-          var result = {};
+
+          var result = {
+            type: 'reject',
+            message: 'Unable to verify connection. Please ensure you have entered the correct network credentials.'
+          };
+
+          // A timeout in case the process never closes
           var timeout = setTimeout(function() {
             result = {
               type: 'reject',
               message: 'Timed out waiting to verify connection. Run `t2 wifi` to manually verify connection. If not connected, ensure you have entered the correct network credentials.'
             };
-            // End the connection
-            remoteProcess.close();
+            return returnResult();
           }, Tessel.__wifiConnectionTimeout);
+
           remoteProcess.stdout.on('data', function(data) {
             if (data.indexOf('signal') > -1) {
               logs.info('Successfully connected!');
@@ -166,17 +172,19 @@ Tessel.prototype.setWiFiState = function(enable) {
                 type: 'resolve',
                 message: '' // resolve doesn't report messages
               };
-              remoteProcess.close();
             }
           });
-          remoteProcess.on('close', function() {
+
+          var returnResult = () => {
             if (result.type === 'reject') {
               reject(result.message);
             } else {
               logState();
               resolve();
             }
-          });
+          };
+
+          remoteProcess.on('close', returnResult);
         } else {
           logState();
           resolve();

--- a/test/unit/wifi.js
+++ b/test/unit/wifi.js
@@ -198,6 +198,7 @@ module.exports['Tessel.prototype.connectToNetwork'] = {
         // Wrap in setImmediate to make sure listener is set up before emitting
         setImmediate(() => {
           this.tessel._rps.stdout.emit('data', 'signal');
+          setImmediate(() => this.tessel._rps.emit('close'));
         });
       } else {
         setImmediate(() => {
@@ -241,6 +242,7 @@ module.exports['Tessel.prototype.connectToNetwork'] = {
         // Wrap in setImmediate to make sure listener is set up before emitting
         setImmediate(() => {
           this.tessel._rps.stdout.emit('data', 'signal');
+          setImmediate(() => this.tessel._rps.emit('close'));
         });
       } else {
         setImmediate(() => {
@@ -287,6 +289,7 @@ module.exports['Tessel.prototype.connectToNetwork'] = {
         // Wrap in setImmediate to make sure listener is set up before emitting
         setImmediate(() => {
           this.tessel._rps.stdout.emit('data', 'signal');
+          setImmediate(() => this.tessel._rps.emit('close'));
         });
       } else {
         setImmediate(() => {
@@ -330,10 +333,11 @@ module.exports['Tessel.prototype.connectToNetwork'] = {
     // Test is expecting several closes...;
     this.tessel._rps.on('control', (command) => {
       if (command.toString() === 'ubus call iwinfo info {"device":"wlan0"}') {
-        // Write to stderr so it completes as expected
+        // Write to stdout so it completes as expected
         // Wrap in setImmediate to make sure listener is set up before emitting
         setImmediate(() => {
           this.tessel._rps.stdout.emit('data', errMessage);
+          setImmediate(() => this.tessel._rps.emit('close'));
         });
       } else {
         setImmediate(() => {
@@ -425,6 +429,7 @@ module.exports['Tessel.prototype.connectToNetwork'] = {
           this.tessel._rps.stdout.emit('data', 'do not have success yet');
           // then write the keyword we're looking for for success
           this.tessel._rps.stdout.emit('data', 'signal');
+          setImmediate(() => this.tessel._rps.emit('close'));
         });
       } else {
         setImmediate(() => {
@@ -488,6 +493,7 @@ module.exports['Tessel.setWifiState'] = {
         // Wrap in setImmediate to make sure listener is set up before emitting
         setImmediate(() => {
           this.tessel._rps.stdout.emit('data', 'signal');
+          setImmediate(() => this.tessel._rps.emit('close'));
         });
       } else {
         setImmediate(() => {
@@ -528,6 +534,7 @@ module.exports['Tessel.setWifiState'] = {
         // Wrap in setImmediate to make sure listener is set up before emitting
         setImmediate(() => {
           this.tessel._rps.stdout.emit('data', 'signal');
+          setImmediate(() => this.tessel._rps.emit('close'));
         });
       } else {
         setImmediate(() => {


### PR DESCRIPTION
The `process.close` can apparently be troublesome. I haven't investigated it fully, but it causes the next call to `.exec` to hang (and the test bench needs to make another call to ensure it can ping a network). We can just remove this function from use and when we need to close processes, just do it with `process.stdin.end('')` (or they will close naturally).

My guess is that in this case, the process was closing naturally and our request to close the process is confusing the usb daemon somehow. Fixing the usb daemon is definitely a better long term fix but I don't have the time to do that before this test rig is needed.