### PR TITLE
run/push: support "subargs" for forwarding to remote process. Fixes gh-732

### DIFF
--- a/lib/tessel/commands.js
+++ b/lib/tessel/commands.js
@@ -18,15 +18,15 @@ module.exports.app = {
  *
  */
 module.exports.js = {
-  execute: (filepath, relpath) => ['node', filepath + relpath],
+  execute: (filepath, relpath, args) => ['node', filepath + relpath].concat(args),
 };
 
 module.exports.rs = {
-  execute: (filepath, relpath) => [filepath + relpath],
+  execute: (filepath, relpath, args) => [filepath + relpath].concat(args),
 };
 
 module.exports.py = {
-  execute: (filepath, relpath) => ['python', filepath + relpath],
+  execute: (filepath, relpath, args) => ['python', filepath + relpath].concat(args),
 };
 
 module.exports.readFile = function(filepath) {

--- a/lib/tessel/deploy.js
+++ b/lib/tessel/deploy.js
@@ -124,6 +124,7 @@ Tessel.prototype.deploy = function(opts) {
 
   // Resolve the application's language/runtime
   opts.lang = deployment.resolveLanguage(opts.lang || opts.entryPoint);
+  opts.subargs = opts.subargs || [];
 
   return new Promise((resolve, reject) => {
     // Stop running an existing applications
@@ -373,7 +374,7 @@ exportables.run = function(tessel, options) {
 
     return preRun.then(() => {
       tessel.connection.exec(
-        commands[lang.meta.extname].execute(Tessel.REMOTE_RUN_PATH, options.resolvedEntryPoint), {
+        commands[lang.meta.extname].execute(Tessel.REMOTE_RUN_PATH, options.resolvedEntryPoint, options.subargs), {
           pty: true
         }, (error, remoteProcess) => {
           if (error) {
@@ -438,6 +439,7 @@ exportables.createShellScript = function(tessel, opts) {
           });
         });
       });
+
       remoteProcess.stdin.end(new Buffer(opts.lang.meta.shell(opts).trim()));
     });
   });

--- a/lib/tessel/deployment/javascript.js
+++ b/lib/tessel/deployment/javascript.js
@@ -53,10 +53,10 @@ var exportables = {
         program
       };
     },
-    shell: (opts) => {
+    shell: (options) => {
       return tags.stripIndent `
         #!/bin/sh
-        exec node /app/remote-script/${opts.resolvedEntryPoint}
+        exec node /app/remote-script/${options.resolvedEntryPoint} ${options.subargs.join(' ')}
       `;
     },
   },

--- a/lib/tessel/deployment/python.js
+++ b/lib/tessel/deployment/python.js
@@ -33,10 +33,10 @@ var exportables = {
         program
       };
     },
-    shell: (opts) => {
+    shell: (options) => {
       return tags.stripIndent `
         #!/bin/sh
-        exec python /app/remote-script/${opts.resolvedEntryPoint}
+        exec python /app/remote-script/${options.resolvedEntryPoint} ${options.subargs.join(' ')}
       `;
     },
   },

--- a/lib/tessel/deployment/rust.js
+++ b/lib/tessel/deployment/rust.js
@@ -37,10 +37,10 @@ var exportables = {
         program
       };
     },
-    shell: (opts) => {
+    shell: (options) => {
       return tags.stripIndent `
         #!/bin/sh
-        exec /app/remote-script/${opts.resolvedEntryPoint}
+        exec /app/remote-script/${options.resolvedEntryPoint} ${options.subargs.join(' ')}
       `;
     },
   },

--- a/test/unit/deploy.js
+++ b/test/unit/deploy.js
@@ -284,7 +284,8 @@ exports['Tessel.prototype.deploy'] = {
     test.expect(12);
     deployTestCode(this.tessel, {
       push: true,
-      single: false
+      single: false,
+      subargs: [],
     }, (error) => {
       if (error) {
         test.ok(false, `deployTestCode failed: ${error.toString()}`);
@@ -538,8 +539,10 @@ exports['deploy.run'] = {
     deploy.run(this.tessel, {
       entryPoint: entryPoint,
       lang: deployment.js,
+      subargs: ['--key=value'],
     }).then(() => {
-      test.deepEqual(this.exec.lastCall.args[0], [deployment.js.meta.binary, Tessel.REMOTE_RUN_PATH + entryPoint]);
+      test.deepEqual(
+        this.exec.lastCall.args[0], [deployment.js.meta.binary, Tessel.REMOTE_RUN_PATH + entryPoint, '--key=value']);
       test.done();
     });
   },
@@ -572,6 +575,7 @@ exports['deploy.run'] = {
     deploy.run(this.tessel, {
       entryPoint: entryPoint,
       lang: deployment.rs,
+      subargs: [],
     }).then(() => {
       test.done();
     });
@@ -591,6 +595,7 @@ exports['deploy.run'] = {
     deploy.run(this.tessel, {
       resolvedEntryPoint: 'foo',
       lang: deployment.js,
+      subargs: [],
     }).then(() => {
       test.equal(this.postRun.callCount, 1);
       test.done();
@@ -640,7 +645,8 @@ exports['deploy.createShellScript'] = {
 
     var opts = {
       lang: deployment.js,
-      resolvedEntryPoint: 'foo'
+      resolvedEntryPoint: 'foo',
+      subargs: ['--key=value'],
     };
 
     deploy.createShellScript(this.tessel, opts).then(() => {


### PR DESCRIPTION
Uses the ["subarg"](https://www.npmjs.com/package/subarg) syntax:

```
t2 run index.js [foo bar baz -a 1 -b 2 --named --key=value]
```

Will result in process.argv on the deployed program:

```
[ '/usr/bin/node',
  '/tmp/remote-script/index.js',
  'foo',
  'bar',
  'baz',
  '-a',
  '1',
  '-b',
  '2',
  '--named',
  '--key=value' ]
```


# Smoke Test

(pull this branch locally)


1. Create a new project: 
  ```
  mkdir t2-732 && cd t2-732 && t2 init;
  npm install minimist --save
  ```
2. Open the `index.js` just now and replace the contents with: 
  ```js
  var argv = require('minimist')(process.argv.slice(2));

  console.log(argv);
  ```
3. Run `t2 run index.js [foo bar baz -a 1 -b 2 --named --key=value]`

Deployment should look something like this: 

```
$ t2 run index.js [foo bar baz -a 1 -b 2 --named --key=value]
INFO Looking for your Tessel...
INFO Connected to ash.
INFO Building project.
INFO Writing project to RAM on ash (9.728 kB)...
INFO Deployed.
INFO Running index.js...
{ _: [ 'foo', 'bar', 'baz' ],
  a: 1,
  b: 2,
  named: true,
  key: 'value' }
```

Signed-off-by: Rick Waldron <waldron.rick@gmail.com>