### PR TITLE
[WIP] Adds progress bar animations for deploying code

### DIFF
--- a/lib/lan/lan_progress_bar.js
+++ b/lib/lan/lan_progress_bar.js
@@ -1,0 +1,14 @@
+var ProgressBar = require('progress');
+var hookWritableStream = require('hook-writable-stream');
+
+// LAN Process specific wrapper around the `progress` module
+function LANProcessProgress(remoteProcess, barTitle, options) {
+  this.remoteProcess = remoteProcess;
+  this.bar = new ProgressBar(barTitle, options);
+
+  hookWritableStream(remoteProcess.stdin, true, (chunk) => {
+    this.bar.tick(chunk.length);
+  });
+}
+
+module.exports = LANProcessProgress;

--- a/lib/lan_connection.js
+++ b/lib/lan_connection.js
@@ -16,6 +16,7 @@ var ssh = require('ssh2');
 
 // Internal
 var Tessel = require('./tessel/tessel');
+var ProgressBar = require('./lan/lan_progress_bar');
 
 //if you have another mdns daemon running, like avahi or bonjour, uncomment following line
 mdns.excludeInterface('0.0.0.0');
@@ -40,6 +41,8 @@ LAN.Connection = function(opts) {
     this.auth.privateKey = opts.privateKey || fs.readFileSync(path.join(Tessel.LOCAL_AUTH_KEY));
   }
 };
+
+LAN.Connection.prototype.ProgressBar = ProgressBar;
 
 LAN.Connection.prototype.exec = function(command, options, callback) {
 

--- a/lib/tessel/deploy.js
+++ b/lib/tessel/deploy.js
@@ -323,6 +323,14 @@ actions.sendBundle = function(tessel, opts) {
               }
             });
 
+            // Create a progress bar to track upload progress
+            tessel.connection.ProgressBar(remoteProcess, '  Uploading [:bar] :percent :etas remaining', {
+              complete: '=',
+              incomplete: ' ',
+              width: 20,
+              total: bundle.length
+            });
+
             // Write the code bundle to the hardware
             remoteProcess.stdin.end(bundle);
           });

--- a/lib/usb/usb_process.js
+++ b/lib/usb/usb_process.js
@@ -183,6 +183,9 @@ RemoteWritableStream.prototype.ack = function(data, dataLength) {
     // Emit the drain event
     this.emit('drain');
   }
+  if (this.writeHeaderFunc === protocol.stdinWrite) {
+    this.emit('ackStdin', data.readUIntLE(0, dataLength));
+  }
 };
 
 // A helper function to continue writing chunks from the back pressure array

--- a/lib/usb/usb_progress_bar.js
+++ b/lib/usb/usb_progress_bar.js
@@ -1,0 +1,13 @@
+var ProgressBar = require('progress');
+
+// USB Process specific wrapper around the `progress` module
+function USBProcessProgress(remoteProcess, barTitle, options) {
+  this.remoteProcess = remoteProcess;
+  this.bar = new ProgressBar(barTitle, options);
+
+  this.remoteProcess.stdin.on('ackStdin', (length) => {
+    this.bar.tick(length);
+  });
+}
+
+module.exports = USBProcessProgress;

--- a/lib/usb_connection.js
+++ b/lib/usb_connection.js
@@ -13,6 +13,7 @@ var debugCommands = require('debug')('commands:usb');
 // Internal
 var DFU = require('./dfu');
 var logs = require('./logs');
+var ProgressBar = require('./usb/usb_progress_bar');
 
 
 
@@ -42,6 +43,8 @@ USB.Connection = function(device) {
 };
 
 util.inherits(USB.Connection, Duplex);
+
+USB.Connection.prototype.ProgressBar = ProgressBar;
 
 USB.Connection.prototype.exec = function(command, options, callback) {
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "fstream": "^1.0.8",
     "fstream-ignore": "1.0.2",
     "glob": "^5.0.15",
+    "hook-writable-stream": "^0.1.0",
     "inquirer": "^0.8.5",
     "mdns-js": "^0.4.0",
     "minimatch": "^3.0.0",


### PR DESCRIPTION
This PR improves the UI of deploying code by adding a progress bar so you have some feedback of how long the process will take (and to ensure nothing is hanging). You can test it out with:
```
t2 init
t2 run index.js
```
You'll see a fancy progress bar quickly go from 0% to 100%.

The only thing I'm not sure about is how to monitor LAN `connection.write` progress well. As is, it just hits 100% immediately because the through stream I'm using just gets passed the entire bundle from `deploy.js` (`remoteProcess.stdin.end(bundle)`). I need some way to monitor progress in the stream's backpressure. @LinusU or @rwaldron, do you have any ideas of how I might be able to do that?

