### PR TITLE
Remove (unnecessary?) `+` at the beginning of the udev rule

### DIFF
--- a/resources/85-tessel.rules
+++ b/resources/85-tessel.rules
@@ -1,1 +1,1 @@
-+ATTRS{idVendor}=="1209", ATTRS{idProduct}=="7551", ENV{ID_MM_DEVICE_IGNORE}="1", MODE="0666"
+ATTRS{idVendor}=="1209", ATTRS{idProduct}=="7551", ENV{ID_MM_DEVICE_IGNORE}="1", MODE="0666"


### PR DESCRIPTION
The `+` caused the udev rule to fail to load on Fedora. Removing it allowed it to work. I'm assuming this was just a typo.