### PR TITLE
warn about ignore folder

### DIFF
--- a/lib/tessel/deploy.js
+++ b/lib/tessel/deploy.js
@@ -731,6 +731,21 @@ actions.tarBundle = function(opts) {
 
   var includeRules = actions.glob.rules(target, '.tesselinclude');
 
+  // assuming a programmer could miss to add .tesselinclude
+  // if there are project folders
+  try {
+    fs.statSync('.tesselinclude');
+  } catch (e) {
+    var dirList = fs.readdirSync('./');
+    dirList.forEach(function(element) {
+      if (element !== 'node_modules' && fs.lstatSync(element).isDirectory()) {
+        // blame for directories because is seams the programmer
+        // forgot to create .tesselinclude and add it into it
+        logs.warn('Ignoring ./' + element + ' (.tesselinclude does not exist)');
+      }
+    });
+  }
+
   // Convert `deployLists.includes` into includeRules
   deployLists.includes.forEach(include => includeRules.push(`node_modules/**/${include}`));
 

--- a/lib/tessel/deploy.js
+++ b/lib/tessel/deploy.js
@@ -734,16 +734,21 @@ actions.tarBundle = function(opts) {
   // assuming a programmer could miss to add .tesselinclude
   // if there are project folders
   try {
-    fs.statSync('.tesselinclude');
+    fs.statSync(globRoot+'/.tesselinclude');
   } catch (e) {
-    var dirList = fs.readdirSync('./');
+    var dirList = fs.readdirSync(globRoot);
+    var list = [];
     dirList.forEach(function(element) {
-      if (element !== 'node_modules' && fs.lstatSync(element).isDirectory()) {
+      if (element !== 'node_modules' && fs.lstatSync(globRoot+'/'+element).isDirectory()) {
         // blame for directories because is seams the programmer
         // forgot to create .tesselinclude and add it into it
-        logs.warn('Ignoring ./' + element + ' (.tesselinclude does not exist)');
+        list.push(element);
       }
     });
+    if (list.length > 0) {
+      logs.warn('Ignored folders due to missing .tesselinclude:');
+      list.forEach(list => console.log(list));
+    }
   }
 
   // Convert `deployLists.includes` into includeRules


### PR DESCRIPTION
Some people doing their first project on Tessel could be confused if
they didn’t read there has to be a `.tesselinclude` to deploy folders.
This PR adds the following warning if not `.tesselinclude` exists (for
each folder found)
```
INFO Looking for your Tessel...
INFO Connected to Third.
WARN Ignoring ./public (.tesselinclude does not exist)
INFO Building project.
INFO Writing project to RAM on Third (1508.864 kB)...
INFO Deployed.
INFO Running index.js...
```