### PR TITLE
Disallow USB connections with `t2 root` command (#673)

### DIFF
--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -432,6 +432,18 @@ makeCommand('root')
   .callback(function(opts) {
     callControllerWith('root', opts);
   })
+  .option('lan', {
+    flag: true,
+    hidden: true
+  })
+  .option('lanPrefer', {
+    flag: true,
+    hidden: true
+  })
+  .option('usb', {
+    flag: true,
+    hidden: true
+  })
   .help('Gain SSH root access to one of your authorized tessels');
 
 

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -763,6 +763,12 @@ controller.root = function(opts) {
   opts.lan = true;
   // We must already be authorized
   opts.authorized = true;
+  // Disable USB flag if passed
+  if (opts.usb) {
+    opts.usb = false;
+    logs.warn('You are trying to connect to Tessel via USB, but this command only works with Wifi.');
+    logs.warn('I will use Wifi to try and look for your Tessel.');
+  }
   // Fetch a Tessel
   return controller.standardTesselCommand(opts, function(tessel) {
     logs.info('Starting SSH Session on Tessel. Type \'exit\' at the prompt to end.');

--- a/test/unit/controller.js
+++ b/test/unit/controller.js
@@ -1070,6 +1070,28 @@ exports['controller.root'] = {
       });
   },
 
+  setsOptsUsbFalseAndWarns: function(test) {
+    test.expect(4);
+
+    var opts = {
+      usb: true
+    };
+
+    this.logsWarn.restore();
+    this.logsWarn = this.sandbox.stub(logs, 'warn', function() {});
+
+    controller.root(opts)
+      .then(() => {
+        var options = this.standardTesselCommand.lastCall.args[0];
+
+        test.equal(this.standardTesselCommand.callCount, 1);
+        test.equal(options, opts);
+        test.equal(options.usb, false);
+        test.equal(this.logsWarn.callCount, 2);
+        test.done();
+      });
+  },
+
   setsAuthorizedTrue: function(test) {
     test.expect(3);
 


### PR DESCRIPTION
Fixes #673 

This will hide the flags if someone runs `t2 root --help` but doesn't disable them completely. I saw at least 2 options here, either error out and don't attempt a connection, or force the use of LAN connection and give the user a warning. I chose the 2nd route as I think it is a better user experience. But I am up for discussions on it.

Current output:

```
❯ t2 root --usb
WARN You are trying to connect to Tessel via USB, but this command only works with Wifi.
WARN I will use Wifi to try and look for your Tessel.
INFO Looking for your Tessel...
INFO Connected to t2-testing.
INFO Starting SSH Session on Tessel. Type 'exit' at the prompt to end.
```