### PR TITLE
Add a crash reporter to diagnose CLI crashes.

### DIFF
--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -15,6 +15,7 @@ updateNotifier({
 
 // Internal
 var controller = require('../lib/controller');
+var CrashReporter = require('../lib/crash_reporter');
 var init = require('../lib/init');
 var logs = require('../lib/logs');
 var drivers = require('./tessel-install-drivers');
@@ -76,6 +77,42 @@ parser.command('install-drivers')
       .then(module.exports.closeSuccessfulCommand, module.exports.closeFailedCommand);
   })
   .help('Install drivers');
+
+parser.command('crash-reporter')
+  .callback(opts => {
+    // t2 crash-reporter --on
+    if (opts.on) {
+      return CrashReporter.on().then(() => {
+        // t2 crash-reporter --on --test
+        if (opts.test) {
+          CrashReporter.test().then(module.exports.closeSuccessfulCommand);
+        }
+      }).then(module.exports.closeSuccessfulCommand, module.exports.closeFailedCommand);
+    } else if (opts.off) {
+      // t2 crash-reporter --on
+      return CrashReporter.off()
+        .then(module.exports.closeSuccessfulCommand, module.exports.closeFailedCommand);
+    }
+
+    // t2 crash-reporter --test
+    if (opts.test) {
+      // not handling failures, as we want to trigger a crash
+      CrashReporter.test()
+        .then(module.exports.closeSuccessfulCommand);
+    }
+  })
+  .option('off', {
+    flag: true,
+    help: 'Disable the Crash Reporter.'
+  })
+  .option('on', {
+    flag: true,
+    help: 'Enable the Crash Reporter.'
+  })
+  .option('test', {
+    flag: true,
+    help: 'Test the Crash Reporter.'
+  });
 
 parser.command('provision')
   .callback(callControllerCallback('provisionTessel'))

--- a/lib/crash_reporter.js
+++ b/lib/crash_reporter.js
@@ -1,0 +1,110 @@
+// System Objects
+var os = require('os');
+
+// Third Party Dependencies
+var request = require('request');
+var tags = require('common-tags');
+
+// Internal
+var logs = require('./logs');
+var packageJson = require('../package.json');
+var Preferences = require('./preferences');
+
+// the value of the crash reporter preference
+// the value has to be one of 'on' or 'off'
+var CRASH_REPORTER_PREFERENCE = 'crash.reporter.preference';
+var SUBMIT_CRASH_URL = 'http://crash-reporter.tessel.io/crashes/submit';
+
+// override for testing
+if (process.env.DEV_MODE === 'true') {
+  SUBMIT_CRASH_URL = 'http://localhost:8080/crashes/submit';
+}
+
+var CrashReporter = {};
+
+CrashReporter.off = function() {
+  return Preferences.write(CRASH_REPORTER_PREFERENCE, 'off')
+    .catch(error => {
+      // do nothing
+      // do not crash the crash reporter :)
+      logs.err('Error turning off crash reporter preferences', error);
+    });
+};
+
+CrashReporter.on = function() {
+  return Preferences.write(CRASH_REPORTER_PREFERENCE, 'on')
+    .catch(error => {
+      // do nothing
+      // do not crash the crash reporter :)
+      logs.err('Error turning on crash reporter preferences', error);
+    });
+};
+
+CrashReporter.submit = function(report) {
+  return Preferences.read(CRASH_REPORTER_PREFERENCE, 'on')
+    .then(value => {
+      if (value === 'on') {
+        var labels = tags.stripIndent `
+          ${packageJson.name},
+          CLI version: ${packageJson.version},
+          Node version: ${process.version},
+          OS platform: ${os.platform()},
+          OS release: ${os.release()}
+        `;
+
+        CrashReporter.post(labels, report)
+          .then(() => {
+            logs.info('Done !');
+          })
+          .catch(error => {
+            logs.err('Error submitting crash report', error);
+          });
+      }
+    })
+    .catch(error => {
+      // do nothing
+      // do not crash the crash reporter :)
+      logs.err('Error submitting crash report', error);
+    });
+};
+
+CrashReporter.post = function(labels, report) {
+  return new Promise((resolve, reject) => {
+    request.post({
+      url: SUBMIT_CRASH_URL,
+      form: {
+        crash: report,
+        labels: labels,
+        f: 'json'
+      }
+    }, (error, httpResponse, body) => {
+      try {
+        if (error) {
+          reject(error);
+        } else {
+          var json = JSON.parse(body);
+          if (json.error) {
+            reject(json.error);
+          } else {
+            resolve();
+          }
+        }
+      } catch (exception) {
+        reject(exception);
+      }
+    });
+  });
+};
+
+CrashReporter.test = () => {
+  return Promise.reject(new Error('Testing the crash reporter'));
+};
+
+var onError = error => {
+  return CrashReporter.submit(error.stack);
+};
+
+process.on('unhandledRejection', onError);
+process.on('uncaughtException', onError);
+
+module.exports = CrashReporter;

