### PR TITLE
Dedupe wifi networks. Fixes gh-793

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -604,17 +604,17 @@ controller.renameTessel = function(opts) {
 
 controller.printAvailableNetworks = function(opts) {
   opts.authorized = true;
-  return controller.standardTesselCommand(opts, function(tessel) {
-    log.info('Scanning for available networks...');
+  return controller.standardTesselCommand(opts, (tessel) => {
+    log.info('Scanning for visible networks...');
 
     // Ask Tessel what networks it finds in a scan
     return tessel.findAvailableNetworks()
-      .then(function(networks) {
-        log.info('Currently visible networks (' + networks.length + '):');
+      .then((networks) => {
+        log.info(`Found ${networks.length} network${networks.length > 1 ? 's' : ''} visible to ${tessel.name}:`);
 
         // Print out networks
-        networks.forEach(function(network) {
-          log.info('\t', network.ssid, '(' + network.quality + ')');
+        networks.forEach((network) => {
+          log.basic(`\t${network.ssid} (${network.quality})`);
         });
       });
   });

--- a/lib/tessel/wifi.js
+++ b/lib/tessel/wifi.js
@@ -11,6 +11,8 @@ var Tessel = require('./tessel');
 
 
 Tessel.prototype.findAvailableNetworks = function() {
+  var listed = {};
+
   return this.simpleExec(commands.scanWiFi())
     .then(function wifiScanResults(result) {
       // For each string chunk
@@ -29,8 +31,12 @@ Tessel.prototype.findAvailableNetworks = function() {
             // Parse the security type - unused at the moment
             security: encryptionRegex.exec(entry)[1],
           };
-          // Add this parsed network to our array
-          networks.push(networkInfo);
+
+          if (!listed[networkInfo.ssid]) {
+            listed[networkInfo.ssid] = true;
+            // Add this parsed network to our array
+            networks.push(networkInfo);
+          }
         } catch (err) {
           // Suppress errors created by entries that cannot be parsed.
         }

--- a/test/unit/wifi.js
+++ b/test/unit/wifi.js
@@ -72,6 +72,57 @@ exports['Tessel.prototype.findAvailableNetworks'] = {
     });
   },
 
+  dedupeNetworks: function(test) {
+    test.expect(2);
+
+    var networks =
+      `Cell 01 - Address: 14:35:8B:11:30:F0
+              ESSID: "technicallyHome"
+              Mode: Master  Channel: 11
+              Signal: -55 dBm  Quality: 55/70
+              Encryption: mixed WPA/WPA2 PSK (TKIP, CCMP)
+
+    Cell 02 - Address: 6C:70:9F:D9:7A:5C
+              ESSID: "Fried Chicken Sandwich"
+              Mode: Master  Channel: 2
+              Signal: -51 dBm  Quality: 59/70
+              Encryption: WPA2 PSK (CCMP)
+
+    Cell 03 - Address: 6C:70:9F:D9:7A:5C
+              ESSID: "Fried Chicken Sandwich"
+              Mode: Master  Channel: 2
+              Signal: -51 dBm  Quality: 59/70
+              Encryption: WPA2 PSK (CCMP)
+
+    Cell 04 - Address: 6C:70:9F:D9:7A:5C
+              ESSID: "Fried Chicken Sandwich"
+              Mode: Master  Channel: 2
+              Signal: -51 dBm  Quality: 59/70
+              Encryption: WPA2 PSK (CCMP)
+
+    Cell 05 - Address: 6C:70:9F:D9:7A:5C
+              ESSID: "Fried Chicken Sandwich"
+              Mode: Master  Channel: 2
+              Signal: -51 dBm  Quality: 59/70
+              Encryption: WPA2 PSK (CCMP)
+
+`;
+    // Do not remove the blank line at the end of preceding string!!
+
+    this.tessel.findAvailableNetworks()
+      .then((found) => {
+        test.equal(found.length, 2);
+        test.equal(this.findAvailableNetworks.callCount, 1);
+        test.done();
+      });
+
+    this.tessel._rps.stdout.push(networks);
+
+    setImmediate(() => {
+      this.tessel._rps.emit('close');
+    });
+  },
+
   compareSignalStrengths: function(test) {
     test.expect(5);
 


### PR DESCRIPTION
# Smoke Tests


1. Run `t2 wifi --list`
2. There should be:
  - no duplicates
  - proper pluralization of the work "network"



Signed-off-by: Rick Waldron <waldron.rick@gmail.com>