### PR TITLE
Add Node version output to `t2 version` command

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -938,20 +938,32 @@ controller.updateTesselWithVersion = function(opts, tessel, currentVersion, buil
     });
 };
 
-controller.tesselFirmwareVerion = function(opts) {
+controller.tesselFirmwareVerion = opts => {
   opts.authorized = true;
-  return controller.standardTesselCommand(opts, function(tessel) {
+  return controller.standardTesselCommand(opts, tessel => {
+    var output = (thing, version) => `Tessel [${tessel.name}] ${thing} version: ${version}`;
+
     // Grab the version information
     return tessel.fetchCurrentBuildInfo()
-      .then(function(versionSha) {
-        return updates.requestBuildList().then(function(builds) {
+      .then(versionSha => {
+        return updates.requestBuildList().then(builds => {
           // Figure out what commit SHA is running on it
-          var version = updates.findBuild(builds, 'sha', versionSha).version;
-          logs.info('Tessel [' + tessel.name + '] version: ' + version);
+          var firmwareVersion = updates.findBuild(builds, 'sha', versionSha).version;
+
+          return tessel.fetchCurrentNodeVersion()
+            .then(nodeVersion => {
+              logs.info(output('Firmware', firmwareVersion));
+              logs.info(output('Node', nodeVersion));
+            })
+            .catch(() => {
+              logs.info(output('Firmware', firmwareVersion));
+              logs.info(output('Node', 'unknown'));
+            });
         });
       })
-      .catch(function() {
-        logs.info('Tessel [' + tessel.name + '] version: unknown');
+      .catch(() => {
+        logs.info(output('Firmware', 'unknown'));
+        logs.info(output('Node', 'unknown'));
       });
   });
 };

--- a/lib/tessel/tessel.js
+++ b/lib/tessel/tessel.js
@@ -126,4 +126,5 @@ require('./erase');
 require('./name');
 require('./provision');
 require('./update');
+require('./version');
 require('./wifi');

--- a/lib/tessel/version.js
+++ b/lib/tessel/version.js
@@ -1,0 +1,19 @@
+// System Objects
+// ...
+
+// Third Party Dependencies
+// ...
+
+// Internal
+var Tessel = require('./tessel');
+
+/*
+  Gathers node version.
+*/
+Tessel.prototype.fetchCurrentNodeVersion = function() {
+  return this.simpleExec(['node', '--version'])
+    .then(version => {
+      // strip the `v` preceding the version
+      return version.trim().substring(1);
+    });
+};

--- a/test/unit/version.js
+++ b/test/unit/version.js
@@ -1,0 +1,40 @@
+// Test dependencies are required and exposed in common/bootstrap.js
+
+exports['Tessel.prototype.fetchCurrentNodeVersion'] = {
+  setUp: function(done) {
+    this.sandbox = sinon.sandbox.create();
+    this.logsWarn = this.sandbox.stub(logs, 'warn', function() {});
+    this.logsInfo = this.sandbox.stub(logs, 'info', function() {});
+    this.logsBasic = this.sandbox.stub(logs, 'basic', function() {});
+    this.tessel = TesselSimulator();
+
+    this.simpleExec = this.sandbox.stub(Tessel.prototype, 'simpleExec', () => {
+      return Promise.resolve('v4.2.1');
+    });
+
+    done();
+  },
+
+  tearDown: function(done) {
+    this.sandbox.restore();
+    this.tessel.mockClose();
+
+    done();
+  },
+
+  properVersionReturned: function(test) {
+    test.expect(3);
+
+    this.tessel.fetchCurrentNodeVersion()
+      .then(version => {
+        test.equal(this.simpleExec.callCount, 1);
+        test.equal(this.simpleExec.calledWith(['node', '--version']), true);
+        test.equal(version, '4.2.1');
+        test.done();
+      })
+      .catch(error => {
+        test.ok(false, `properVersionReturned failed: ${error.toString()}`);
+        test.done();
+      });
+  }
+};


### PR DESCRIPTION
Fixes #667 

This adds additional information to the `t2 version` command. If for some reason it fails to fetch the Node version, but was able to get the firmware version, it will output just that along with unknown for the Node version.

If it fails to get the firmware version first then it skips trying to get the Node version and just outputs unknown for both versions.

All the tests pass. There weren't any currently testing `controller.tesselFirmwareVerion` function, so I added those with this as well since I touched that function. I would love some feedback on the tests as I am pretty green with Sinon. :)

Also, note that `Verion` above should be `Version`, but I opted to not correct the spelling and would tackle that in a separate PR. Trying not to do so much here, but if you would like, I could rename that in this PR as well.