### PR TITLE
Wifi: eliminate use of timeout in wifi connection verification

### DIFF
--- a/lib/tessel/wifi.js
+++ b/lib/tessel/wifi.js
@@ -92,17 +92,18 @@ Tessel.prototype.connectToNetwork = function(opts) {
   var ssid = opts.ssid;
   var password = opts.password;
   var security = opts.security;
-  var status = 'Wifi connection successful.';
+  var status = 'Wifi Connected.';
 
   if (password && !security) {
     security = 'psk2';
   }
 
+  status += ` SSID: ${ssid}`;
+
   if (password && security) {
-    status += ' SSID: ' + ssid + ', password ' + password + ', security mode: ' + security;
+    status += `, password: ${password}, security: ${security}`;
   } else if (!password && (!security || security === 'none')) {
     security = 'none';
-    status += ' SSID: ' + ssid;
   }
 
   var setSSID = () => this.simpleExec(commands.setNetworkSSID(ssid));
@@ -137,61 +138,70 @@ Tessel.prototype.resetMDNS = function() {
 };
 
 Tessel.prototype.setWiFiState = function(enable) {
-  var logState = () => logs.info('Wifi', enable ? 'Enabled.' : 'Disabled.');
-
   return new Promise((resolve, reject) => {
     return this.simpleExec(commands.turnOnWifi(enable))
       .then(() => this.simpleExec(commands.commitWirelessCredentials()))
       .then(() => this.simpleExec(commands.reconnectWifi()))
-      .then(() => new Promise((resolve) => setTimeout(resolve, 2000))) // delay to let wifi reconnection settle before fetching info
-      .then(() => this.connection.exec(commands.getWifiInfo(), (err, remoteProcess) => {
-        if (err) {
-          return reject(err);
-        }
-        if (enable) {
+      .then(() => {
+        var settle = (rejection) => {
+          if (rejection) {
+            reject(rejection);
+          } else {
+            logs.info('Wifi', enable ? 'Enabled.' : 'Disabled.');
+            resolve();
+          }
+        };
+        /*
+        To explain the following "magic number"...
 
-          var result = {
-            type: 'reject',
-            message: 'Unable to verify connection. Please ensure you have entered the correct network credentials.'
-          };
+        The `tries` limit is set to 10 as an arbitrarily chosen minimum and maximum restriction.
+        This could actually be increased to ~33, which is the approximate number of tries
+        that could potentially be made in 12 seconds (the delay period (2) + timeout period (10)).
+        This was determined by counting the number of complete tries made against a
+        known invalid ssid, within a 12 second period. I ran the measurement code 10 times
+        and the rounded average count was 33 tries.
 
-          // A timeout in case the process never closes
-          var timeout = setTimeout(function() {
-            result = {
-              type: 'reject',
-              message: 'Timed out waiting to verify connection. Run `t2 wifi` to manually verify connection. If not connected, ensure you have entered the correct network credentials.'
-            };
-            return returnResult();
-          }, Tessel.__wifiConnectionTimeout);
+        `tries` shouldn't be set lower than 10, as each wifi info request takes approximately 340ms.
+        This was determined by measuring the time between each attempt against a known invalid
+        ssid (with no tries limit). 340 is the rounded average of 10 complete operations, including
+        only the lowest number of measurements; ie. if one operation made 35 tries, and nine
+        operatons made 30 tries, then the only the first 30 were included in the result set.
 
-          remoteProcess.stdout.on('data', function(data) {
-            if (data.indexOf('signal') > -1) {
-              logs.info('Successfully connected!');
-              clearTimeout(timeout);
-              result = {
-                type: 'resolve',
-                message: '' // resolve doesn't report messages
-              };
+        The result is a maximum of 3.4s before verification is treated as a failure.
+        This is slightly more than the previous delay + one operation, but substantially less than
+        the full 10 second timeout, with a higher likelihood of success (that is, zero failures were
+        observed when using a valid ssid + password + security).
+        */
+        var tries = 10;
+        var pollForWifiSignal = () => {
+          this.connection.exec(commands.getWifiInfo(), (err, remoteProcess) => {
+            if (err) {
+              return reject(err);
             }
+            this.receive(remoteProcess, (err, result) => {
+              if (err) {
+                return reject(err);
+              }
+              if (result.toString().includes('signal')) {
+                settle();
+              } else {
+                tries--;
+
+                if (tries) {
+                  pollForWifiSignal();
+                } else {
+                  settle('Unable to verify connection. Please ensure you have entered the correct network credentials.');
+                }
+              }
+            });
           });
+        };
 
-          var returnResult = () => {
-            if (result.type === 'reject') {
-              reject(result.message);
-            } else {
-              logState();
-              resolve();
-            }
-          };
-
-          remoteProcess.on('close', returnResult);
+        if (enable) {
+          pollForWifiSignal();
         } else {
-          logState();
-          resolve();
+          settle();
         }
-
-      }));
+      });
   });
 };
-
-Tessel.__wifiConnectionTimeout = 10000;


### PR DESCRIPTION
Last night at nodebots.nyc, I was experiencing issues with the wifi connection commands reporting timeouts or producing `WARN Unable to verify connection. Please ensure you have entered the correct network credentials.`. After I landed #596, I took a closer look at `setWiFiState` and realized that if I eliminated the time out and replaced it with a recursively called "polling" mechanism, I could increase the likelihood of successfully verifying the wifi connection. I've arbitrarily selected 10 as the limit of tries that will be made; this could actually be increased to ~33, which is the approximate number of tries that could potentially be made in 12 seconds (the delay period (2) + timeout period (10)). I determined this by counting the number of complete tries made against a known invalid ssid, within a 12 second period. I ran the measurement code 10 times and the rounded average count was 33 tries. 