### PR TITLE
t2 crash-reporter: do not register process event handlers in CI environment.

### DIFF
--- a/lib/crash-reporter.js
+++ b/lib/crash-reporter.js
@@ -117,7 +117,11 @@ var onError = error => {
   return CrashReporter.submit(error.stack);
 };
 
-process.on('unhandledRejection', onError);
-process.on('uncaughtException', onError);
+onError.isCrashHandler = true;
+
+if (!process.env.CI) {
+  process.on('unhandledRejection', onError);
+  process.on('uncaughtException', onError);
+}
 
 module.exports = CrashReporter;

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-jshint": "^0.11.2",
-    "grunt-contrib-nodeunit": "^0.4.1",
+    "grunt-contrib-nodeunit": "^1.0.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-git-authors": "^3.2.0",
     "grunt-jsbeautifier": "^0.2.10",

--- a/test/unit/crash-reporter.js
+++ b/test/unit/crash-reporter.js
@@ -10,6 +10,30 @@ exports['CrashReporter'] = {
     test.equal(typeof CrashReporter.submit, 'function');
     test.equal(typeof CrashReporter.test, 'function');
     test.done();
+  },
+
+  noProcessExceptionOrRejectionHandlers: function(test) {
+    test.expect(1);
+
+    var expect = process.env.CI ? 0 : 2;
+    var tally = 0;
+
+    Object.keys(process._events).forEach(key => {
+      if (Array.isArray(process._events[key])) {
+        process._events[key].forEach(handler => {
+          if (handler.isCrashHandler) {
+            tally++;
+          }
+        });
+      } else {
+        if (process._events[key].isCrashHandler) {
+          tally++;
+        }
+      }
+    });
+
+    test.equal(tally, expect);
+    test.done();
   }
 };
 


### PR DESCRIPTION
Discovered during work on gh-703

Signed-off-by: Rick Waldron <waldron.rick@gmail.com>
