### PR TITLE
change erase log reference from tessel to t2

### DIFF
--- a/lib/tessel/erase.js
+++ b/lib/tessel/erase.js
@@ -25,7 +25,7 @@ Tessel.prototype.eraseScript = function() {
       // If we get a notice that the command failed
       if (error.message.indexOf('Command failed') !== -1) {
         // Let the user know what went wrong
-        return Promise.reject('No files have been pushed. Run `tessel push FILE` to push to Flash.');
+        return Promise.reject('No files have been pushed. Run `t2 push FILE` to push to Flash.');
       } else {
         // Otherwise this is an unexpected error
         return Promise.reject('An unexpected error occurred:' + error.message);


### PR DESCRIPTION
Fixed the log output for `t2 erase` to reference `t2` instead of `tessel`