### PR TITLE
Use the proper stop method to use the scanner methods multiple times

### DIFF
--- a/lib/discover.js
+++ b/lib/discover.js
@@ -15,7 +15,8 @@ var usb = require('./usb_connection');
 
 
 function TesselSeeker() {
-  this.lanScan = undefined;
+  this.lanScan = null;
+  this.usbScan = null;
   this.seekDuration = undefined;
   this.scanTimeout = undefined;
 }
@@ -117,16 +118,12 @@ TesselSeeker.prototype.start = function(opts) {
 
 TesselSeeker.prototype.stop = function() {
 
-  if (this.lanScan !== undefined) {
-    this.lanScan.stop();
-
-    this.lanScan = undefined;
+  if (this.lanScan !== null) {
+    this.lanScan = lan.stopScan();
   }
 
-  if (this.usbScan !== undefined) {
-    this.usbScan.stop();
-
-    this.usbScan = undefined;
+  if (this.usbScan !== null) {
+    this.usbScan = usb.stopScan();
   }
 
   // If a timeout was provided

--- a/lib/lan_connection.js
+++ b/lib/lan_connection.js
@@ -132,10 +132,10 @@ LAN.Connection.prototype._processArgsForTransport = function(command) {
   return command;
 };
 
-var scanner;
+var scanner = null;
 
 function startScan() {
-  if (scanner === undefined) {
+  if (scanner === null) {
     scanner = new LAN.Scanner();
     scanner.start();
   }
@@ -144,9 +144,9 @@ function startScan() {
 }
 
 function stopScan() {
-  if (scanner !== undefined) {
+  if (scanner !== null) {
     scanner.stop();
-    scanner = undefined;
+    scanner = null;
   }
 }
 

--- a/lib/usb_connection.js
+++ b/lib/usb_connection.js
@@ -359,10 +359,10 @@ USB.Connection.prototype._processArgsForTransport = function(command) {
   return command;
 };
 
-var scanner;
+var scanner = null;
 
 function startScan() {
-  if (scanner === undefined) {
+  if (scanner === null) {
     scanner = new USB.Scanner();
 
     setImmediate(() => scanner.start());
@@ -372,9 +372,9 @@ function startScan() {
 }
 
 function stopScan() {
-  if (scanner !== undefined) {
+  if (scanner !== null) {
     scanner.stop();
-    scanner = undefined;
+    scanner = null;
   }
 
   return scanner;

--- a/test/unit/discover.js
+++ b/test/unit/discover.js
@@ -26,9 +26,8 @@ exports['TesselSeeker'] = {
 
   initialization: function(test) {
     test.expect(2);
-
-    test.equal(this.lanScan, undefined);
-    test.equal(this.usbScan, undefined);
+    test.equal(this.lanScan, null);
+    test.equal(this.usbScan, null);
     test.done();
   },
 };
@@ -43,6 +42,12 @@ exports['TesselSeeker.prototype.start'] = {
     });
     this.lanStartScan = this.sandbox.stub(lan, 'startScan', function() {
       return new FakeScanner();
+    });
+    this.usbStopScan = this.sandbox.stub(usb, 'stopScan', function() {
+      return null;
+    });
+    this.lanStopScan = this.sandbox.stub(lan, 'stopScan', function() {
+      return null;
     });
     this.seeker = new TesselSeeker();
     // The default amount of time to scan for connections
@@ -120,6 +125,12 @@ exports['TesselSeeker.prototype.stop'] = {
     this.lanStartScan = this.sandbox.stub(lan, 'startScan', function() {
       return new FakeScanner();
     });
+    this.usbStopScan = this.sandbox.stub(usb, 'stopScan', function() {
+      return null;
+    });
+    this.lanStopScan = this.sandbox.stub(lan, 'stopScan', function() {
+      return null;
+    });
     this.seeker = new TesselSeeker();
 
     done();
@@ -137,59 +148,64 @@ exports['TesselSeeker.prototype.stop'] = {
   },
 
   stopAfterStart: function(test) {
-    test.expect(1);
-
-    this.seeker.start();
-    this.seeker.stop();
-
-    // Both active scanners called stop
-    test.equal(this.stop.callCount, 2);
-
-    test.done();
-  },
-
-  stopDuplicateCall: function(test) {
     test.expect(2);
 
     this.seeker.start();
     this.seeker.stop();
 
     // Both active scanners called stop
-    test.equal(this.stop.callCount, 2);
+    test.equal(this.usbStopScan.callCount, 1);
+    test.equal(this.lanStopScan.callCount, 1);
+
+    test.done();
+  },
+
+  stopDuplicateCall: function(test) {
+    test.expect(4);
+
+    this.seeker.start();
+    this.seeker.stop();
+
+    // Call count remains 1 each
+    test.equal(this.usbStopScan.callCount, 1);
+    test.equal(this.lanStopScan.callCount, 1);
 
     // Duplicate call
     this.seeker.stop();
 
-    // Call count remains 2
-    test.equal(this.stop.callCount, 2);
+    // Call count remains at one
+    test.equal(this.usbStopScan.callCount, 1);
+    test.equal(this.lanStopScan.callCount, 1);
 
     test.done();
   },
 
   stopOnlyUsb: function(test) {
-    test.expect(1);
+    test.expect(2);
 
     this.seeker.start();
 
-    this.seeker.lanScan = undefined;
+    this.seeker.lanScan = null;
 
     this.seeker.stop();
 
-    test.equal(this.stop.callCount, 1);
+    test.equal(this.usbStopScan.callCount, 1);
+    test.equal(this.lanStopScan.callCount, 0);
 
     test.done();
   },
 
   stopOnlyLan: function(test) {
-    test.expect(1);
+    test.expect(2);
 
     this.seeker.start();
 
-    this.seeker.usbScan = undefined;
+    this.seeker.usbScan = null;
 
     this.seeker.stop();
 
-    test.equal(this.stop.callCount, 1);
+    test.equal(this.usbStopScan.callCount, 0);
+    test.equal(this.lanStopScan.callCount, 1);
 
     test.done();
   }
@@ -211,6 +227,12 @@ exports['TesselSeeker Scan Time'] = {
     });
     this.lanStartScan = this.sandbox.stub(lan, 'startScan', function() {
       return new FakeScanner();
+    });
+    this.usbStopScan = this.sandbox.stub(usb, 'stopScan', function() {
+      return null;
+    });
+    this.lanStopScan = this.sandbox.stub(lan, 'stopScan', function() {
+      return null;
     });
     this.seeker = new TesselSeeker();
     // The default amount of time to scan for connections


### PR DESCRIPTION
Previously, it was impossible to call the `scanner.start` method multiple times because the scanner was never `stop`ped properly. All the Tessels that were originally found would still be considered found so no new Tessels would be returned. I also changed the default type of the scanners to `null` instead of `undefined` because that seemed more idiomatic.