### PR TITLE
AP/WIFI check password validity for encryption type

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -664,7 +664,7 @@ controller.connectToNetwork = function(opts) {
   var ssid = opts.ssid;
   var password = opts.password;
   var security = opts.security;
-  var securityOptions = ['none', 'wep', 'psk', 'psk2', 'wpa', 'wpa2'];
+  var securityOptions = ['none', 'wep', 'psk', 'psk2'];
   return new Promise(function(resolve, reject) {
       if (!ssid) {
         return reject('Invalid credentials: must set SSID with the -n or --ssid option.');

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -681,9 +681,8 @@ controller.connectToNetwork = function(opts) {
       if (security === 'wep') {
         // WEP passphrases can be 10, 26, or 58 hexadecimal digits long.
         // Match for hexadecimal characters:
-        const regex = /^[0-9a-f]+$/i;
-        if (!regex.test(password)) {
-          return reject('Invalid passphrase: WEP keys must consist of hexadecimal digits.');
+        if (isNaN(`0x${password}`)) {
+          return reject('Invalid passphrase: WEP keys must consist of hexadecimal digits, i.e. 0 through 9 and "a" through "f".');
         }
         // Then test for length:
         const length = password.length;
@@ -697,9 +696,9 @@ controller.connectToNetwork = function(opts) {
         // Match ASCII codes for all 127 printable ASCII characters:
         const asciiRegex = /^[\x00-\x7F]{8,63}$/;
         // Match exactly 64 hexadecimal digits:
-        const hexRegex = /^[0-9a-f]{64}$/i;
-        // Reject if both regexes fail.
-        if (!asciiRegex.test(password) && !hexRegex.test(password)) {
+        const hexTest = !isNaN(`0x${password}`) && password.length === 64;
+        // Reject if both tests fail.
+        if (!asciiRegex.test(password) && !hexTest) {
           return reject('Invalid passphrase: WPA/WPA2-PSK passkeys must be 8-63 ASCII characters, or 64 hexadecimal digits.');
         }
       }

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -677,6 +677,32 @@ controller.connectToNetwork = function(opts) {
       if (security && securityOptions.indexOf(security) < 0) {
         return reject(`"${security}" is not a valid security option. Please choose on of the following: ${securityOptions.join(', ')}`);
       }
+      
+      if (security === 'wep') {
+        // WEP passphrases can be 10, 26, or 58 hexadecimal digits long.
+        // Match for hexadecimal characters:
+        const regex = /^[0-9a-f]+$/i;
+        if (!regex.test(password)) {
+          return reject('Invalid passphrase: WEP keys must consist of hexadecimal digits.');
+        }
+        // Then test for length:
+        const length = password.length;
+        if (length !== 10 || length !== 26 || length !== 58) {
+          return reject('Invalid passphrase: WEP keys must be 10, 26, or 58 digits long for 64-, 128-, and 256-bit WEP.');
+        }
+      }
+      
+      if (security === 'psk' || security === 'psk2') {
+        // WPA/WPA2-PSK passphrases can be 8-63 ASCII characters, or 64 hexadecimal digits.
+        // Match ASCII codes for all 127 printable ASCII characters:
+        const asciiRegex = /^[\x00-\x7F]{8,63}$/;
+        // Match exactly 64 hexadecimal digits:
+        const hexRegex = /^[0-9a-f]{64}$/i;
+        // Reject if both regexes fail.
+        if (!asciiRegex.test(password) && !hexRegex.test(password)) {
+          return reject('Invalid passphrase: WPA/WPA2-PSK passkeys must be 8-63 ASCII characters, or 64 hexadecimal digits.');
+        }
+      }
       resolve();
     })
     .then(() => {

--- a/test/unit/controller.js
+++ b/test/unit/controller.js
@@ -1065,6 +1065,104 @@ exports['controller.closeTesselConnections'] = {
         test.done();
       });
   },
+
+  invalidAccessPointWEPPasswordCharacters: function(test) {
+    test.expect(1);
+
+    controller.createAccessPoint({
+      ssid: 'test',
+      password: 'nothexdigits',
+      security: 'wep'
+    })
+    .catch(error => {
+      test.ok(error);
+      test.done();
+    });
+  },
+
+  invalidAccessPointWEPPasswordLength: function(test) {
+    test.expect(1);
+
+    controller.createAccessPoint({
+      ssid: 'test',
+      password: '0123456789ABCDEF',
+      security: 'wep'
+    })
+    .catch(error => {
+      test.ok(error);
+      test.done();
+    });
+  },
+
+  invalidAccessPointPSKPasswordCharacters: function(test) {
+    test.expect(1);
+
+    controller.createAccessPoint({
+      ssid: 'test',
+      password: 'Password™',
+      security: 'psk'
+    })
+    .catch(error => {
+      test.ok(error);
+      test.done();
+    });
+  },
+
+  invalidAccessPointPSKASCIIPasswordTooShort: function(test) {
+    test.expect(1);
+
+    controller.createAccessPoint({
+      ssid: 'test',
+      password: 'short',
+      security: 'psk'
+    })
+    .catch(error => {
+      test.ok(error);
+      test.done();
+    });
+  },
+
+  invalidAccessPointPSKASCIIPasswordTooLong: function(test) {
+    test.expect(1);
+
+    controller.createAccessPoint({
+      ssid: 'test',
+      password: 'this is a very long passphrase. in fact, it is over 63 characters, which makes it invalid.',
+      security: 'psk'
+    })
+    .catch(error => {
+      test.ok(error);
+      test.done();
+    });
+  },
+
+  invalidAccessPointPSKHexPasswordTooShort: function(test) {
+    test.expect(1);
+
+    controller.createAccessPoint({
+      ssid: 'test',
+      password: 'DEAD',
+      security: 'psk'
+    })
+    .catch(error => {
+      test.ok(error);
+      test.done();
+    });
+  },
+
+  invalidAccessPointPSKHexPasswordTooLong: function(test) {
+    test.expect(1);
+
+    controller.createAccessPoint({
+      ssid: 'test',
+      password: 'DEADDEADDEADDEADDEADDEADDEADDEADDEADDEADDEADDEADDEADDEADDEADDEADDEAD',
+      security: 'psk'
+    })
+    .catch(error => {
+      test.ok(error);
+      test.done();
+    });
+  },
 };
 
 exports['controller.root'] = {


### PR DESCRIPTION
This pull request fixes #760.

**Changes**:
* Removes WPA Enterprise options (`wpa`, `wpa2`) from `securityOptions` array.
* Adds network passphrase validation and relevant tests.