### PR TITLE
Check access point config before enabling through `ap --on`

### DIFF
--- a/lib/tessel/access-point.js
+++ b/lib/tessel/access-point.js
@@ -31,8 +31,31 @@ Tessel.prototype.enableAccessPoint = function() {
   var status = 'Access Point successfully enabled.';
 
   return new Promise((resolve, reject) => {
-    return this.simpleExec(commands.turnAccessPointOn())
-      .then(() => commitAndClose(this, status, resolve, reject));
+    return this.getAccessPointInfo()
+      .then((info) => {
+        if (info.ssid) {
+          return this.simpleExec(commands.turnAccessPointOn())
+            .then(() => {
+              var logInfo = [`SSID: ${info.ssid}`];
+
+              if (info.key && info.encryption !== 'none') {
+                logInfo.push(`Password: ${info.key}`);
+              }
+
+              logInfo.push(
+                `Security: ${info.encryption}`,
+                `IP Address: ${info.ip}`
+              );
+
+              status += `\n${logInfo.join('\n')}`;
+
+              return commitAndClose(this, status, resolve, reject);
+            });
+        } else {
+          reject(`${this.name} is not configured as an access point (run "t2 ap --help" to learn more)`);
+        }
+      })
+      .catch(reject);
   });
 };
 

--- a/test/unit/access-point.js
+++ b/test/unit/access-point.js
@@ -211,8 +211,11 @@ exports['Tessel.prototype.enableAccessPoint'] = {
     this.reconnectWifi = this.sandbox.spy(commands, 'reconnectWifi');
     this.reconnectDnsmasq = this.sandbox.spy(commands, 'reconnectDnsmasq');
     this.reconnectDhcp = this.sandbox.spy(commands, 'reconnectDhcp');
+    this.getAccessPointConfig = this.sandbox.spy(commands, 'getAccessPointConfig');
+    this.getAccessPointIP = this.sandbox.spy(commands, 'getAccessPointIP');
 
     this.tessel = TesselSimulator();
+    this.tessel.name = 'TestTessel';
 
     done();
   },
@@ -224,13 +227,41 @@ exports['Tessel.prototype.enableAccessPoint'] = {
   },
 
   turnsOn: function(test) {
-    test.expect(4);
+    test.expect(6);
+    var results = {
+      ssid: 'TestSSID',
+      key: 'TestPass123',
+      encryption: 'psk2',
+      disabled: '1',
+      ip: '192.168.200.1'
+    };
 
     // Test is expecting two closes...;
-    this.tessel._rps.on('control', () => {
-      setImmediate(() => {
-        this.tessel._rps.emit('close');
-      });
+    this.tessel._rps.on('control', (command) => {
+      if (command.toString() === 'uci show wireless.@wifi-iface[1]') {
+        var info = new Buffer(tags.stripIndent `
+          wireless.cfg053579.ssid='${results.ssid}'
+          wireless.cfg053579.key='${results.key}'
+          wireless.cfg053579.encryption='${results.encryption}'
+          wireless.cfg053579.disabled='1'`);
+
+        setImmediate(() => {
+          this.tessel._rps.stdout.emit('data', info);
+          this.tessel._rps.emit('close');
+        });
+      } else if (command.toString() === 'uci get network.lan.ipaddr') {
+        var ipInfo = new Buffer(`${results.ip}\n`);
+
+        setImmediate(() => {
+          this.tessel._rps.stdout.emit('data', ipInfo);
+          this.tessel._rps.emit('close');
+        });
+      } else {
+        setImmediate(() => {
+          this.tessel._rps.stdout.removeAllListeners();
+          this.tessel._rps.emit('close');
+        });
+      }
     });
 
     this.tessel.enableAccessPoint()
@@ -239,10 +270,59 @@ exports['Tessel.prototype.enableAccessPoint'] = {
         test.equal(this.reconnectWifi.callCount, 1);
         test.equal(this.reconnectDnsmasq.callCount, 1);
         test.equal(this.reconnectDhcp.callCount, 1);
+        test.equal(this.getAccessPointConfig.callCount, 1);
+        test.equal(this.getAccessPointIP.callCount, 1);
         test.done();
       })
       .catch(error => {
         test.ok(false, error.toString());
+        test.done();
+      });
+  },
+
+  failsWhenUnconfigured: function(test) {
+    test.expect(1);
+    var results = {
+      key: 'TestPass123',
+      encryption: 'psk2',
+      disabled: '1',
+      ip: '192.168.200.1'
+    };
+
+    // Test is expecting two closes...;
+    this.tessel._rps.on('control', (command) => {
+      if (command.toString() === 'uci show wireless.@wifi-iface[1]') {
+        var info = new Buffer(tags.stripIndent `
+          wireless.cfg053579.key='${results.key}'
+          wireless.cfg053579.encryption='${results.encryption}'
+          wireless.cfg053579.disabled='1'`);
+
+        setImmediate(() => {
+          this.tessel._rps.stdout.emit('data', info);
+          this.tessel._rps.emit('close');
+        });
+      } else if (command.toString() === 'uci get network.lan.ipaddr') {
+        var ipInfo = new Buffer(`${results.ip}\n`);
+
+        setImmediate(() => {
+          this.tessel._rps.stdout.emit('data', ipInfo);
+          this.tessel._rps.emit('close');
+        });
+      } else {
+        setImmediate(() => {
+          this.tessel._rps.stdout.removeAllListeners();
+          this.tessel._rps.emit('close');
+        });
+      }
+    });
+
+    this.tessel.enableAccessPoint()
+      .then(() => {
+        test.fail('Should not pass');
+        test.done();
+      })
+      .catch(error => {
+        test.ok(error);
         test.done();
       });
   }


### PR DESCRIPTION
If someone tries to enable a Tessel as an access point before configuring it, it would confirm enabling without actually working. This PR checks the access point info before enabling and returns that info after enabling.