### PR TITLE
Rename `tesselFirmwareVerion` to `tesselEnvVersions`. Fixes gh-682

### DIFF
--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -389,7 +389,7 @@ makeCommand('update')
   .help('Update the Tessel firmware and openWRT image');
 
 makeCommand('version')
-  .callback(callControllerCallback('tesselFirmwareVerion'))
+  .callback(callControllerCallback('tesselEnvVersions'))
   .help('Display Tessel\'s current firmware version');
 
 makeCommand('ap')

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -938,7 +938,7 @@ controller.updateTesselWithVersion = function(opts, tessel, currentVersion, buil
     });
 };
 
-controller.tesselFirmwareVerion = opts => {
+controller.tesselEnvVersions = opts => {
   opts.authorized = true;
   return controller.standardTesselCommand(opts, tessel => {
     var output = (thing, version) => `Tessel [${tessel.name}] ${thing} version: ${version}`;

--- a/test/unit/controller.js
+++ b/test/unit/controller.js
@@ -350,7 +350,7 @@ exports['controller.runHeuristics'] = {
   }
 };
 
-exports['controller.tesselFirmwareVerion'] = {
+exports['controller.tesselEnvVersions'] = {
   setUp: function(done) {
     this.sandbox = sinon.sandbox.create();
     this.logsWarn = this.sandbox.stub(logs, 'warn', function() {});
@@ -386,7 +386,7 @@ exports['controller.tesselFirmwareVerion'] = {
 
     var opts = {};
 
-    controller.tesselFirmwareVerion(opts)
+    controller.tesselEnvVersions(opts)
       .then(() => {
         // Version command was sent
         test.equal(this.standardTesselCommand.callCount, 1);
@@ -428,7 +428,7 @@ exports['controller.tesselFirmwareVerion'] = {
 
     var opts = {};
 
-    controller.tesselFirmwareVerion(opts)
+    controller.tesselEnvVersions(opts)
       .then(() => {
         // Version command was sent
         test.equal(this.standardTesselCommand.callCount, 1);
@@ -470,7 +470,7 @@ exports['controller.tesselFirmwareVerion'] = {
 
     var opts = {};
 
-    controller.tesselFirmwareVerion(opts)
+    controller.tesselEnvVersions(opts)
       .then(() => {
         // Version command was sent
         test.equal(this.standardTesselCommand.callCount, 1);


### PR DESCRIPTION
This fixes the incorrect spelling of the word version and also renames the method to a more appropriate name.