### PR TITLE
Fix-bricked-restore

### DIFF
--- a/lib/tessel/restore.js
+++ b/lib/tessel/restore.js
@@ -142,7 +142,7 @@ exportables.validateDeviceId = function(usb) {
 
 // 9.6.3 Bulk Erase (BE 60h or C7h)
 exportables.bulkEraseFlash = function(usb) {
-  return exportables.transaction(usb, COMMAND_BE);
+  return (exportables.transaction(usb, COMMAND_BE)).then(() => exportables.waitTransactionComplete(usb));
 };
 
 // NOTE: The following commands do not directly interact with the flash memory registers

--- a/lib/tessel/restore.js
+++ b/lib/tessel/restore.js
@@ -220,7 +220,11 @@ exportables.flash = function(tessel, buffers) {
     buffers.partition = exportables.partition(mac1, mac2);
 
     return Promise.resolve().then(() => {
-        log.info('Bulk Erasing Flash Memory...');
+        log.info('Setting WRITE_ENABLED');
+        return exportables.enableWrite(usb);
+      })
+      .then(() => {
+        log.info('Bulk Erasing Flash Memory (this may take a minute)...');
         return exportables.bulkEraseFlash(usb);
       })
       .then(() => {


### PR DESCRIPTION
During [refactor](https://github.com/tessel/t2-cli/commit/5c6e994af34e4219dce84a8c1f77725c9630b5f0), `exportables.enableWrite` was defined but never called. Also make sure to wait for memory to be erased before writing. 

fixes #824 