### PR TITLE
show tessel.connectionType before tessel.name

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -104,7 +104,7 @@ Tessel.list = function(opts) {
       }
 
       // Print out details...
-      logs.basic(sprintf('\t%s\t%s\t%s', tessel.name, tessel.connection.connectionType, note));
+      logs.basic(sprintf('\t%s\t%s\t%s', tessel.connection.connectionType, tessel.name, note));
     });
 
     // Called after CTRL+C or timeout
@@ -229,8 +229,8 @@ Tessel.get = function(opts) {
                         var authorization = isAuthorized ? '' : '(not authorized)';
                         var display = sprintf(
                           '\t%s\t%s\t%s',
-                          tessel.name,
                           tessel.connection.connectionType,
+                          tessel.name,
                           authorization
                         );
 


### PR DESCRIPTION
moved tessel.connectionType in front of tessel.name for `t2 list` to improve readability of output.