### PR TITLE
t2 restore: progress bars for all write operations

### DIFF
--- a/lib/tessel/restore.js
+++ b/lib/tessel/restore.js
@@ -182,6 +182,7 @@ exportables.waitTransactionComplete = function(usb) {
 exportables.write = function(usb, offset, buffer) {
 
   var bar = new Progress('  Writing [:bar] :percent :etas remaining', {
+    clear: true,
     complete: '=',
     incomplete: ' ',
     width: 20,

--- a/lib/tessel/restore.js
+++ b/lib/tessel/restore.js
@@ -2,7 +2,7 @@
 // ...
 
 // Third Party Dependencies
-// ...
+var Progress = require('progress');
 
 // Internal
 var log = require('../log');
@@ -180,12 +180,24 @@ exportables.waitTransactionComplete = function(usb) {
 };
 
 exportables.write = function(usb, offset, buffer) {
+
+  var bar = new Progress('  Writing [:bar] :percent :etas remaining', {
+    complete: '=',
+    incomplete: ' ',
+    width: 20,
+    total: buffer.length
+  });
+
+  log.spinner.stop();
+
   return new Promise(resolve => {
     var sendChunk = () => {
       var size = buffer.length > PAGE_SIZE ? PAGE_SIZE : buffer.length;
       exportables.writePage(usb, offset, buffer.slice(0, size)).then(() => {
         buffer = buffer.slice(size);
         offset += PAGE_SIZE;
+
+        bar.tick(size);
 
         // If "buffer" still has contents, keep sending chunks.
         if (buffer.length) {

--- a/lib/tessel/restore.js
+++ b/lib/tessel/restore.js
@@ -181,7 +181,7 @@ exportables.waitTransactionComplete = function(usb) {
 
 exportables.write = function(usb, offset, buffer) {
 
-  var bar = new Progress('  Writing [:bar] :percent :etas remaining', {
+  var bar = new Progress('     [:bar] :percent :etas remaining', {
     clear: true,
     complete: '=',
     incomplete: ' ',

--- a/lib/tessel/restore.js
+++ b/lib/tessel/restore.js
@@ -245,7 +245,7 @@ exportables.flash = function(tessel, buffers) {
         return exportables.write(usb, 0x40000, buffers.partition);
       })
       .then(() => {
-        log.info('Writing OpenWRT SquashFS (this may take a few minutes)...');
+        log.info('Writing OpenWRT SquashFS...');
         return exportables.write(usb, 0x50000, buffers.squashfs);
       })
       .then(() => {

--- a/lib/update-fetch.js
+++ b/lib/update-fetch.js
@@ -169,7 +169,7 @@ exportables.downloadTgz = function(tgzUrl, fileMap) {
       var contentLength = parseInt(res.headers['content-length'], 10);
 
       // Create a new progress bar
-      var bar = new Progress('  Downloading [:bar] :percent :etas remaining', {
+      var bar = new Progress('     [:bar] :percent :etas remaining', {
         clear: true,
         complete: '=',
         incomplete: ' ',

--- a/lib/update-fetch.js
+++ b/lib/update-fetch.js
@@ -5,7 +5,7 @@ var fs = require('fs');
 // Third Party Dependencies
 var gunzip = require('zlib').createGunzip();
 var extract = require('tar-stream').extract();
-var ProgressBar = require('progress');
+var Progress = require('progress');
 var request = require('request');
 var streamToBuffer = require('stream-to-buffer');
 var urljoin = require('url-join');
@@ -127,7 +127,7 @@ exportables.fetchBuild = function(build) {
 
 exportables.downloadTgz = function(tgzUrl, fileMap) {
   return new Promise((resolve, reject) => {
-    log.info('Downloading files. This may take a few minutes...');
+    log.info('Downloading files (this may take a few minutes)...');
 
     var files = {};
 
@@ -169,7 +169,7 @@ exportables.downloadTgz = function(tgzUrl, fileMap) {
       var contentLength = parseInt(res.headers['content-length'], 10);
 
       // Create a new progress bar
-      var bar = new ProgressBar('  Downloading [:bar] :percent :etas remaining', {
+      var bar = new Progress('  Downloading [:bar] :percent :etas remaining', {
         complete: '=',
         incomplete: ' ',
         width: 20,

--- a/lib/update-fetch.js
+++ b/lib/update-fetch.js
@@ -127,7 +127,7 @@ exportables.fetchBuild = function(build) {
 
 exportables.downloadTgz = function(tgzUrl, fileMap) {
   return new Promise((resolve, reject) => {
-    log.info('Downloading files (this may take a few minutes)...');
+    log.info('Downloading files...');
 
     var files = {};
 

--- a/lib/update-fetch.js
+++ b/lib/update-fetch.js
@@ -170,6 +170,7 @@ exportables.downloadTgz = function(tgzUrl, fileMap) {
 
       // Create a new progress bar
       var bar = new Progress('  Downloading [:bar] :percent :etas remaining', {
+        clear: true,
         complete: '=',
         incomplete: ' ',
         width: 20,


### PR DESCRIPTION
Needs tests, but wondering what folks think. The result is pretty nice: 


![](https://i.gyazo.com/923103485f92641c77806950eda53733.png)

![](https://i.gyazo.com/acc69f9c4aacb43affeb7ab447e7d293.png)

![](https://i.gyazo.com/770668fbf4bb187da78a385df10d3996.png)

![](https://i.gyazo.com/2ca22f170f4d84d8411ec63d4917f10c.png)

![](https://i.gyazo.com/9b56a7aaddb9abe6b831b26b63378a64.png)

Signed-off-by: Rick Waldron <waldron.rick@gmail.com>