### PR TITLE
Dedupe Tessels found on LAN connections. Fixes gh-719

### DIFF
--- a/lib/lan-connection.js
+++ b/lib/lan-connection.js
@@ -183,17 +183,18 @@ LAN.Scanner.prototype.start = function() {
     });
 
     // When the browser finds a new device
-    this.browser.on('update', (data) => {
+    this.browser.on('update', (discovered) => {
       try {
-        debug(`Device found: ${data.fullname}`);
-        // Check if it's a Tessel
-        if (this.discovered.indexOf(data) > -1) {
+        debug(`Device found: ${discovered.fullname}`);
+
+        // Check against already discovered devices
+        if (this.discovered.find(known => known.host === discovered.host)) {
           return;
         }
+        // Add to list of discovered devices
+        this.discovered.push(discovered);
 
-        var connection = new LAN.Connection(data);
-
-        this.emit('connection', connection);
+        this.emit('connection', new LAN.Connection(discovered));
       } catch (err) {
         this.emit('error', err);
       }

--- a/test/unit/lan-connection.js
+++ b/test/unit/lan-connection.js
@@ -200,30 +200,69 @@ exports['LAN.Scanner.prototype.start'] = {
   },
 
   updateDiscovered: function(test) {
-    test.expect(1);
+    test.expect(3);
 
     var data = {};
     var connectionHandler = this.sandbox.spy();
 
     this.scanner.start();
+    test.equal(this.scanner.discovered.length, 0);
     this.scanner.on('connection', connectionHandler);
     this.scanner.browser.emit('update', data);
 
     test.equal(connectionHandler.callCount, 1);
+    test.equal(this.scanner.discovered.length, 1);
     test.done();
   },
 
   updateDiscoveredExists: function(test) {
-    test.expect(1);
+    test.expect(4);
 
     var connectionHandler = this.sandbox.spy();
+    var discovery = {
+      addresses: ['192.168.1.9'],
+      query: ['_tessel._tcp.local'],
+      type: [{
+        name: 'tessel',
+        protocol: 'tcp',
+        subtypes: [],
+        description: undefined
+      }],
+      port: 22,
+      fullname: 'bishop._tessel._tcp.local',
+      txt: [''],
+      host: 'bishop.local',
+      interfaceIndex: 0,
+      networkInterface: 'en0'
+    };
 
-    this.scanner.start();
+    var connection = {
+      auth: {
+        host: '192.168.1.9',
+        port: 22,
+        username: 'root',
+        passphrase: '',
+        privateKey: undefined,
+        readyTimeout: 5000
+      },
+      ip: '192.168.1.9',
+      host: 'bishop.local',
+      connectionType: 'LAN',
+      authorized: false,
+      ssh: undefined
+    };
+
+    test.equal(this.scanner.discovered.length, 0);
+
     this.scanner.on('connection', connectionHandler);
-    this.scanner.discovered.push(1);
-    this.scanner.browser.emit('update', 1);
+    this.scanner.start();
+
+    this.scanner.discovered.push(connection);
+    test.equal(this.scanner.discovered.length, 1);
+    this.scanner.browser.emit('update', discovery);
 
     test.equal(connectionHandler.callCount, 0);
+    test.equal(this.scanner.discovered.length, 1);
     test.done();
   },
 


### PR DESCRIPTION
The problem here was:

1. Nothing was actually being put into `this.discovered`
2. Even if there had been, the test we did have would've passed anyway because it just put a number in the list and then emitted a number. That would assume that the thing put into `this.discovered` had the same object identity as the thing being checked, which is wrong.


# Smoke Test


This is easier to do with 2 or more Tessels, so I've just taken screen shots to show the result of the changes: 

Before: 
![](https://i.gyazo.com/9f9b83bd31a447d1ea510b611d2760b4.png)

After: 
![](https://i.gyazo.com/026f56f80949bb36fa60d980a4054738.png)

Signed-off-by: Rick Waldron <waldron.rick@gmail.com>