--- a/lib/preferences.js
+++ b/lib/preferences.js
@@ -1,0 +1,70 @@
+// System Objects
+var path = require('path');
+
+// Third Party Dependencies
+var fs = require('fs-extra');
+
+// Internal
+var logs = require('./logs');
+
+
+var home = (process.platform.startsWith('win')) ? process.env.HOMEPATH : process.env.HOME;
+var preferencesJson = path.join(home, '.tessel', 'preferences.json');
+var Preferences = {};
+
+Preferences.read = function(key, defaultValue) {
+  return Preferences.load().then(contents => {
+      if (contents) {
+        return contents[key] || defaultValue;
+      } else {
+        return defaultValue;
+      }
+    })
+    .catch(error => {
+      logs.err('Error reading preference', key, error);
+      return defaultValue;
+    });
+};
+
+Preferences.write = function(key, value) {
+  return new Promise((resolve, reject) => {
+    Preferences.load()
+      .then(contents => {
+        contents = contents || {};
+        contents[key] = value;
+        fs.writeFile(preferencesJson, JSON.stringify(contents), function(error) {
+          if (error) {
+            logs.err('Error writing preference', key, value);
+            reject(error);
+          } else {
+            resolve();
+          }
+        });
+      })
+      .catch(error => {
+        reject(error);
+      });
+  });
+};
+
+Preferences.load = function() {
+  return new Promise((resolve, reject) => {
+    fs.exists(preferencesJson, (exists) => {
+      if (exists) {
+        fs.readFile(preferencesJson, (error, data) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve(JSON.parse(data));
+          }
+        });
+      } else {
+        // we don't have any local preferences
+        // return falsy value
+        resolve();
+      }
+    });
+  });
+};
+
+module.exports = Preferences;

--- a/test/common/bootstrap.js
+++ b/test/common/bootstrap.js
@@ -43,6 +43,8 @@ global.provision = require('../../lib/tessel/provision');
 global.deployLists = require('../../lib/tessel/deploy-lists');
 
 // ./lib/*
+global.CrashReporter = require('../../lib/crash_reporter');
+global.Preferences = require('../../lib/preferences');
 global.controller = require('../../lib/controller');
 global.discover = require('../../lib/discover');
 global.logs = require('../../lib/logs');

