### PR TITLE
t2 run: move JS-specific "post run" operation to a language specific definition

### DIFF
--- a/lib/tessel/deploy.js
+++ b/lib/tessel/deploy.js
@@ -355,23 +355,24 @@ exportables.sendBundle = function(tessel, opts) {
 };
 
 
-exportables.run = function(tessel, opts) {
-  if (opts.resolvedEntryPoint === undefined) {
-    opts.resolvedEntryPoint = opts.entryPoint;
+exportables.run = function(tessel, options) {
+  if (options.resolvedEntryPoint === undefined) {
+    options.resolvedEntryPoint = options.entryPoint;
   }
 
-  log.info('Running %s...', opts.resolvedEntryPoint);
+  log.info('Running %s...', options.resolvedEntryPoint);
 
   return new Promise((resolve, reject) => {
-    var prom = Promise.resolve();
+    var preRun = Promise.resolve();
+    var lang = options.lang;
 
-    if (opts.lang.preRun) {
-      prom = opts.lang.preRun(tessel, opts);
+    if (lang.preRun) {
+      preRun = lang.preRun(tessel, options);
     }
 
-    return prom.then(() => {
+    return preRun.then(() => {
       tessel.connection.exec(
-        commands[opts.lang.meta.extname].execute(Tessel.REMOTE_RUN_PATH, opts.resolvedEntryPoint), {
+        commands[lang.meta.extname].execute(Tessel.REMOTE_RUN_PATH, options.resolvedEntryPoint), {
           pty: true
         }, (error, remoteProcess) => {
           if (error) {
@@ -380,14 +381,13 @@ exportables.run = function(tessel, opts) {
 
           log.spinner.stop();
 
+          if (lang.postRun) {
+            options.remoteProcess = remoteProcess;
+            lang.postRun(tessel, options);
+          }
+
           // When the stream closes, return from the function
           remoteProcess.once('close', resolve);
-
-          if (tessel.connection.connectionType === 'LAN') {
-            // Pipe input TO the remote process.
-            process.stdin.pipe(remoteProcess.stdin);
-            process.stdin.setRawMode(true);
-          }
 
           // Pipe output FROM the remote process.
           remoteProcess.stdout.pipe(process.stdout);

--- a/lib/tessel/deployment/javascript.js
+++ b/lib/tessel/deployment/javascript.js
@@ -63,11 +63,21 @@ var exportables = {
   lists: lists,
 };
 
-
-exportables.preBundle = function(opts) {
-  return exportables.resolveBinaryModules(opts);
+/*
+exportables.preRun = function(tessel, options) {
+  return Promise.resolve();
 };
+*/
 
+exportables.postRun = function(tessel, options) {
+  if (tessel.connection.connectionType === 'LAN') {
+    // Pipe input TO the remote process.
+    process.stdin.pipe(options.remoteProcess.stdin);
+    process.stdin.setRawMode(true);
+  }
+
+  return Promise.resolve();
+};
 
 function logMissingBinaryModuleWarning(name) {
   var warning = tags.stripIndent `
@@ -368,9 +378,13 @@ exportables.injectBinaryModules = function(globRoot, tempBundlePath, options) {
   });
 };
 
-exportables.tarBundle = function(opts) {
+exportables.preBundle = function(options) {
+  return exportables.resolveBinaryModules(options);
+};
+
+exportables.tarBundle = function(options) {
   var cwd = process.cwd();
-  var target = opts.target || cwd;
+  var target = options.target || cwd;
   var relative = path.relative(cwd, target);
   var globRoot = relative || target;
   var packer = tar.Pack({
@@ -378,8 +392,8 @@ exportables.tarBundle = function(opts) {
   });
   var buffers = [];
 
-  if (opts.full) {
-    opts.slim = false;
+  if (options.full) {
+    options.slim = false;
   }
 
   var includeRules = glob.rules(target, '.tesselinclude')
@@ -425,18 +439,18 @@ exportables.tarBundle = function(opts) {
   // project files themselves.
   var tempBundleDir = fsTemp.mkdirSync();
 
-  if (opts.slim) {
+  if (options.slim) {
     return new Promise((resolve, reject) => {
       var absRoot = path.resolve(globRoot);
       // Setup for detecting "overlooked" assets (files, directories, etc.)
-      var common = ['node_modules', 'package.json', '.tesselinclude', opts.resolvedEntryPoint];
+      var common = ['node_modules', 'package.json', '.tesselinclude', options.resolvedEntryPoint];
       // These will be compared against the dependency graph
       var assets = fs.readdirSync(globRoot)
         .filter(entry => (common.indexOf(entry) === -1))
         .map(entry => path.join(globRoot, entry));
 
       // Initialize a project for dependency graphing
-      var entry = path.join(relative, opts.resolvedEntryPoint);
+      var entry = path.join(relative, options.resolvedEntryPoint);
       var project = exportables.project({
         entry: entry,
         dirname: globRoot,
@@ -485,7 +499,7 @@ exportables.tarBundle = function(opts) {
               return;
             }
 
-            if (opts.single && !dependency.entry) {
+            if (options.single && !dependency.entry) {
               return;
             }
 
@@ -518,7 +532,7 @@ exportables.tarBundle = function(opts) {
           //    where the file in question was actually ignored due to
           //    an ignore rule. Ultimately, .tesselinclude has the final
           //    word on any file's inclusion/exclusion
-          if (!opts.single) {
+          if (!options.single) {
             includeFiles.forEach(file => {
               var target = path.join(tempBundleDir, file);
               if (!written[target]) {
@@ -536,7 +550,7 @@ exportables.tarBundle = function(opts) {
             log.warn('Some assets in this project were not deployed (see: t2 run --help)');
           }
 
-          exportables.injectBinaryModules(globRoot, tempBundleDir, opts)
+          exportables.injectBinaryModules(globRoot, tempBundleDir, options)
             .then(() => {
               var fstream = new Reader({
                 path: tempBundleDir,
@@ -577,7 +591,7 @@ exportables.tarBundle = function(opts) {
       // This allows us a safe way to "swap" binary modules.
       fs.copySync(globRoot, tempBundleDir);
 
-      return exportables.injectBinaryModules(globRoot, tempBundleDir, opts)
+      return exportables.injectBinaryModules(globRoot, tempBundleDir, options)
         .then(() => {
           var fstream = new Ignore({
             basename: '',
@@ -595,7 +609,7 @@ exportables.tarBundle = function(opts) {
             fstream.addIgnoreRules(includeNegateRules);
           }
 
-          if (!opts.single && includeFiles.length) {
+          if (!options.single && includeFiles.length) {
             // Instead of making a complete subclass of Ignore (as is done in fstream-npm,
             // https://github.com/npm/fstream-npm/blob/master/fstream-npm.js#L91-L183),
             // we'll over-ride the just the `applyIgnores` method for cases where there
@@ -609,8 +623,8 @@ exportables.tarBundle = function(opts) {
             };
           }
 
-          if (opts.single) {
-            fstream.addIgnoreRules(['*', '!' + opts.resolvedEntryPoint]);
+          if (options.single) {
+            fstream.addIgnoreRules(['*', '!' + options.resolvedEntryPoint]);
           }
 
           // This ensures that the remote root directory

--- a/lib/tessel/deployment/rust.js
+++ b/lib/tessel/deployment/rust.js
@@ -54,11 +54,19 @@ exportables.tarBundle = function() {
   return Promise.resolve(new Buffer([0xFF]));
 };
 
-exportables.preRun = function(tessel) {
+// The following line will be ignored by JSHint because
+// presently, `options` is not in use, but it's valuable to
+// include the parameter in the list.
+exportables.preRun = function(tessel, options) { // jshint ignore:line
   return new Promise((resolve) => {
     return tessel.connection.exec(commands.chmod('+x', `${Tessel.REMOTE_RUN_PATH}rust_executable`), {}, () => resolve());
   });
 };
 
+/*
+exportables.postRun = function(tessel, options) {
+  return Promise.resolve();
+};
+*/
 
 module.exports = exportables;

--- a/test/unit/deploy.js
+++ b/test/unit/deploy.js
@@ -397,9 +397,7 @@ exports['Tessel.prototype.restart'] = {
 
   tearDown: function(done) {
     this.tessel.mockClose();
-
     sandbox.restore();
-
     done();
   },
 
@@ -479,6 +477,7 @@ exports['deploy.run'] = {
     done();
   },
   tearDown: function(done) {
+    this.tessel.mockClose();
     sandbox.restore();
     done();
   },
@@ -523,54 +522,45 @@ exports['deploy.run'] = {
     });
   },
 
-  runStdInOutLan: function(test) {
-    test.expect(4);
+  runPostRunExistsLAN: function(test) {
+    test.expect(1);
 
     this.tessel.connection.connectionType = 'LAN';
 
+    this.postRun = sandbox.stub(deployment.js, 'postRun', () => Promise.resolve());
     this.exec = sandbox.stub(this.tessel.connection, 'exec', (command, options, callback) => {
       callback(null, this.tessel._rps);
       this.tessel._rps.emit('close');
     });
 
-    this.stdinPipe = sandbox.stub(process.stdin, 'pipe');
-    this.stdinSetRawMode = sandbox.stub(process.stdin, 'setRawMode');
-
     deploy.run(this.tessel, {
       resolvedEntryPoint: 'foo',
       lang: deployment.js,
     }).then(() => {
-      test.equal(this.stdinPipe.callCount, 1);
-      test.equal(this.stdinPipe.lastCall.args[0], this.tessel._rps.stdin);
-      test.equal(this.stdinSetRawMode.callCount, 1);
-      test.equal(this.stdinSetRawMode.lastCall.args[0], true);
+      test.equal(this.postRun.callCount, 1);
       test.done();
     });
   },
 
-  runStdInOutUsb: function(test) {
-    test.expect(2);
+  runPostRunExistsUSB: function(test) {
+    test.expect(1);
 
     this.tessel.connection.connectionType = 'USB';
-
     this.exec = sandbox.stub(this.tessel.connection, 'exec', (command, options, callback) => {
       callback(null, this.tessel._rps);
       this.tessel._rps.emit('close');
     });
 
-    this.stdinPipe = sandbox.stub(process.stdin, 'pipe');
-    this.stdinSetRawMode = sandbox.stub(process.stdin, 'setRawMode');
+    this.postRun = sandbox.stub(deployment.js, 'postRun', () => Promise.resolve());
 
     deploy.run(this.tessel, {
       resolvedEntryPoint: 'foo',
       lang: deployment.js,
     }).then(() => {
-      test.equal(this.stdinPipe.callCount, 0);
-      test.equal(this.stdinSetRawMode.callCount, 0);
+      test.equal(this.postRun.callCount, 1);
       test.done();
     });
   },
-
 };
 
 exports['deploy.createShellScript'] = {
@@ -580,6 +570,7 @@ exports['deploy.createShellScript'] = {
     done();
   },
   tearDown: function(done) {
+    this.tessel.mockClose();
     sandbox.restore();
     done();
   },

--- a/test/unit/deployment/javascript.js
+++ b/test/unit/deployment/javascript.js
@@ -1721,6 +1721,7 @@ exports['deploy.sendBundle, error handling'] = {
   },
 
   tearDown: function(done) {
+    this.tessel.mockClose();
     sandbox.restore();
     done();
   },
@@ -2478,6 +2479,7 @@ exports['deploy.createShellScript'] = {
     done();
   },
   tearDown: function(done) {
+    this.tessel.mockClose();
     sandbox.restore();
     done();
   },
@@ -2564,4 +2566,50 @@ exports['deployment.js.lists'] = {
     test.done();
   }
 
+};
+
+
+exports['deployment.js.postRun'] = {
+  setUp: function(done) {
+    this.info = sandbox.stub(log, 'info');
+    this.stdinPipe = sandbox.stub(process.stdin, 'pipe');
+    this.stdinSetRawMode = sandbox.stub(process.stdin, 'setRawMode');
+    this.tessel = TesselSimulator();
+    done();
+  },
+  tearDown: function(done) {
+    this.tessel.mockClose();
+    sandbox.restore();
+    done();
+  },
+
+  postRunLAN: function(test) {
+    test.expect(2);
+
+    this.tessel.connection.connectionType = 'LAN';
+    deployment.js.postRun(this.tessel, {
+      remoteProcess: {
+        stdin: null
+      }
+    }).then(() => {
+      test.equal(this.stdinPipe.callCount, 1);
+      test.equal(this.stdinSetRawMode.callCount, 1);
+      test.done();
+    });
+  },
+
+  postRunUSB: function(test) {
+    test.expect(2);
+
+    this.tessel.connection.connectionType = 'USB';
+    deployment.js.postRun(this.tessel, {
+      remoteProcess: {
+        stdin: null
+      }
+    }).then(() => {
+      test.equal(this.stdinPipe.callCount, 0);
+      test.equal(this.stdinSetRawMode.callCount, 0);
+      test.done();
+    });
+  },
 };


### PR DESCRIPTION
@johnnyman727 This should be reviewed and merged before any of the pending Rust support changes.



Signed-off-by: Rick Waldron <waldron.rick@gmail.com>