### PR TITLE
t2 crash-reporter: Sanitize the user's username from crash reports. Fixes gh-728

### DIFF
--- a/lib/crash-reporter.js
+++ b/lib/crash-reporter.js
@@ -47,6 +47,24 @@ CrashReporter.on = function() {
     });
 };
 
+CrashReporter.sanitize = function(input) {
+  return CrashReporter.sanitize.redactions.reduce((stack, redaction) => redaction(stack), input);
+};
+
+CrashReporter.sanitize.redactions = [
+  (stack) => {
+    var index = __dirname.indexOf('t2-cli');
+
+    if (index !== -1) {
+      stack = stack.replace(new RegExp(escape(__dirname.slice(0, index)), 'g'), '');
+    }
+
+    return stack;
+  },
+  (stack) => stack.replace(new RegExp(escape(os.homedir()), 'g'), ''),
+];
+
+
 CrashReporter.submit = function(report, opts) {
   if (opts === undefined) {
     opts = {};
@@ -65,12 +83,7 @@ CrashReporter.submit = function(report, opts) {
           OS release: ${os.release()}
         `;
 
-        var index = __dirname.indexOf('t2-cli');
-        var stack = report.stack || String(report);
-
-        if (index !== -1) {
-          stack = stack.replace(new RegExp(escape(__dirname.slice(0, index)), 'g'), '');
-        }
+        var stack = CrashReporter.sanitize(report.stack || String(report));
 
         return CrashReporter.post(labels, stack)
           .then(fingerprint => {

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -47,6 +47,7 @@
     "NodeRSA": true,
     "RSA": true,
     "osenv": true,
+    "os": true,
     "path": true,
     "Preferences": true,
     "Project": true,

--- a/test/common/bootstrap.js
+++ b/test/common/bootstrap.js
@@ -3,6 +3,7 @@ global.IS_TEST_ENV = true;
 // System Objects
 global.cp = require('child_process');
 global.events = require('events');
+global.os = require('os');
 global.path = require('path');
 global.stream = require('stream');
 global.util = require('util');


### PR DESCRIPTION
Transforms a stack trace, eliminating user-specific information from the posted output. Note that first example below was already supported, but the test for it was incorrect. 

- Path to t2-cli install
  Before: 
  ```
  Error: This happened at /Users/rwaldron/clonez/t2-cli/test/unit. Line 1 in /Users/rwaldron/clonez/t2-cli/test/unit/crash-reporter.js
    at CrashReporter.sanitize.setUp.dirname.test (/Users/rwaldron/clonez/t2-cli/test/unit/crash-reporter.js:231:17)
    at /Users/rwaldron/clonez/t2-cli/node_modules/nodeunit/lib/core.js:232:20
    at /Users/rwaldron/clonez/t2-cli/node_modules/nodeunit/deps/async.js:168:13
    at /Users/rwaldron/clonez/t2-cli/node_modules/nodeunit/deps/async.js:131:25
    at /Users/rwaldron/clonez/t2-cli/node_modules/nodeunit/deps/async.js:165:17
    at /Users/rwaldron/clonez/t2-cli/node_modules/nodeunit/deps/async.js:463:34
    at CrashReporter.sanitize.setUp.done (/Users/rwaldron/clonez/t2-cli/test/unit/crash-reporter.js:217:5)
    at /Users/rwaldron/clonez/t2-cli/node_modules/nodeunit/lib/core.js:260:35
    at /Users/rwaldron/clonez/t2-cli/node_modules/nodeunit/deps/async.js:458:21
    at /Users/rwaldron/clonez/t2-cli/node_modules/nodeunit/deps/async.js:163:13
  ```

  After:
  ```
  Error: This happened at t2-cli/test/unit. Line 1 in t2-cli/test/unit/crash-reporter.js
    at CrashReporter.sanitize.setUp.dirname.test (t2-cli/test/unit/crash-reporter.js:231:17)
    at t2-cli/node_modules/nodeunit/lib/core.js:232:20
    at t2-cli/node_modules/nodeunit/deps/async.js:168:13
    at t2-cli/node_modules/nodeunit/deps/async.js:131:25
    at t2-cli/node_modules/nodeunit/deps/async.js:165:17
    at t2-cli/node_modules/nodeunit/deps/async.js:463:34
    at CrashReporter.sanitize.setUp.done (t2-cli/test/unit/crash-reporter.js:217:5)
    at t2-cli/node_modules/nodeunit/lib/core.js:260:35
    at t2-cli/node_modules/nodeunit/deps/async.js:458:21
    at t2-cli/node_modules/nodeunit/deps/async.js:163:13
  ```
- home directory
  Before: 
  ```
  Error: permission denied, open '/Users/rwaldron/.config'
    at CrashReporter.sanitize.setUp.dirname.filename.home.test (/Users/rwaldron/clonez/t2-cli/test/unit/crash-reporter.js:269:17)
    at /Users/rwaldron/clonez/t2-cli/node_modules/nodeunit/lib/core.js:232:20
    at /Users/rwaldron/clonez/t2-cli/node_modules/nodeunit/deps/async.js:168:13
    at /Users/rwaldron/clonez/t2-cli/node_modules/nodeunit/deps/async.js:131:25
    at /Users/rwaldron/clonez/t2-cli/node_modules/nodeunit/deps/async.js:165:17
    at /Users/rwaldron/clonez/t2-cli/node_modules/nodeunit/deps/async.js:463:34
    at Object.exports.CrashReporter.exports.CrashReporter.submit.setUp.sanitizes.exports.CrashReporter.sanitize.setUp.done (/Users/rwaldron/clonez/t2-cli/test/unit/crash-reporter.js:217:5)
    at /Users/rwaldron/clonez/t2-cli/node_modules/nodeunit/lib/core.js:260:35
    at /Users/rwaldron/clonez/t2-cli/node_modules/nodeunit/deps/async.js:458:21
    at /Users/rwaldron/clonez/t2-cli/node_modules/nodeunit/deps/async.js:163:13
  ```

  After:
  ```
  Error: This happened at t2-cli/test/unit. Line 1 in Error: permission denied, open '/.config'
    at CrashReporter.sanitize.setUp.dirname.filename.home.test (t2-cli/test/unit/crash-reporter.js:269:17)
    at t2-cli/node_modules/nodeunit/lib/core.js:232:20
    at t2-cli/node_modules/nodeunit/deps/async.js:168:13
    at t2-cli/node_modules/nodeunit/deps/async.js:131:25
    at t2-cli/node_modules/nodeunit/deps/async.js:165:17
    at t2-cli/node_modules/nodeunit/deps/async.js:463:34
    at Object.exports.CrashReporter.exports.CrashReporter.submit.setUp.sanitizes.exports.CrashReporter.sanitize.setUp.done (t2-cli/test/unit/crash-reporter.js:217:5)
    at t2-cli/node_modules/nodeunit/lib/core.js:260:35
    at t2-cli/node_modules/nodeunit/deps/async.js:458:21
    at t2-cli/node_modules/nodeunit/deps/async.js:163:13
  ```




Signed-off-by: Rick Waldron <waldron.rick@gmail.com>