--- a/test/unit/crash-reporter.js
+++ b/test/unit/crash-reporter.js
@@ -1,0 +1,181 @@
+/*global CrashReporter */
+/*global Preferences */
+
+exports['CrashReporter'] = {
+  surface: function(test) {
+    test.expect(5);
+    test.equal(typeof CrashReporter.on, 'function');
+    test.equal(typeof CrashReporter.off, 'function');
+    test.equal(typeof CrashReporter.post, 'function');
+    test.equal(typeof CrashReporter.submit, 'function');
+    test.equal(typeof CrashReporter.test, 'function');
+    test.done();
+  }
+};
+
+exports['CrashReporter.on'] = {
+  setUp: function(done) {
+    this.sandbox = sinon.sandbox.create();
+    this.logsErr = this.sandbox.stub(logs, 'err');
+    this.pWrite = this.sandbox.stub(Preferences, 'write').returns(Promise.resolve());
+    done();
+  },
+
+  tearDown: function(done) {
+    this.sandbox.restore();
+    done();
+  },
+
+  onSuccess: function(test) {
+    test.expect(1);
+
+    CrashReporter.on().then(() => {
+      test.equal(this.pWrite.callCount, 1);
+      test.done();
+    });
+  },
+
+  onFailure: function(test) {
+    test.expect(2);
+    this.pWrite.restore();
+    this.pWrite = this.sandbox.stub(Preferences, 'write').returns(Promise.reject());
+
+    // Despite the write failure, we don't _want_ to crash the crash reporter
+    CrashReporter.on().then(() => {
+      test.equal(this.pWrite.callCount, 1);
+      test.equal(this.logsErr.callCount, 1);
+      test.done();
+    });
+  },
+
+};
+
+exports['CrashReporter.off'] = {
+  setUp: function(done) {
+    this.sandbox = sinon.sandbox.create();
+    this.logsErr = this.sandbox.stub(logs, 'err');
+    this.pWrite = this.sandbox.stub(Preferences, 'write').returns(Promise.resolve());
+    done();
+  },
+
+  tearDown: function(done) {
+    this.sandbox.restore();
+    done();
+  },
+
+  offSuccess: function(test) {
+    test.expect(1);
+
+    CrashReporter.off().then(() => {
+      test.equal(this.pWrite.callCount, 1);
+      test.done();
+    });
+  },
+
+  offFailure: function(test) {
+    test.expect(2);
+    this.pWrite.restore();
+    this.pWrite = this.sandbox.stub(Preferences, 'write').returns(Promise.reject());
+
+    // Despite the write failure, we don't _want_ to crash the crash reporter
+    CrashReporter.off().then(() => {
+      test.equal(this.pWrite.callCount, 1);
+      test.equal(this.logsErr.callCount, 1);
+      test.done();
+    });
+  },
+
+};
+
+exports['CrashReporter.submit'] = {
+  setUp: function(done) {
+    this.sandbox = sinon.sandbox.create();
+    this.logsErr = this.sandbox.stub(logs, 'err');
+    this.logsInfo = this.sandbox.stub(logs, 'info');
+    this.pRead = this.sandbox.stub(Preferences, 'read').returns(Promise.resolve('on'));
+    this.pWrite = this.sandbox.stub(Preferences, 'write').returns(Promise.resolve());
+    this.crPost = this.sandbox.spy(CrashReporter, 'post');
+    this.request = this.sandbox.stub(request, 'post', (opts, handler) => {
+      return handler(null, {}, '{}');
+    });
+    done();
+  },
+
+  tearDown: function(done) {
+    this.sandbox.restore();
+    done();
+  },
+
+  submit: function(test) {
+    test.expect(7);
+
+    var report = 'Error: undefined is not a function';
+    CrashReporter.submit(report).then(() => {
+      var args = this.crPost.lastCall.args;
+      test.equal(this.crPost.callCount, 1);
+      test.equal(typeof args[0], 'string');
+      test.ok(args[0].indexOf('CLI version') > 0, 'Label CLI version should be present');
+      test.ok(args[0].indexOf('Node version') > 0, 'Label Node version should be present');
+      test.ok(args[0].indexOf('OS platform') > 0, 'Label OS platform should be present');
+      test.ok(args[0].indexOf('OS release') > 0, 'Label OS release should be present');
+      test.equal(args[1], report);
+      test.done();
+    });
+  },
+};
+
+exports['CrashReporter.post'] = {
+  setUp: function(done) {
+    this.sandbox = sinon.sandbox.create();
+    this.logsErr = this.sandbox.stub(logs, 'err');
+    this.logsInfo = this.sandbox.stub(logs, 'info');
+    this.pRead = this.sandbox.stub(Preferences, 'read').returns(Promise.resolve('on'));
+    this.pWrite = this.sandbox.stub(Preferences, 'write').returns(Promise.resolve());
+    this.crPost = this.sandbox.spy(CrashReporter, 'post');
+    this.request = this.sandbox.stub(request, 'post', (opts, handler) => {
+      return handler(null, {}, '{}');
+    });
+    done();
+  },
+
+  tearDown: function(done) {
+    this.sandbox.restore();
+    done();
+  },
+
+  post: function(test) {
+    test.expect(4);
+
+    var labels = 'foo';
+    var report = 'Error: undefined is not a function';
+
+    CrashReporter.post(labels, report).then(() => {
+      var args = this.request.lastCall.args;
+      test.equal(this.request.callCount, 1);
+      test.equal(args[0].form.crash, report);
+      test.equal(args[0].form.labels, labels);
+      test.equal(args[0].form.f, 'json');
+      test.done();
+    });
+  },
+
+  postWithBadResponse: function(test) {
+    test.expect(2);
+
+    this.request.restore();
+    this.request = this.sandbox.stub(request, 'post', (opts, handler) => {
+      return handler(null, {}, '** {Bad Response} **');
+    });
+
+    var message = 'Bad response should have caused a failure';
+    CrashReporter.post().then(() => {
+      test.ok(false, message);
+      test.done();
+    }).catch(error => {
+      test.notEqual(error, null, 'Error cannot be null');
+      test.ok(true, message);
+      test.done();
+    });
+  },
+
+};

