### PR TITLE
Add CLI version to `t2 version` command output (#604)

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -947,6 +947,7 @@ controller.updateTesselWithVersion = function(opts, tessel, currentVersion, buil
 controller.tesselEnvVersions = opts => {
   opts.authorized = true;
   return controller.standardTesselCommand(opts, tessel => {
+    var cliVersion = require('../package.json').version;
     var output = (thing, version) => `Tessel [${tessel.name}] ${thing} version: ${version}`;
 
     // Grab the version information
@@ -958,16 +959,19 @@ controller.tesselEnvVersions = opts => {
 
           return tessel.fetchCurrentNodeVersion()
             .then(nodeVersion => {
+              logs.info(output('CLI', cliVersion));
               logs.info(output('Firmware', firmwareVersion));
               logs.info(output('Node', nodeVersion));
             })
             .catch(() => {
+              logs.info(output('CLI', cliVersion));
               logs.info(output('Firmware', firmwareVersion));
               logs.info(output('Node', 'unknown'));
             });
         });
       })
       .catch(() => {
+        logs.info(output('CLI', cliVersion));
         logs.info(output('Firmware', 'unknown'));
         logs.info(output('Node', 'unknown'));
       });

--- a/test/unit/controller.js
+++ b/test/unit/controller.js
@@ -361,6 +361,8 @@ exports['controller.tesselEnvVersions'] = {
       name: 'TestTessel'
     });
 
+    this.packageJsonVersion = require('../../package.json').version;
+
     this.standardTesselCommand = this.sandbox.stub(controller, 'standardTesselCommand', (opts, callback) => {
       return callback(this.tessel);
     });
@@ -382,7 +384,7 @@ exports['controller.tesselEnvVersions'] = {
   },
 
   properVersionsReturned: function(test) {
-    test.expect(6);
+    test.expect(7);
 
     var opts = {};
 
@@ -395,18 +397,20 @@ exports['controller.tesselEnvVersions'] = {
         // Execute `node --version` command on tessel
         test.equal(this.fetchCurrentNodeVersion.callCount, 1);
         // Make sure we have some output
-        test.equal(this.logsInfo.callCount, 2);
+        test.equal(this.logsInfo.callCount, 3);
 
+        // Output of CLI version to console
+        test.equal(this.logsInfo.firstCall.args[0], `Tessel [TestTessel] CLI version: ${this.packageJsonVersion}`);
         // Output of firmware version to console
-        test.equal(this.logsInfo.firstCall.args[0], 'Tessel [TestTessel] Firmware version: 0.0.1');
+        test.equal(this.logsInfo.secondCall.args[0], 'Tessel [TestTessel] Firmware version: 0.0.1');
         // Output of Node version to console
-        test.equal(this.logsInfo.secondCall.args[0], 'Tessel [TestTessel] Node version: 4.2.1');
+        test.equal(this.logsInfo.thirdCall.args[0], 'Tessel [TestTessel] Node version: 4.2.1');
         test.done();
       });
   },
 
   nodeVersionFailed: function(test) {
-    test.expect(6);
+    test.expect(7);
 
     this.logsInfo.restore();
     this.logsInfo = this.sandbox.stub(logs, 'info', function() {});
@@ -437,18 +441,20 @@ exports['controller.tesselEnvVersions'] = {
         // Execute `node --version` command on tessel
         test.equal(this.fetchCurrentNodeVersion.callCount, 1);
         // Make sure we have some output
-        test.equal(this.logsInfo.callCount, 2);
+        test.equal(this.logsInfo.callCount, 3);
 
+        // Output of CLI version to console
+        test.equal(this.logsInfo.firstCall.args[0], `Tessel [TestTessel] CLI version: ${this.packageJsonVersion}`);
         // Output of firmware version to console
-        test.equal(this.logsInfo.firstCall.args[0], 'Tessel [TestTessel] Firmware version: 0.0.1');
+        test.equal(this.logsInfo.secondCall.args[0], 'Tessel [TestTessel] Firmware version: 0.0.1');
         // Output of Node version to console
-        test.equal(this.logsInfo.secondCall.args[0], 'Tessel [TestTessel] Node version: unknown');
+        test.equal(this.logsInfo.thirdCall.args[0], 'Tessel [TestTessel] Node version: unknown');
         test.done();
       });
   },
 
   firmwareVersionFailed: function(test) {
-    test.expect(6);
+    test.expect(7);
 
     this.logsInfo.restore();
     this.logsInfo = this.sandbox.stub(logs, 'info', function() {});
@@ -479,12 +485,14 @@ exports['controller.tesselEnvVersions'] = {
         // Execute `node --version` command on tessel
         test.equal(this.fetchCurrentNodeVersion.callCount, 0);
         // Make sure we have some output
-        test.equal(this.logsInfo.callCount, 2);
+        test.equal(this.logsInfo.callCount, 3);
 
+        // Output of CLI version to console
+        test.equal(this.logsInfo.firstCall.args[0], `Tessel [TestTessel] CLI version: ${this.packageJsonVersion}`);
         // Output of firmware version to console
-        test.equal(this.logsInfo.firstCall.args[0], 'Tessel [TestTessel] Firmware version: unknown');
+        test.equal(this.logsInfo.secondCall.args[0], 'Tessel [TestTessel] Firmware version: unknown');
         // Output of Node version to console
-        test.equal(this.logsInfo.secondCall.args[0], 'Tessel [TestTessel] Node version: unknown');
+        test.equal(this.logsInfo.thirdCall.args[0], 'Tessel [TestTessel] Node version: unknown');
         test.done();
       });
   }


### PR DESCRIPTION
Fixes #604 

As discussed in #604, the initial issue was resolved with a separate PR, but this information might be handy as well.

If this is not wanted on the CLI, that's fine, we can just close the PR. But, it is up here for discussion.