### PR TITLE
Allow deployment from entry point without package.json in directory. Fixes gh-717

### DIFF
--- a/lib/tessel/deploy.js
+++ b/lib/tessel/deploy.js
@@ -263,6 +263,7 @@ exportables.findProject = function(opts) {
 
     var pushdir = fs.realpathSync(path.dirname(file)) || '';
     var relpath = '';
+    var useProgramDirname = false;
 
     if (!single) {
       while (path.dirname(pushdir) !== pushdir &&
@@ -275,8 +276,10 @@ exportables.findProject = function(opts) {
         }
       }
 
-      if (path.dirname(pushdir) === pushdir) {
-        reject('Invalid project directory');
+      if (exportables.endOfLookup(pushdir)) {
+        // Don't bother with configuration file check, it's not there.
+        checkConfiguration = false;
+        useProgramDirname = true;
       }
     }
 
@@ -290,12 +293,24 @@ exportables.findProject = function(opts) {
       program = validated.program;
     }
 
+    // If there was no directory found containing a configuration file,
+    // ie. package.json or Cargo.toml, then fallback to using the program
+    // entry point's path.dirname(...)
+    if (useProgramDirname) {
+      pushdir = path.dirname(program);
+      relpath = '';
+    }
+
     resolve({
       pushdir: pushdir,
       program: program,
       entryPoint: path.join(relpath, path.basename(program)),
     });
   });
+};
+
+exportables.endOfLookup = function(pushdir) {
+  return path.dirname(pushdir) === pushdir;
 };
 
 exportables.sendBundle = function(tessel, opts) {

--- a/test/unit/deployment/javascript.js
+++ b/test/unit/deployment/javascript.js
@@ -1679,11 +1679,29 @@ exports['deploy.findProject'] = {
     deploy.findProject(opts).then(project => {
       // Without the `single` flag, this would've continued upward
       // until it found a directory with a package.json.
-      test.ok(project.pushdir, fs.realpathSync(path.dirname(pushdir)));
+      test.equal(project.pushdir, fs.realpathSync(pushdir));
       test.done();
     });
   },
 
+  noPackageJsonUseProgramDirname: function(test) {
+    test.expect(1);
+
+    // This is no package.json here
+    var entryPoint = path.normalize('test/unit/fixtures/project-no-package.json/index.js');
+    var opts = {
+      entryPoint: entryPoint,
+      lang: deployment.js,
+      single: false,
+    };
+
+    this.endOfLookup = sandbox.stub(deploy, 'endOfLookup').returns(true);
+
+    deploy.findProject(opts).then(project => {
+      test.equal(project.pushdir, path.dirname(path.join(process.cwd(), entryPoint)));
+      test.done();
+    });
+  },
 };
 
 


### PR DESCRIPTION
# Smoke Test

```sh
mkdir t2-no-package.json && cd t2-no-package.json;
t2 init;
rm {package.json,.tesselinclude};
ls -ah;
t2 run index.js;
```

Observed:

```
rwaldron at nova in ~/robotz
$ mkdir t2-no-package.json && cd t2-no-package.json;
rwaldron at nova in ~/robotz/t2-no-package.json
$ t2 init;
Initializing Tessel 2 Project...
Created package.json.
Created .tesselinclude.
Wrote "Hello World" to index.js
rwaldron at nova in ~/robotz/t2-no-package.json
$ rm {package.json,.tesselinclude};
rwaldron at nova in ~/robotz/t2-no-package.json
$ ls -ah;
.
└── [-rw-r--r-- rwaldron staff     287 Jun 10 17:51]  index.js

0 directories, 1 file
rwaldron at nova in ~/robotz/t2-no-package.json
$ t2 run index.js;
INFO Looking for your Tessel...
INFO Connected to Tessel-02A347EF35F2.
INFO Building project.
INFO Writing project to RAM on Tessel-02A347EF35F2 (3.072 kB)...
INFO Deployed.
INFO Running index.js...
I'm blinking! (Press CTRL + C to stop)
```


## Expected Outcome

A new project is created, the package.json and .tesselinclude are deleted (the latter is not necessary), the index is deployed without failing to find a package.json 


cc @HipsterBrown 






Signed-off-by: Rick Waldron <waldron.rick@gmail.com>