### PR TITLE
Do not local path.join(...) for remote system paths. Fixes gh-632

### DIFF
--- a/lib/tessel/update.js
+++ b/lib/tessel/update.js
@@ -1,5 +1,5 @@
 // System Objects
-var path = require('path');
+// ...
 
 // Third Party Dependencies
 // ...
@@ -10,7 +10,7 @@ var logs = require('../logs');
 var Tessel = require('./tessel');
 var updates = require('../update-fetch');
 
-var updatePath = path.join('/tmp/', updates.OPENWRT_BINARY_FILE);
+var updatePath = `/tmp/${updates.OPENWRT_BINARY_FILE}`;
 var remoteVersioningFile = '/etc/tessel-version';
 
 /*


### PR DESCRIPTION
Fairly critical, as this will definitely be breaking `t2 update` on windows. I've tested on both OSX and Windows, so once this goes green I'm making an executive decision to land and release today.


Signed-off-by: Rick Waldron <waldron.rick@gmail.com>