### PR TITLE
Add contributors to package.json

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,5 @@
+Flaki <git@flaki.hu> <flaki@Flakis-Air.local>
+Jia Huang <jialiya.huang0@gmail.com>
+Jon McKay <johnnyman727@gmail.com>
+Josh Dudley <jdudley@abrasive-tech.com> <dudley.21@osu.edu>
+Kelsey Breseman <ifoundthemeaningoflife@gmail.com>

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -86,6 +86,7 @@ module.exports = function(grunt) {
   // These plugins provide necessary tasks.
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-nodeunit');
+  grunt.loadNpmTasks('grunt-git-authors');
   grunt.loadNpmTasks('grunt-jscs');
   grunt.loadNpmTasks('grunt-jsbeautifier');
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "grunt-contrib-jshint": "^0.11.2",
     "grunt-contrib-nodeunit": "^0.4.1",
     "grunt-contrib-watch": "^0.6.1",
+    "grunt-git-authors": "^3.2.0",
     "grunt-jsbeautifier": "^0.2.10",
     "grunt-jscs": "^2.3.0",
     "mkdirp": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -81,5 +81,34 @@
   "preferGlobal": true,
   "engines": {
     "node": ">=4.2.0"
-  }
+  },
+  "contributors": [
+    "Jon McKay <johnnyman727@gmail.com>",
+    "Kelsey Breseman <ifoundthemeaningoflife@gmail.com>",
+    "Tim Cameron Ryan <id@timryan.org>",
+    "HarleyKwyn <kwyn.meagher@gmail.com>",
+    "Kenneth Nierenhausen <kennethnierenhausen@gmail.com>",
+    "Rick Waldron <waldron.rick@gmail.com>",
+    "Jia Huang <jialiya.huang0@gmail.com>",
+    "Kevin Mehall <km@kevinmehall.net>",
+    "Linus Unnebäck <linus@folkdatorn.se>",
+    "Dale Stone <dale@stonenet.co.uk>",
+    "Chris Boette <chris@impossibleventures.com>",
+    "Daniel Bunzendahl <db@bunzendahl.com>",
+    "Will Prater <will@superformula.com>",
+    "Nicholas van de Walle <nicholas@niceguys.co>",
+    "dtex <donovan@donovan.bz>",
+    "HipsterBrown <headhipster@hipsterbrown.com>",
+    "Nick Hehr <headhipster@hipsterbrown.com>",
+    "Jonathan Altman <jonathan.a@gmail.com>",
+    "Francis Gulotta <wizard@roborooter.com>",
+    "Flaki <git@flaki.hu>",
+    "Josh Dudley <jdudley@abrasive-tech.com>",
+    "Student007 <db@bunzendahl.com>",
+    "Thorsten Hoeger <thorsten.hoeger@hoegernet.com>",
+    "Rahul Ravikumar <rahul@rahulrav.com>",
+    "Neil Kistner <neil.kistner@gmail.com>",
+    "Thomas Jansen <thojansen@gmail.com>",
+    "Scott González <scott.gonzalez@gmail.com>"
+  ]
 }


### PR DESCRIPTION
Fixes #686

I added a `.mailmap` to handle some bad author data, but I had to guess for some of the authors. All of Flaki's commits had a bogus address for his laptop, so I chose his public email address from GitHub. Josh Dudley had two commits, each with a different address, so I chose the first one. If anyone wants their info changed, the `.mailmap` can be adjusted and the list will be corrected the next time `grunt update-contributors` is run.