### PR TITLE
Add custom hostname flag to uci when using `t2 rename`

### DIFF
--- a/lib/tessel/commands.js
+++ b/lib/tessel/commands.js
@@ -92,6 +92,9 @@ module.exports.getHostname = function() {
 module.exports.setHostname = function(hostname) {
   return ['uci', 'set', 'system.@system[0].hostname=' + hostname];
 };
+module.exports.setHostnameFlag = function() {
+  return ['uci', 'set', 'system.@system[0].custom_hostname_set=1'];
+};
 module.exports.commitHostname = function() {
   return ['uci', 'commit', 'system'];
 };

--- a/lib/tessel/name.js
+++ b/lib/tessel/name.js
@@ -36,6 +36,10 @@ Tessel.prototype.setName = function(name) {
     // Write the new hostname to the device
     return this.simpleExec(commands.setHostname(name))
       .then(() => {
+        // Set a flag to remember our hostname on upgrade
+        return this.simpleExec(commands.setHostnameFlag());
+      })
+      .then(() => {
         // Commit the new hostname
         return this.simpleExec(commands.commitHostname());
       })

--- a/test/unit/name.js
+++ b/test/unit/name.js
@@ -20,6 +20,7 @@ exports['Tessel.prototype.rename'] = {
     this.commitHostname = this.sandbox.spy(commands, 'commitHostname');
     this.openStdinToFile = this.sandbox.spy(commands, 'openStdinToFile');
     this.setHostname = this.sandbox.spy(commands, 'setHostname');
+    this.setHostnameFlag = this.sandbox.spy(commands, 'setHostnameFlag');
     this.getHostname = this.sandbox.spy(commands, 'getHostname');
     this.logsWarn = this.sandbox.stub(logs, 'warn', function() {});
     this.logsInfo = this.sandbox.stub(logs, 'info', function() {});
@@ -81,7 +82,7 @@ exports['Tessel.prototype.rename'] = {
   },
 
   resetName: function(test) {
-    test.expect(7);
+    test.expect(8);
 
     this.tessel.rename({
         reset: true
@@ -94,6 +95,7 @@ exports['Tessel.prototype.rename'] = {
         test.equal(this._getMACAddress.callCount, 1);
         test.equal(this.setName.callCount, 1);
         test.equal(this.setHostname.callCount, 1);
+        test.equal(this.setHostnameFlag.callCount, 1);
         test.equal(this.commitHostname.callCount, 1);
         test.equal(this.openStdinToFile.callCount, 1);
 
@@ -107,7 +109,7 @@ exports['Tessel.prototype.rename'] = {
   },
 
   validRename: function(test) {
-    test.expect(6);
+    test.expect(7);
 
     this.tessel.rename({
         newName: 'ValidAndUnique'
@@ -120,6 +122,7 @@ exports['Tessel.prototype.rename'] = {
         test.equal(this.getName.callCount, 1);
         test.equal(this.setName.callCount, 1);
         test.equal(this.setHostname.callCount, 1);
+        test.equal(this.setHostnameFlag.callCount, 1);
         test.equal(this.commitHostname.callCount, 1);
         test.equal(this.openStdinToFile.callCount, 1);
         test.ok(this.setHostname.lastCall.calledWith('ValidAndUnique'));
@@ -163,7 +166,7 @@ exports['Tessel.prototype.rename'] = {
   },
 
   invalidSetName: function(test) {
-    test.expect(2);
+    test.expect(3);
 
     this.tessel.setName('...')
       .then((value) => {
@@ -176,6 +179,7 @@ exports['Tessel.prototype.rename'] = {
         test.equal(this.isValidName.callCount, 1);
         // test.equal(this.tessel.connection.exec.callCount, 0);
         test.equal(this.setHostname.callCount, 0);
+        test.equal(this.setHostnameFlag.callCount, 0);
 
         test.done();
       });


### PR DESCRIPTION
This is the other half of the puzzle for https://github.com/tessel/openwrt-tessel/pull/59 and completes https://github.com/tessel/openwrt-tessel/issues/19.

Also would close #252 and make https://github.com/tessel/t2-start/pull/117 not necessary.