### PR TITLE
t2 run: hook up process.stdin to remote.stdin

### DIFF
--- a/lib/tessel/deploy.js
+++ b/lib/tessel/deploy.js
@@ -370,20 +370,24 @@ exportables.run = function(tessel, opts) {
     }
 
     return prom.then(() => {
-      tessel.connection.exec(commands[opts.lang.meta.extname].execute(Tessel.REMOTE_RUN_PATH, opts.resolvedEntryPoint), {
-        pty: true
-      }, (error, remoteProcess) => {
-        if (error) {
-          return reject(error);
-        }
+      tessel.connection.exec(
+        commands[opts.lang.meta.extname].execute(Tessel.REMOTE_RUN_PATH, opts.resolvedEntryPoint), {
+          pty: true
+        }, (error, remoteProcess) => {
+          if (error) {
+            return reject(error);
+          }
 
-        // When the stream closes, return from the function
-        remoteProcess.once('close', resolve);
+          // When the stream closes, return from the function
+          remoteProcess.once('close', resolve);
 
-        // Pipe data and errors
-        remoteProcess.stdout.pipe(process.stdout);
-        remoteProcess.stderr.pipe(process.stderr);
-      });
+          // Pipe input TO the remote process.
+          process.stdin.pipe(remoteProcess.stdin);
+
+          // Pipe output FROM the remote process.
+          remoteProcess.stdout.pipe(process.stdout);
+          remoteProcess.stderr.pipe(process.stderr);
+        });
     });
   });
 };

--- a/test/unit/deploy.js
+++ b/test/unit/deploy.js
@@ -521,8 +521,26 @@ exports['deploy.run'] = {
       test.deepEqual(this.exec.lastCall.args[0], ['rust_executable']);
       test.done();
     });
-  }
+  },
 
+  runStdInOut: function(test) {
+    test.expect(1);
+
+    this.exec = sandbox.stub(this.tessel.connection, 'exec', (command, options, callback) => {
+      callback(null, this.tessel._rps);
+      this.tessel._rps.emit('close');
+    });
+
+    this.stdinPipe = sandbox.stub(process.stdin, 'pipe');
+
+    deploy.run(this.tessel, {
+      resolvedEntryPoint: 'foo',
+      lang: deployment.js,
+    }).then(() => {
+      test.equal(this.stdinPipe.callCount, 1);
+      test.done();
+    });
+  },
 };
 
 exports['deploy.createShellScript'] = {


### PR DESCRIPTION
Unblocks use of readline, etc.


# Smoke Test

```
mkdir readline && cd readline && t2 init;
```

open index.js and replace it with: 

```js
const readline = require('readline');
const rl = readline.createInterface(process.stdin, process.stdout);

rl.setPrompt('>');
rl.prompt();

rl.on('line', (line) => {
  console.log(`You wrote: "${line.trim()}"`);
  rl.prompt();
}).on('close', () => {
  console.log('Goodbye.');
  process.exit(0);
});
```


```
t2 run index.js
```


Should allow input like this: 

```
$ t2 run index.js
INFO Looking for your Tessel...
INFO Connected to ash4.
INFO Building project.
INFO Writing project to RAM on ash4 (3.072 kB)...
INFO Deployed.
INFO Running index.js...
>submarine mission for you baby
You wrote: "submarine mission for you baby"
```

Signed-off-by: Rick Waldron <waldron.rick@gmail.com>