### PR TITLE
uglify warn with filename

### DIFF
--- a/lib/tessel/deploy.js
+++ b/lib/tessel/deploy.js
@@ -803,6 +803,7 @@ actions.tarBundle = function(opts) {
           dependencies.forEach(dependency => {
             var isJS = dependency.file.endsWith('.js');
             var source = dependency.source;
+            var file = dependency.file;
             var target = path.normalize(dependency.file.replace(absRoot, tempBundleDir));
             var compressionOptions = deployLists.compressionOptions[dependency.packageName];
 
@@ -812,7 +813,7 @@ actions.tarBundle = function(opts) {
 
             if (isJS) {
               try {
-                source = actions.compress(source, compressionOptions);
+                source = actions.compress(source, compressionOptions, file);
               } catch (error) {
                 reject(error);
               }
@@ -1018,7 +1019,7 @@ actions.project = function(options) {
   return new Project(options);
 };
 
-actions.compress = function(source, options) {
+actions.compress = function(source, options, file) {
   source = typeof source === 'string' ? source : source.toString();
 
   options = options || {
@@ -1094,6 +1095,7 @@ actions.compress = function(source, options) {
       // the edge cases ourselves. This also means
       // that ES6 code won't trigger false failures
       // on minifier parsers that haven't been updated.
+      logs.warn(uglifyError.message + ' at line ' + uglifyError.line + ':' + uglifyError.col + ' in file: ' + file);
       return source;
     }
   }

--- a/lib/tessel/deploy.js
+++ b/lib/tessel/deploy.js
@@ -1095,7 +1095,7 @@ actions.compress = function(source, options, file) {
       // the edge cases ourselves. This also means
       // that ES6 code won't trigger false failures
       // on minifier parsers that haven't been updated.
-      logs.warn(uglifyError.message + ' at line ' + uglifyError.line + ':' + uglifyError.col + ' in file: ' + file);
+      logs.warn(`${uglifyError.message} at line ${uglifyError.line}: ${uglifyError.col} in file: ${file}`);
       return source;
     }
   }


### PR DESCRIPTION
Due to hard debugging problems I decided to publish this solution as a
PR. It creates WARN messages if the final uglify process lands in the
last catch and gives reasonable feedback like this:
```
WARN Unexpected token operator «*», expected punc «(» at line 55:18 in
file: /Users/Student007/tessel2/experiment1/index.js
```