### PR TITLE
Fixes https://github.com/tessel/t2-cli/issues/691

### DIFF
--- a/lib/crash-reporter.js
+++ b/lib/crash-reporter.js
@@ -13,13 +13,14 @@ var Preferences = require('./preferences');
 // the value of the crash reporter preference
 // the value has to be one of 'on' or 'off'
 var CRASH_REPORTER_PREFERENCE = 'crash.reporter.preference';
-var SUBMIT_CRASH_URL = 'http://crash-reporter.tessel.io/crashes/submit';
+var CRASH_REPORTER_BASE_URL = 'http://crash-reporter.tessel.io';
 
 // override for testing
 if (process.env.DEV_MODE === 'true') {
-  SUBMIT_CRASH_URL = 'http://localhost:8080/crashes/submit';
+  CRASH_REPORTER_BASE_URL = 'http://localhost:8080';
 }
 
+var SUBMIT_CRASH_URL = `${CRASH_REPORTER_BASE_URL}/crashes/submit`;
 var rPathEscape = /[|\\{}()[\]^$+*?.]/g;
 
 function escape(p) {
@@ -65,16 +66,12 @@ CrashReporter.submit = function(report) {
           stack = stack.replace(new RegExp(escape(__dirname.slice(0, index)), 'g'), '');
         }
 
-        CrashReporter.post(labels, stack)
-          .then(() => {
-            logs.info('Crash Reported: http://crash-reporter.tessel.io/');
-          })
-          .catch(error => {
-            logs.err('Error submitting crash report', error);
+        return CrashReporter.post(labels, stack)
+          .then(fingerprint => {
+            logs.info(`Crash Reported: ${CRASH_REPORTER_BASE_URL}/crashes?fingerprint=${fingerprint}`);
           });
       }
-    })
-    .catch(error => {
+    }).catch(error => {
       // do nothing
       // do not crash the crash reporter :)
       logs.err('Error submitting crash report', error);
@@ -99,7 +96,8 @@ CrashReporter.post = function(labels, report) {
           if (json.error) {
             reject(json.error);
           } else {
-            resolve();
+            var fingerprint = json.crash_report.fingerprint;
+            resolve(fingerprint);
           }
         }
       } catch (exception) {
@@ -114,6 +112,9 @@ CrashReporter.test = () => {
 };
 
 var onError = error => {
+  // log the error as sometimes we might be swallowing
+  // unhandled remote node exceptions
+  logs.err('Detected CLI crash', error, error.stack);
   return CrashReporter.submit(error.stack);
 };
 

--- a/lib/crash-reporter.js
+++ b/lib/crash-reporter.js
@@ -96,8 +96,7 @@ CrashReporter.post = function(labels, report) {
           if (json.error) {
             reject(json.error);
           } else {
-            var fingerprint = json.crash_report.fingerprint;
-            resolve(fingerprint);
+            resolve(json.crash_report.fingerprint);
           }
         }
       } catch (exception) {


### PR DESCRIPTION
Sometimes remote node crashes are swallowed by the Crash reporter. Now the uncaught exception
handler prints them, and the Crash reporter also returns the correct `fingerprint`, so the
crash can be discovered and reported.