### PR TITLE
t2 run/push: built-in whitelist rules should have node_modules/** prefix to ensure they are found at any installation depth below node_modules/

### DIFF
--- a/lib/tessel/deployment/lists/javascript.js
+++ b/lib/tessel/deployment/lists/javascript.js
@@ -1,13 +1,13 @@
 module.exports = {
   includes: [
-    'aws-sdk/apis/*.json',
-    'mime/types/*.types',
-    'negotiator/**/*.js',
-    'socket.io-client/socket.io.js',
+    'node_modules/**/aws-sdk/apis/*.json',
+    'node_modules/**/mime/types/*.types',
+    'node_modules/**/negotiator/**/*.js',
+    'node_modules/**/socket.io-client/socket.io.js',
   ],
 
   ignores: [
-    'node_modules/tessel/**/*',
+    'node_modules/**/tessel/**/*',
   ],
 
   // These are used to override all other rules.

--- a/test/unit/deployment/javascript.js
+++ b/test/unit/deployment/javascript.js
@@ -2498,10 +2498,10 @@ exports['deployment.js.lists'] = {
     test.expect(1);
 
     var includes = [
-      'aws-sdk/apis/*.json',
-      'mime/types/*.types',
-      'negotiator/**/*.js',
-      'socket.io-client/socket.io.js',
+      'node_modules/**/aws-sdk/apis/*.json',
+      'node_modules/**/mime/types/*.types',
+      'node_modules/**/negotiator/**/*.js',
+      'node_modules/**/socket.io-client/socket.io.js',
     ];
 
     test.deepEqual(lists.includes, includes);
@@ -2512,7 +2512,7 @@ exports['deployment.js.lists'] = {
     test.expect(1);
 
     var ignores = [
-      'node_modules/tessel/**/*',
+      'node_modules/**/tessel/**/*',
     ];
 
     test.deepEqual(lists.ignores, ignores);


### PR DESCRIPTION
Issue appears when using npm 3

Signed-off-by: Rick Waldron <waldron.rick@gmail.com>