--- a/test/unit/preferences.js
+++ b/test/unit/preferences.js
@@ -1,0 +1,125 @@
+/*global Preferences */
+
+exports['Preferences'] = {
+  surface: function(test) {
+    test.expect(3);
+    test.equal(typeof Preferences.read, 'function');
+    test.equal(typeof Preferences.write, 'function');
+    test.equal(typeof Preferences.load, 'function');
+    test.done();
+  }
+};
+
+exports['Preferences.load'] = {
+  setUp: function(done) {
+    this.sandbox = sinon.sandbox.create();
+    this.logsErr = this.sandbox.stub(logs, 'err');
+    this.logsInfo = this.sandbox.stub(logs, 'info');
+
+    this.exists = this.sandbox.stub(fs, 'exists', (file, handler) => {
+      handler(true);
+    });
+    this.readFile = this.sandbox.stub(fs, 'readFile', (file, handler) => {
+      handler(null, '{}');
+    });
+    done();
+  },
+  tearDown: function(done) {
+    this.sandbox.restore();
+    done();
+  },
+
+  load: function(test) {
+    test.expect(2);
+
+    Preferences.load().then(() => {
+      test.equal(this.exists.callCount, 1);
+      test.equal(this.exists.lastCall.args[0].endsWith('preferences.json'), true);
+      test.done();
+    });
+  },
+};
+
+exports['Preferences.read'] = {
+  setUp: function(done) {
+    this.sandbox = sinon.sandbox.create();
+    this.logsErr = this.sandbox.stub(logs, 'err');
+    this.logsInfo = this.sandbox.stub(logs, 'info');
+
+    this.exists = this.sandbox.stub(fs, 'exists', (file, handler) => {
+      handler(true);
+    });
+    done();
+  },
+  tearDown: function(done) {
+    this.sandbox.restore();
+    done();
+  },
+
+  readWithDefaults: function(test) {
+    test.expect(1);
+
+    var defaultValue = 'value';
+    this.readFile = this.sandbox.stub(fs, 'readFile', (file, handler) => {
+      handler(null, '{}');
+    });
+
+    Preferences.read('key', defaultValue).then(result => {
+      test.equal(result, defaultValue);
+      test.done();
+    });
+  },
+
+  readSetValues: function(test) {
+    test.expect(1);
+
+    var defaultValue = null;
+    var value = 'value';
+    this.readFile = this.sandbox.stub(fs, 'readFile', (file, handler) => {
+      handler(null, `{"key": "${value}"}`);
+    });
+
+    Preferences.read('key', defaultValue).then(result => {
+      test.equal(result, value);
+      test.done();
+    });
+  }
+};
+
+exports['Preferences.write'] = {
+  setUp: function(done) {
+    this.sandbox = sinon.sandbox.create();
+    this.state = {};
+    this.logsErr = this.sandbox.stub(logs, 'err');
+    this.logsInfo = this.sandbox.stub(logs, 'info');
+    this.exists = this.sandbox.stub(fs, 'exists', (file, handler) => {
+      handler(true);
+    });
+    this.readFile = this.sandbox.stub(fs, 'readFile', (file, handler) => {
+      handler(null, JSON.stringify(this.state));
+    });
+    this.writeFile = this.sandbox.stub(fs, 'writeFile', (file, data, handler) => {
+      this.state = JSON.parse(data);
+      handler(null);
+    });
+    done();
+  },
+
+  tearDown: function(done) {
+    this.sandbox.restore();
+    done();
+  },
+
+  write: function(test) {
+    test.expect(2);
+
+    var key = 'key';
+    var value = 'value';
+
+    Preferences.write(key, value).then(() => {
+      test.equal(true, this.state.hasOwnProperty(key));
+      test.equal(value, this.state[key]);
+      test.done();
+    });
+  }
+};


### PR DESCRIPTION
All crashes get submitted by default. The user can turn off crash reporting if he wants to.