### PR TITLE
Deploy: implements customizable binary path rewriting/translation

### DIFF
--- a/lib/tessel/deploy-lists.js
+++ b/lib/tessel/deploy-lists.js
@@ -4,6 +4,15 @@ module.exports = {
     'socket.io-client/socket.io.js',
     'mime/types/*.types'
   ],
+  binaryPathTranslations: {
+    '*': [{
+      find: `${process.platform}-${process.arch}`,
+      replace: 'linux-mipsel'
+    }],
+    /*
+      Other module-specific translations could be added in the future.
+     */
+  },
   compressionOptions: {
     'extend': {
       special: {

--- a/lib/tessel/deploy.js
+++ b/lib/tessel/deploy.js
@@ -667,16 +667,28 @@ actions.resolveBinaryModules.readGypFileSync = function(gypfile) {
 };
 
 actions.injectBinaryModules = function(globRoot, tempBundlePath) {
+  var binaryPathTranslations = deployLists.binaryPathTranslations['*'];
   return new Promise((resolve) => {
     // For every binary module in use...
     binaryModulesUsed.forEach(details => {
       if (details.resolved) {
+        var translations = binaryPathTranslations.slice().concat(
+          deployLists.binaryPathTranslations[details.name] || []
+        );
         var buildDir = details.buildPath.replace(path.dirname(details.buildPath), '');
-        var sourceBinary = path.join(details.extractPath, buildDir, details.binName);
+        var sourceBinaryPath = path.join(details.extractPath, buildDir, details.binName);
         var tempTargetModulePath = path.join(tempBundlePath, details.modulePath);
-        var tempTargetBinary = path.join(tempTargetModulePath, details.buildPath, details.binName);
+        var tempTargetBinaryPath = path.join(tempTargetModulePath, details.buildPath, details.binName);
 
-        fs.copySync(sourceBinary, tempTargetBinary);
+        sourceBinaryPath = translations.reduce((accum, translation) => {
+          return accum.replace(translation.find, translation.replace);
+        }, sourceBinaryPath);
+
+        tempTargetBinaryPath = translations.reduce((accum, translation) => {
+          return accum.replace(translation.find, translation.replace);
+        }, tempTargetBinaryPath);
+
+        fs.copySync(sourceBinaryPath, tempTargetBinaryPath);
 
         // Also ensure that package.json was copied.
         fs.copySync(
@@ -1101,5 +1113,6 @@ actions.compress = function(source, options) {
 };
 
 if (global.IS_TEST_ENV) {
+  actions.deployLists = deployLists;
   module.exports = actions;
 }

--- a/test/unit/deploy.js
+++ b/test/unit/deploy.js
@@ -2351,6 +2351,41 @@ exports['deploy.injectBinaryModules'] = {
     });
   },
 
+  rewriteBinaryBuildPlatformPaths: function(test) {
+    test.expect(2);
+
+    this.forEach = sandbox.stub(Map.prototype, 'forEach', (handler) => {
+      handler({
+        binName: 'serialport.node',
+        buildPath: path.normalize('/build/Release/node-v46-FAKE_PLATFORM-FAKE_ARCH/'),
+        buildType: 'Release',
+        globPath: path.normalize('node_modules/serialport/build/Release/node-v46-FAKE_PLATFORM-FAKE_ARCH/serialport.node'),
+        ignored: false,
+        name: 'serialport',
+        modulePath: path.normalize('node_modules/serialport'),
+        resolved: true,
+        version: '2.0.6',
+        extractPath: path.normalize('~/.tessel/binaries/serialport-2.0.6-Release')
+      });
+    });
+
+    var find = deploy.deployLists.binaryPathTranslations['*'][0].find;
+
+    deploy.deployLists.binaryPathTranslations['*'][0].find = 'FAKE_PLATFORM-FAKE_ARCH';
+
+    deploy.injectBinaryModules(this.globRoot, fsTemp.mkdirSync()).then(() => {
+      // If the replacement operation did not work, these would still be
+      // "FAKE_PLATFORM-FAKE_ARCH"
+      test.equal(this.copySync.firstCall.args[0].endsWith('linux-mipsel/serialport.node'), true);
+      test.equal(this.copySync.firstCall.args[1].endsWith('linux-mipsel/serialport.node'), true);
+      // Restore the path translation...
+      deploy.deployLists.binaryPathTranslations['*'][0].find = find;
+
+      test.done();
+    });
+  },
+
+
   throwError: function(test) {
     test.expect(1);
 


### PR DESCRIPTION
If you've previously used serialport, you have a broken version of the cached binary. Clean it out with: 

```
rm -r ~/.tessel/binaries/serialport-2.0.6-Release/
```


Smoke Test: 


1. Set up project
  ```
  mkdir serialdemo; cd serialdemo; 
  t2 init;
  npm install firmata;
  touch blink.js;
  ```

2. Paste this into blink.js: 
  ```js
  var Board = require("firmata");
  var board = new Board("/dev/ttyACM0");

  board.on("ready", function() {
    var pin = 13;
    var state = 1;

    board.pinMode(pin, board.MODES.OUTPUT);

    setInterval(function() {
      board.digitalWrite(pin, (state ^= 1));
    }, 500);
  });
  ```
3. Plug an Arduino into your Tessel 2
4. Run `t2 run blink.js`


The Arduino's L or an LED plugged into pin 13 should be blinking. 

