### PR TITLE
Bail out if not a valid version of node. Fixes gh-764

### DIFF
--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -19,6 +19,11 @@ const CLI_ENTRYPOINT = 'cli.entrypoint';
 // Check for updates
 const pkg = require('../package.json');
 
+if (parseInt(process.versions.node) > 5) {
+  log.error('Tessel 2 CLI (t2-cli) is supported for use with the Node.js 4.x.x LTS Release.');
+  process.exit();
+}
+
 /*
  * If a command has been run with root,
  * do not try to read the update-notifier config file.


### PR DESCRIPTION
Sure, this is incredibly brutal, but the usb module DOESN'T WORK on Node.js > 4, so there is no point in being misleading. This is "fail hard, fail early" at it's bluntest.

cc @HipsterBrown 

Signed-off-by: Rick Waldron <waldron.rick@gmail.com>