### PR TITLE
Turn top comment into crate-wide comment

### DIFF
--- a/resources/rust/main.rs
+++ b/resources/rust/main.rs
@@ -1,4 +1,4 @@
-/// A blinky example for Tessel
+//! A blinky example for Tessel
 
 // Import the tessel library
 extern crate rust_tessel;


### PR DESCRIPTION
Rust has several forms of special doc comments.
Three slashes `///` are the usual doc comments and are picked up by `rustdoc`, these should be used to document methods, structs, etc.
`//!` comments are used to document the containing items, in case of the top module documenting exactly this.

This gets important once once features or other things are added, as they can't come after a normal comment, but can after a top-level comment.