### PR TITLE
Type of option 'password' should be string

### DIFF
--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -228,6 +228,7 @@ makeCommand('wifi')
   .option('password', {
     abbr: 'p',
     metavar: 'PASSWORD',
+    type: 'string',
     help: 'Set the password of the network to connect to'
   })
   .option('security', {


### PR DESCRIPTION
When your wifi password contains only numbers and is long the cli converts it to a number with exponential representation. This breaks the configuration.

```
$ t2 wifi -n MySSID -p 432565XXXXXXXXXXXXXXXXXXXXXXXXXXXXX8743
INFO Looking for your Tessel...
INFO Connected to Tessel.
INFO Wifi Enabled.
INFO Wifi Connected. SSID: MySSID, password: 4.32565XXXXXXXXXXXXX+39, security: psk2
```