### PR TITLE
Stop crashing when update-notifier fails

### DIFF
--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -23,7 +23,6 @@ const pkg = require('../package.json');
 try {
   updateNotifier({ pkg }).notify();
 } catch (err) {
-  logs.warn('Failed to check for newer version of the CLI');
   CrashReporter.submit(err.stack);
 }
 

--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -23,7 +23,7 @@ const pkg = require('../package.json');
 try {
   updateNotifier({ pkg }).notify();
 } catch (err) {
-  CrashReporter.submit(err.stack);
+  CrashReporter.submit(err.stack, { silent: true });
 }
 
 function makeCommand(commandName) {

--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -19,9 +19,13 @@ const CLI_ENTRYPOINT = 'cli.entrypoint';
 
 // Check for updates
 const pkg = require('../package.json');
-updateNotifier({
-  pkg
-}).notify();
+
+try {
+  updateNotifier({ pkg }).notify();
+} catch (err) {
+  logs.warn('Failed to check for newer version of the CLI');
+  CrashReporter.submit(err.stack);
+}
 
 function makeCommand(commandName) {
   return parser.command(commandName)

--- a/lib/crash-reporter.js
+++ b/lib/crash-reporter.js
@@ -47,7 +47,11 @@ CrashReporter.on = function() {
     });
 };
 
-CrashReporter.submit = function(report) {
+CrashReporter.submit = function(report, opts) {
+  if (opts === undefined) { opts = {}; }
+
+  const silent = (opts.silent || false);
+
   return Preferences.read(CRASH_REPORTER_PREFERENCE, 'on')
     .then(value => {
       if (value === 'on') {
@@ -68,7 +72,9 @@ CrashReporter.submit = function(report) {
 
         return CrashReporter.post(labels, stack)
           .then(fingerprint => {
-            logs.info(`Crash Reported: ${CRASH_REPORTER_BASE_URL}/crashes?fingerprint=${fingerprint}`);
+            if (!silent) {
+              logs.info(`Crash Reported: ${CRASH_REPORTER_BASE_URL}/crashes?fingerprint=${fingerprint}`);
+            }
           });
       }
     }).catch(error => {


### PR DESCRIPTION
*related: #714*

ping @rwaldron @johnnyman727 

This is a quick fix that will stop the t2 cli from crashing for the affected users. It will print a warning and then report the error to our crash server.

![screen shot 2016-04-27 at 23 08 50](https://cloud.githubusercontent.com/assets/189580/14868271/097e1880-0ccd-11e6-95e9-8624a22b1676.png)

Another funny thing I noticed is that the crash reporter won't be able to upload crash data if we call `process.exit()` to early, like we do when running only `t2` for example, but that's another issue altogether...