### PR TITLE
Ensure IDs are sorted prior to selecting next

### DIFF
--- a/lib/usb/usb_daemon.js
+++ b/lib/usb/usb_daemon.js
@@ -225,7 +225,7 @@ function USBDaemon() {
   this._nextID = () => {
 
     // Get all currently used ids, what's the first available?
-    var usedIDs = this.getIDsInUse();
+    var usedIDs = this.getIDsInUse().sort();
     var prev;
     var cur;
 

--- a/test/unit/daemon.js
+++ b/test/unit/daemon.js
@@ -1,0 +1,62 @@
+module.exports['Daemon._nextID'] = {
+  setUp: function(done) {
+    this.sandbox = sinon.sandbox.create();
+    done();
+  },
+
+  tearDown: function(done) {
+    this.sandbox.restore();
+    done();
+  },
+
+  // Returns the next element in the list when ordered with no gaps
+  selectSubsequentId: function(test) {
+    test.expect(1);
+    this.getIDsInUse = this.sandbox.stub(Daemon, 'getIDsInUse').returns([0, 1, 2]);
+    var next = Daemon._nextID();
+    test.equal(next, 3);
+    test.done();
+  },
+
+  // Detects gaps at the front of the id array. Returns first element in gap
+  selectMissingId: function(test) {
+    test.expect(1);
+    this.getIDsInUse = this.sandbox.stub(Daemon, 'getIDsInUse').returns([1, 2]);
+    var next = Daemon._nextID();
+    test.equal(next, 0);
+    test.done();
+  },
+
+  // Detects gap in middle of array
+  detectGapId: function(test) {
+    test.expect(1);
+    this.getIDsInUse = this.sandbox.stub(Daemon, 'getIDsInUse').returns([0, 1, 3]);
+    var next = Daemon._nextID();
+    test.equal(next, 2);
+    test.done();
+  },
+
+  // Can handle out of order ids, returns next after max or first gap
+  handleUnorderedIds: function(test) {
+    test.expect(1);
+    this.getIDsInUse = this.sandbox.stub(Daemon, 'getIDsInUse').returns([2, 3, 1]);
+    var next = Daemon._nextID();
+    test.equal(next, 0);
+    test.done();
+  },
+
+  // Will not return a new id if we already have 255 processes running
+  throwOnMaxIds: function(test) {
+    test.expect(1);
+
+    var maxIds = 255;
+    var idsInUse = [];
+    for (var i = 0; i < maxIds; i++) {
+      idsInUse.push(i);
+    }
+
+    this.getIDsInUse = this.sandbox.stub(Daemon, 'getIDsInUse').returns(idsInUse);
+    test.throws(Daemon._nextID());
+    test.done();
+  }
+};


### PR DESCRIPTION
When Tessel needs to create a new process on OpenWRT via a USB Connection (eg. `node /tmp/remote-script/index.js` to run a script), the CLI communicates with the USB Daemon running on OpenWRT to spawn a new process. As part of the protocol with the USB Daemon, the CLI must specify an integer to be used as the identifier for that process. That ensures the CLI and USB Daemon can route `stdin`, `stdout`, and `stderr` properly for multiple processes.

The `_nextID` function is responsible for selecting that next identifier for a new process (between 0-254) created over a USB Connection (LAN is managed by SSH). It does so by analyzing the processes identifiers already in use and selecting the next available number. For example, if the process IDs in use were `[0, 1, 3, 4, 6]`, the next available ID would be `2`.

The problem was that this function didn't take into account that the IDs-in-use list might be out of order so you could get something like `[1, 0]`. In this case, the function would see that the first element is not zero and return zero to be the next available ID, even though it was already in use.

This PR solves the problem by sorting the list of IDs-in-use before searching for the next available.

- [x] Add tests.