### PR TITLE
Test fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ before_install:
   - npm install -g grunt-cli
 
 install: npm install
-script: grunt
+script: grunt test

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -91,11 +91,11 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-jsbeautifier');
 
 
-  // 'npm test' runs these tasks
-  grunt.registerTask('test', ['jshint', 'jscs', 'jsbeautifier', 'nodeunit']);
+  grunt.registerTask('test', ['jshint', 'jscs', 'nodeunit']);
+  grunt.registerTask('all', ['jsbeautifier', 'jshint', 'jscs', 'nodeunit']);
 
   // Default task.
-  grunt.registerTask('default', ['test']);
+  grunt.registerTask('default', ['all']);
 
 
   // Support running a single test suite

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ clone_depth: 10
 
 environment:
   matrix:
-    - nodejs_version: 4.0
+    - nodejs_version: 4
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ install:
 build: off
 
 test_script:
-  - npm test
+  - grunt test
 
 cache:
   - node_modules

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,12 +10,16 @@ environment:
 platform:
   - x86
   - x64
+
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm install -g npm
   - npm install
 
 build: off
+
+before_test:
+  - npm install -g grunt-cli
 
 test_script:
   - ps: "grunt test # PowerShell"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,15 +5,21 @@ clone_depth: 10
 environment:
   matrix:
     - nodejs_version: 4
+    - nodejs_version: 5
 
+platform:
+  - x86
+  - x64
 install:
   - ps: Install-Product node $env:nodejs_version
+  - npm install -g npm
   - npm install
 
 build: off
 
 test_script:
-  - grunt test
+  - ps: "grunt test # PowerShell"
+  - cmd: grunt test
 
 cache:
   - node_modules

--- a/lib/tessel/provision.js
+++ b/lib/tessel/provision.js
@@ -8,13 +8,13 @@ var util = require('util');
 // Third Party Dependencies
 var async = require('async');
 var fs = require('fs-extra');
-var NodeRSA = require('node-rsa');
 var osenv = require('osenv');
 var sshpk = require('sshpk');
 
 // Internal
 var commands = require('./commands');
 var logs = require('../logs');
+var RSA = require('./rsa-delegation');
 var Tessel = require('./tessel');
 
 
@@ -83,7 +83,7 @@ actions.setupLocal = function(keyFile) {
     logs.info('Creating public and private keys for Tessel authentication...');
 
     // Generate SSH key
-    var key = new NodeRSA({
+    var key = new RSA({
       b: 2048
     });
     var privateKey = key.exportKey('private');
@@ -100,12 +100,12 @@ actions.setupLocal = function(keyFile) {
       // owner can read and write
       var fileOptions = {
         encoding: 'utf8',
-        mode: 384
+        mode: 0o600,
       };
       async.parallel([
           (cb) => fs.writeFile(keyFile + '.pub', publicKey, fileOptions, cb), (cb) => fs.writeFile(keyFile, privateKey, fileOptions, cb),
         ],
-        function(err) {
+        (err) => {
           if (err) {
             return reject(err);
           }
@@ -125,9 +125,7 @@ actions.authTessel = function(tessel, filepath) {
     actions.checkAuthFileExists(tessel, remoteAuthFile)
       .then(function readKey() {
         // Read the public key
-        fs.readFile(filepath + '.pub', {
-          encoding: 'utf-8'
-        }, function(err, pubKey) {
+        fs.readFile(filepath + '.pub', 'utf8', (err, pubKey) => {
           if (err) {
             return reject(err);
           }

--- a/lib/tessel/rsa-delegation.js
+++ b/lib/tessel/rsa-delegation.js
@@ -1,0 +1,5 @@
+function MockRSA() {}
+
+MockRSA.prototype.exportKey = function() {};
+
+module.exports = global.IS_TEST_ENV ? MockRSA : require('node-rsa');

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -45,6 +45,7 @@
     "mdns": true,
     "mkdirp": true,
     "NodeRSA": true,
+    "RSA": true,
     "osenv": true,
     "path": true,
     "Preferences": true,

--- a/test/common/bootstrap.js
+++ b/test/common/bootstrap.js
@@ -24,7 +24,6 @@ global.Ignore = require('fstream-ignore');
 global.inquirer = require('inquirer');
 global.mdns = require('mdns-js');
 global.mkdirp = require('mkdirp');
-global.NodeRSA = require('node-rsa');
 global.osenv = require('osenv');
 global.Project = require('t2-project');
 global.request = require('request');
@@ -42,6 +41,7 @@ global.Tessel = require('../../lib/tessel/tessel');
 global.commands = require('../../lib/tessel/commands');
 global.deploy = require('../../lib/tessel/deploy');
 global.provision = require('../../lib/tessel/provision');
+global.RSA = require('../../lib/tessel/rsa-delegation');
 global.deployLists = require('../../lib/tessel/deploy-lists');
 
 // ./lib/*

--- a/test/unit/crash-reporter.js
+++ b/test/unit/crash-reporter.js
@@ -263,7 +263,11 @@ exports['CrashReporter.status'] = {
   setUp: function(done) {
     this.sandbox = sinon.sandbox.create();
     this.logsInfo = this.sandbox.stub(logs, 'info');
-    this.crPost = this.sandbox.spy(CrashReporter, 'status');
+    this.prefLoad = this.sandbox.stub(Preferences, 'load', () => {
+      return Promise.resolve({
+        'crash.reporter.preference': 'on'
+      });
+    });
     done();
   },
 

--- a/test/unit/root.js
+++ b/test/unit/root.js
@@ -85,9 +85,12 @@ exports['tessel.root'] = {
     tessel.name = 'Frank';
     tessel.lanConnection.ip = '1.1.1.1';
 
-    // Emit the Tessel
-    setImmediate(() => {
-      this.activeSeeker.emit('tessel', tessel);
-    });
+    // Interval until an active seeker exists...
+    this.interval = setInterval(() => {
+      if (this.activeSeeker) {
+        clearInterval(this.interval);
+        this.activeSeeker.emit('tessel', tessel);
+      }
+    }, 1);
   },
 };


### PR DESCRIPTION
- don't use NodeRSA in tests
- stub fs operations whenever possible
- stub public key operations whenever possible
- interval until activeSeeker is available

A complete run should look like: 

```
$ grunt
Running "jshint:all" (jshint) task
>> 27 files lint free.

Running "jshint:tests" (jshint) task
>> 64 files lint free.

Running "jscs:all" (jscs) task
>> 91 files without code style errors.

Running "jsbeautifier:all" (jsbeautifier) task
Beautified 103 files, changed 1 files...OK

Running "nodeunit:tests" (nodeunit) task
Testing access-point.js.........OK
Testing bin-tessel-2.js....................................OK
Testing constructor.js......OK
Testing controller.js..................................OK
Testing crash-reporter.js.............OK
Testing daemon.js.....OK
Testing deploy-lists.js..OK
Testing deploy.js..........................................................................OK
Testing discover.js...............OK
Testing erase.js..OK
Testing index.js....OK
Testing key.js....OK
Testing lan-connection.js..........OK
Testing menu.js..OK
Testing name.js........OK
Testing preferences.js.......OK
Testing provision.js.................OK
Testing root.js..OK
Testing tessel.js................OK
Testing update.js......................OK
Testing usb-connection.js.............OK
Testing usb-process.js..OK
Testing version.js.OK
Testing wifi.js..............OK
>> 1065 assertions passed (6838ms)
```

Specifically, it ends with 1065 assertions


Signed-off-by: Rick Waldron <waldron.rick@gmail.com>