### PR TITLE
add option n for update command to not save config

### DIFF
--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -353,6 +353,12 @@ makeCommand('update')
     flag: true,
     help: 'Update to the latest version regardless of current version.'
   })
+  .option('delete', {
+    abbr: 'd',
+    required: false,
+    flag: true,
+    help: 'Delete configuration files during update.'
+  })
   .option('openwrt-path', {
     abbr: 'op',
     required: false,

--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -353,11 +353,11 @@ makeCommand('update')
     flag: true,
     help: 'Update to the latest version regardless of current version.'
   })
-  .option('delete', {
-    abbr: 'd',
+  .option('n', {
+    abbr: 'n',
     required: false,
     flag: true,
-    help: 'Delete configuration files during update.'
+    help: 'Do not save configuration during update.'
   })
   .option('openwrt-path', {
     abbr: 'op',

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -800,7 +800,7 @@ controller.printAvailableUpdates = function() {
   });
 };
 
-controller.update = function(opts) {
+controller.update = function(opts) {  
   opts.authorized = true;
   return controller.standardTesselCommand(opts, function(tessel) {
     if (opts.openwrtPath || opts.firmwarePath) {
@@ -813,7 +813,7 @@ controller.update = function(opts) {
 
 controller.updateWithLocalBuilds = function(opts, tessel) {
   return updates.loadLocalBinaries(opts)
-    .then((images) => tessel.update(images))
+    .then((images) => tessel.update(opts, images))
     .then(() => logs.info('Finished updating Tessel with local builds.'));
 };
 
@@ -925,7 +925,7 @@ controller.updateTesselWithVersion = function(opts, tessel, currentVersion, buil
   return updates.fetchBuild(build)
     .then(function startUpdate(image) {
       // Update Tessel with it
-      return tessel.update(image)
+      return tessel.update(opts, image)
         // Log that the update completed
         .then(function logCompletion() {
           if (!opts.force) {

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -800,7 +800,7 @@ controller.printAvailableUpdates = function() {
   });
 };
 
-controller.update = function(opts) {  
+controller.update = function(opts) {
   opts.authorized = true;
   return controller.standardTesselCommand(opts, function(tessel) {
     if (opts.openwrtPath || opts.firmwarePath) {

--- a/lib/tessel/commands.js
+++ b/lib/tessel/commands.js
@@ -88,6 +88,9 @@ module.exports.callTesselMDNS = function(action) {
 module.exports.sysupgrade = function(path) {
   return ['sysupgrade', path];
 };
+module.exports.sysupgradeNoSaveConfig = function(path) {
+  return ['sysupgrade', '-n', path];
+};
 module.exports.getMemoryInfo = function() {
   return ['cat', '/proc/meminfo'];
 };

--- a/lib/tessel/update.js
+++ b/lib/tessel/update.js
@@ -27,7 +27,7 @@ Tessel.prototype.fetchCurrentBuildInfo = function() {
     });
 };
 
-Tessel.prototype.update = function(opts, newImage) {  
+Tessel.prototype.update = function(opts, newImage) {
   return new Promise((resolve) => {
       if (newImage.openwrt.length > 0) {
         return this.updateOpenWRT(opts, newImage.openwrt).then(resolve);
@@ -79,18 +79,17 @@ Tessel.prototype.updateOpenWRT = function(opts, image) {
         // Begin the sysupgrade
         logs.info('Starting OpenWRT update.');
         logs.info('Please do not remove power from Tessel.');
-        logs.info('This process will take at least two minutes...');         
-        
+        logs.info('This process will take at least two minutes...');
+
         var sysupgradeCommand = [];
-        if (opts.delete) {                             
+        if (opts.delete) {
           logs.info('Configuration Files will be deleted.');
           sysupgradeCommand = commands.sysupgradeNoSaveConfig(updatePath);
-        }
-        else {
+        } else {
           logs.info('Configuration Files will not be deleted.');
           sysupgradeCommand = commands.sysupgrade(updatePath);
         }
-        
+
         // The USBDaemon will cut out or the SSH command will close        
         this.connection.exec(sysupgradeCommand, (err, remoteProc) => {
           if (err) {

--- a/lib/tessel/update.js
+++ b/lib/tessel/update.js
@@ -27,10 +27,10 @@ Tessel.prototype.fetchCurrentBuildInfo = function() {
     });
 };
 
-Tessel.prototype.update = function(newImage) {
+Tessel.prototype.update = function(opts, newImage) {  
   return new Promise((resolve) => {
       if (newImage.openwrt.length > 0) {
-        return this.updateOpenWRT(newImage.openwrt).then(resolve);
+        return this.updateOpenWRT(opts, newImage.openwrt).then(resolve);
       } else {
         logs.warn('No OpenWRT binary loaded... skipping OpenWRT update');
         resolve();
@@ -48,7 +48,7 @@ Tessel.prototype.update = function(newImage) {
     });
 };
 
-Tessel.prototype.updateOpenWRT = function(image) {
+Tessel.prototype.updateOpenWRT = function(opts, image) {
   // This ensures usb updates will work on older OpenWRT images
   // by overwriting the upgrade file
   return this.fixOldUpdateScripts()
@@ -79,9 +79,20 @@ Tessel.prototype.updateOpenWRT = function(image) {
         // Begin the sysupgrade
         logs.info('Starting OpenWRT update.');
         logs.info('Please do not remove power from Tessel.');
-        logs.info('This process will take at least two minutes...');
-        // The USBDaemon will cut out or the SSH command will close
-        this.connection.exec(commands.sysupgrade(updatePath), (err, remoteProc) => {
+        logs.info('This process will take at least two minutes...');         
+        
+        var sysupgradeCommand = [];
+        if (opts.delete) {                             
+          logs.info('Configuration Files will be deleted.');
+          sysupgradeCommand = commands.sysupgradeNoSaveConfig(updatePath);
+        }
+        else {
+          logs.info('Configuration Files will not be deleted.');
+          sysupgradeCommand = commands.sysupgrade(updatePath);
+        }
+        
+        // The USBDaemon will cut out or the SSH command will close        
+        this.connection.exec(sysupgradeCommand, (err, remoteProc) => {
           if (err) {
             return reject(err);
           } else {

--- a/lib/tessel/update.js
+++ b/lib/tessel/update.js
@@ -82,11 +82,11 @@ Tessel.prototype.updateOpenWRT = function(opts, image) {
         logs.info('This process will take at least two minutes...');
 
         var sysupgradeCommand = [];
-        if (opts.delete) {
-          logs.info('Configuration Files will be deleted.');
+        if (opts.n) {
+          logs.info('Configuration is not saved during update.');
           sysupgradeCommand = commands.sysupgradeNoSaveConfig(updatePath);
         } else {
-          logs.info('Configuration Files will not be deleted.');
+          logs.info('Configuration is saved during update.');
           sysupgradeCommand = commands.sysupgrade(updatePath);
         }
 

--- a/test/unit/update.js
+++ b/test/unit/update.js
@@ -366,7 +366,7 @@ exports['controller.update'] = {
   },
 
   buildLatestNoConfigSave: function(test) {
-    test.expect(7);
+    test.expect(8);
 
     // Create a Tessel sim
     this.tessel = TesselSimulator({
@@ -399,6 +399,8 @@ exports['controller.update'] = {
         test.equal(this.update.callCount, 1);
         // It was provided the binaries and options
         test.equal(this.update.calledWith(opts, binaries), true);
+        // Provided Options match first parameter
+        test.deepEqual(this.update.lastCall.args[0], opts);
         // Then Tessel was closed
         test.equal(this.tessel.closed, true);
         // We closed all open Tessel connections

--- a/test/unit/update.js
+++ b/test/unit/update.js
@@ -364,7 +364,7 @@ exports['controller.update'] = {
         test.done();
       });
   },
-  
+
   buildLatestNoConfigSave: function(test) {
     test.expect(7);
 
@@ -726,9 +726,9 @@ exports['Tessel.update'] = {
       test.done();
     });
   },
-  
+
   configurationShouldNotBeSaved: function(test) {
-     var updatePath = `/tmp/${updates.OPENWRT_BINARY_FILE}`;
+    var updatePath = `/tmp/${updates.OPENWRT_BINARY_FILE}`;
 
     this.exec = this.sandbox.stub(this.tessel.connection, 'exec', (command, handler) => {
       handler(null, this.tessel._rps);
@@ -741,7 +741,9 @@ exports['Tessel.update'] = {
     this.openStdinToFile = this.sandbox.stub(commands, 'openStdinToFile');
     this.sysupgradeNoSaveConfig = this.sandbox.stub(commands, 'sysupgradeNoSaveConfig');
 
-    this.tessel.updateOpenWRT({"n": true}, this.newImage.openwrt).then(() => {
+    this.tessel.updateOpenWRT({
+      n: true
+    }, this.newImage.openwrt).then(() => {
       test.equal(this.openStdinToFile.callCount, 1);
       test.equal(this.sysupgradeNoSaveConfig.callCount, 1);
       test.equal(this.openStdinToFile.lastCall.args[0], updatePath);
@@ -750,7 +752,7 @@ exports['Tessel.update'] = {
     }).catch((error) => {
       test.ok(false, error);
       test.done();
-    });   
+    });
   },
 
   standardUpdate: function(test) {

--- a/test/unit/update.js
+++ b/test/unit/update.js
@@ -128,7 +128,7 @@ exports['controller.update'] = {
         // The Tessel was updated
         test.equal(this.update.callCount, 1);
         // The update used the appropriate binaries
-        test.equal(this.update.calledWith(binaries), true);
+        test.equal(this.update.calledWith(opts, binaries), true);
         // Then the Tessel was closed
         test.equal(this.tessel.closed, true);
         // We closed all open Tessel connections
@@ -210,7 +210,7 @@ exports['controller.update'] = {
         // Update Tessel was successfully called
         test.equal(this.update.callCount, 1);
         // It was provided the binaries
-        test.equal(this.update.calledWith(binaries), true);
+        test.equal(this.update.calledWith(opts, binaries), true);
         // Then Tessel was closed
         test.equal(this.tessel.closed, true);
         // We closed all open Tessel connections
@@ -350,7 +350,55 @@ exports['controller.update'] = {
         // Update Tessel was not called because it was already up to date
         test.equal(this.update.callCount, 1);
         // It was provided the binaries
-        test.equal(this.update.calledWith(binaries), true);
+        test.equal(this.update.calledWith(opts, binaries), true);
+        // Then Tessel was closed
+        test.equal(this.tessel.closed, true);
+        // We closed all open Tessel connections
+        test.equal(this.closeTesselConnections.callCount, 1);
+        // We called the close function with an array
+        test.equal(Array.isArray(this.closeTesselConnections.args[0]), true);
+        test.done();
+      })
+      .catch(error => {
+        test.ok(false, `update failed: ${error.toString()}`);
+        test.done();
+      });
+  },
+  
+  buildLatestNoConfigSave: function(test) {
+    test.expect(7);
+
+    // Create a Tessel sim
+    this.tessel = TesselSimulator({
+      type: 'USB',
+      end: () => Promise.resolve()
+    });
+
+    var binaries = {
+      firmware: new Buffer(0),
+      openwrt: new Buffer(0)
+    };
+
+    this.fetchBuild = this.sandbox.stub(updates, 'fetchBuild', function() {
+      return Promise.resolve(binaries);
+    });
+
+    var opts = {
+      force: true,
+      lanPrefer: true,
+      n: true
+    };
+
+    controller.update(opts)
+      .then(() => {
+        // We fetched only one build
+        test.equal(this.fetchBuild.callCount, 1);
+        // It was the latest build
+        test.equal(this.fetchBuild.calledWith(builds[1]), true);
+        // Update Tessel was not called because it was already up to date
+        test.equal(this.update.callCount, 1);
+        // It was provided the binaries and options
+        test.equal(this.update.calledWith(opts, binaries), true);
         // Then Tessel was closed
         test.equal(this.tessel.closed, true);
         // We closed all open Tessel connections
@@ -667,7 +715,7 @@ exports['Tessel.update'] = {
     this.openStdinToFile = this.sandbox.stub(commands, 'openStdinToFile');
     this.sysupgrade = this.sandbox.stub(commands, 'sysupgrade');
 
-    this.tessel.updateOpenWRT(this.newImage.openwrt).then(() => {
+    this.tessel.updateOpenWRT({}, this.newImage.openwrt).then(() => {
       test.equal(this.openStdinToFile.callCount, 1);
       test.equal(this.sysupgrade.callCount, 1);
       test.equal(this.openStdinToFile.lastCall.args[0], updatePath);
@@ -677,6 +725,32 @@ exports['Tessel.update'] = {
       test.ok(false, error);
       test.done();
     });
+  },
+  
+  configurationShouldNotBeSaved: function(test) {
+     var updatePath = `/tmp/${updates.OPENWRT_BINARY_FILE}`;
+
+    this.exec = this.sandbox.stub(this.tessel.connection, 'exec', (command, handler) => {
+      handler(null, this.tessel._rps);
+      setImmediate(() => {
+        this.tessel._rps.stdout.emit('data', new Buffer('Upgrade completed'));
+        this.tessel._rps.emit('close');
+      });
+    });
+
+    this.openStdinToFile = this.sandbox.stub(commands, 'openStdinToFile');
+    this.sysupgradeNoSaveConfig = this.sandbox.stub(commands, 'sysupgradeNoSaveConfig');
+
+    this.tessel.updateOpenWRT({"n": true}, this.newImage.openwrt).then(() => {
+      test.equal(this.openStdinToFile.callCount, 1);
+      test.equal(this.sysupgradeNoSaveConfig.callCount, 1);
+      test.equal(this.openStdinToFile.lastCall.args[0], updatePath);
+      test.equal(this.sysupgradeNoSaveConfig.lastCall.args[0], updatePath);
+      test.done();
+    }).catch((error) => {
+      test.ok(false, error);
+      test.done();
+    });   
   },
 
   standardUpdate: function(test) {
@@ -715,7 +789,7 @@ exports['Tessel.update'] = {
     });
 
     // Begin the update
-    this.tessel.update(this.newImage)
+    this.tessel.update({}, this.newImage)
       // Update completed as expected
       .then(() => {
         test.equal(this.updateFirmware.callCount, 1);


### PR DESCRIPTION
While trying to set up wifi manually via ssh and uci commands, my wifi settings were somehow broken. Even manually setting the wifi settings to another ad-hoc network was no longer working as only parts are overwritten by the cli tool and ssh was no longer working as there was no wifi possible anymore. On the other hand the update did not reset my configuration, so I essentially needed this fix to unbrick my tessel2. Any feedback is appreciated to get this merged. Workaround was originally posted in #619. @johnnyman727