### PR TITLE
Replace `this` with `grunt.task.current` in `changelog` task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -148,7 +148,7 @@ module.exports = (grunt) => {
 
 
   grunt.registerTask('changelog', '`changelog:0.0.0--0.0.2` or `changelog`', (range) => {
-    var done = this.async();
+    var done = grunt.task.current.async();
 
     if (!range) {
       // grunt changelog


### PR DESCRIPTION
Now produces the expected output: 

```
❯ grunt changelog
Running "changelog" task


| Commit | Message/Description |
| ------ | ------------------- |
|03f167c|0.0.21|
|52ae38d|Fix the order in which updates are presented (#736)|
|24fdd7d|Deployment reorg/refactor as groundwork for multi-language support (#723)|



Done, without errors.
```

Arrow function isn't binding the context correctly here and caused the
task to fail. Keeping the nice arrow syntax we can use the current task
from the grunt object to get the `async` function.

Fix #738