### PR TITLE
Only access point or wifi is enabled at one time

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -594,7 +594,7 @@ controller.renameTessel = function(opts) {
     .then(function executeRename() {
       return controller.standardTesselCommand(opts, function(tessel) {
         log.info(`Renaming ${tessel.name} to ${opts.newName}`);
-              return tessel.rename(opts);
+        return tessel.rename(opts);
       });
     });
 };

--- a/lib/tessel/access-point.js
+++ b/lib/tessel/access-point.js
@@ -147,7 +147,7 @@ Tessel.prototype.createAccessPoint = function(opts) {
       .then(commitAndClosePromise);
   };
 
-  return this.simpleExec(commands.getAccessPointSSID())
+  return this.simpleExec(commands.getAccessPoint())
     .then(() => {
 
       // When an AP exists, change the status to

--- a/lib/tessel/commands.js
+++ b/lib/tessel/commands.js
@@ -134,6 +134,9 @@ module.exports.setLanNetworkNetmask = function() {
 module.exports.commitNetwork = function() {
   return ['uci', 'commit', 'network'];
 };
+module.exports.getAccessPoint = function() {
+  return ['uci', 'get', 'wireless.@wifi-iface[1]'];
+};
 module.exports.getAccessPointSSID = function() {
   return ['uci', 'get', 'wireless.@wifi-iface[1].ssid'];
 };

--- a/test/unit/access-point.js
+++ b/test/unit/access-point.js
@@ -16,7 +16,7 @@ exports['Tessel.prototype.createAccessPoint'] = {
     this.setLanNetworkNetmask = this.sandbox.spy(commands, 'setLanNetworkNetmask');
     this.commitNetwork = this.sandbox.spy(commands, 'commitNetwork');
     this.setAccessPoint = this.sandbox.spy(commands, 'setAccessPoint');
-    this.getAccessPointSSID = this.sandbox.spy(commands, 'getAccessPointSSID');
+    this.getAccessPoint = this.sandbox.spy(commands, 'getAccessPoint');
     this.setAccessPointDevice = this.sandbox.spy(commands, 'setAccessPointDevice');
     this.setAccessPointNetwork = this.sandbox.spy(commands, 'setAccessPointNetwork');
     this.setAccessPointMode = this.sandbox.spy(commands, 'setAccessPointMode');
@@ -29,6 +29,12 @@ exports['Tessel.prototype.createAccessPoint'] = {
     this.reconnectDhcp = this.sandbox.spy(commands, 'reconnectDhcp');
 
     this.tessel = TesselSimulator();
+    // These are needed because the sheer number of commands run within
+    // each test exceeds the default maximum number of listeners. This
+    // is only an issue with tests because we re-use the same remote
+    // process simulator across all command calls
+    this.tessel._rps.stdout.setMaxListeners(100);
+    this.tessel._rps.stderr.setMaxListeners(100);
 
     done();
   },
@@ -47,7 +53,7 @@ exports['Tessel.prototype.createAccessPoint'] = {
       security: 'psk2'
     };
 
-    // Test is expecting two closes...;
+    // Immediately close any opened connections
     this.tessel._rps.on('control', () => {
       setImmediate(() => {
         this.tessel._rps.emit('close');
@@ -70,7 +76,7 @@ exports['Tessel.prototype.createAccessPoint'] = {
 
     this.tessel.createAccessPoint(creds)
       .then(() => {
-        test.equal(this.getAccessPointSSID.callCount, 1);
+        test.equal(this.getAccessPoint.callCount, 1);
         test.equal(this.setAccessPoint.callCount, 1);
         test.equal(this.setAccessPointDevice.callCount, 1);
         test.equal(this.setAccessPointNetwork.callCount, 1);
@@ -116,7 +122,7 @@ exports['Tessel.prototype.createAccessPoint'] = {
 
     this.tessel.createAccessPoint(creds)
       .then(() => {
-        test.equal(this.getAccessPointSSID.callCount, 1);
+        test.equal(this.getAccessPoint.callCount, 1);
         test.equal(this.setAccessPointSSID.callCount, 1);
         test.equal(this.setAccessPointPassword.callCount, 0);
         test.equal(this.setAccessPointSecurity.callCount, 1);
@@ -150,7 +156,7 @@ exports['Tessel.prototype.createAccessPoint'] = {
 
     this.tessel.createAccessPoint(creds)
       .then(() => {
-        test.equal(this.getAccessPointSSID.callCount, 1);
+        test.equal(this.getAccessPoint.callCount, 1);
         test.equal(this.setAccessPointSSID.callCount, 1);
         test.equal(this.setAccessPointPassword.callCount, 1);
         test.equal(this.setAccessPointSecurity.callCount, 1);
@@ -185,7 +191,7 @@ exports['Tessel.prototype.createAccessPoint'] = {
 
     this.tessel.createAccessPoint(creds)
       .then(() => {
-        test.equal(this.getAccessPointSSID.callCount, 1);
+        test.equal(this.getAccessPoint.callCount, 1);
         test.equal(this.setAccessPointSSID.callCount, 1);
         test.equal(this.setAccessPointPassword.callCount, 1);
         test.equal(this.setAccessPointSecurity.callCount, 1);
@@ -242,7 +248,7 @@ exports['Tessel.prototype.enableAccessPoint'] = {
       ip: '192.168.200.1'
     };
 
-    // Test is expecting two closes...;
+
     this.tessel._rps.on('control', (command) => {
       if (command.toString() === 'uci show wireless.@wifi-iface[1]') {
         var info = new Buffer(tags.stripIndent `


### PR DESCRIPTION
Fixes #755.

* Ensures that extra `wifi-iface` lines aren't generated.

@Frijol found that you can't have both wifi and access points enabled at the same time or else the access point doesn't show up.