### PR TITLE
Adhoc network support

### DIFF
--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -482,6 +482,46 @@ makeCommand('version')
 
 makeCommand('ap')
   .callback(options => {
+    options.mode = 'ap';
+    log.level(options.loglevel);
+
+    if (options.on || options.off) {
+      if (options.on) {
+        callControllerWith('enableAccessPoint', options);
+      } else {
+        callControllerWith('disableAccessPoint', options);
+      }
+    } else if (options.ssid) {
+      callControllerWith('createAccessPoint', options);
+    } else {
+      callControllerWith('getAccessPointInfo', options);
+    }
+  })
+  .option('ssid', {
+    abbr: 'n',
+    help: 'Name of the network.'
+  })
+  .option('password', {
+    abbr: 'p',
+    help: 'Password to access network.'
+  })
+  .option('security', {
+    abbr: 's',
+    help: 'Encryption to use on network (i.e. wep, psk, psk2, wpa, wpa2).'
+  })
+  .option('off', {
+    flag: true,
+    help: 'Disable the access point'
+  })
+  .option('on', {
+    flag: true,
+    help: 'Enable the access point'
+  })
+  .help('Configure the Tessel as an access point');
+
+makeCommand('adhoc')
+  .callback(options => {
+    options.mode = 'adhoc';
     log.level(options.loglevel);
 
     if (options.on || options.off) {

--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -546,17 +546,17 @@ makeCommand('adhoc')
   })
   .option('security', {
     abbr: 's',
-    help: 'Encryption to use on network (i.e. wep, psk, psk2, wpa, wpa2).'
+    help: 'Encryption used on network (i.e. wep, psk, psk2, wpa, wpa2).'
   })
   .option('off', {
     flag: true,
-    help: 'Disable the access point'
+    help: 'Disable the adhoc network'
   })
   .option('on', {
     flag: true,
-    help: 'Enable the access point'
+    help: 'Enable the adhoc network'
   })
-  .help('Configure the Tessel as an access point');
+  .help('Configure the Tessel as an adhoc network');
 
 makeCommand('root')
   .callback(options => {

--- a/lib/tessel/access-point.js
+++ b/lib/tessel/access-point.js
@@ -102,7 +102,7 @@ Tessel.prototype.getAccessPointInfo = function() {
 
 Tessel.prototype.createAccessPoint = function(opts) {
   var ssid = opts.ssid;
-  var password = opts.pass;
+  var password = opts.password;
   var security = opts.security;
   var mode = opts.mode;
   var status = 'Created Access Point successfully. ';

--- a/lib/tessel/access-point.js
+++ b/lib/tessel/access-point.js
@@ -84,7 +84,7 @@ Tessel.prototype.getAccessPointInfo = function() {
 
         info = {
           ssid: values[0],
-          key: values[1],
+          key: values[2] !== 'none' ? values[1] : null, // the password for a previous configuration could still exist, so omit this info if the encryption is 'none'
           encryption: values[2],
           disabled: values[3]
         };
@@ -104,6 +104,7 @@ Tessel.prototype.createAccessPoint = function(opts) {
   var ssid = opts.ssid;
   var password = opts.pass;
   var security = opts.security;
+  var mode = opts.mode;
   var status = 'Created Access Point successfully. ';
 
 
@@ -125,6 +126,8 @@ Tessel.prototype.createAccessPoint = function(opts) {
 
     var setAccessPointSecurity = () => this.simpleExec(commands.setAccessPointSecurity(security));
 
+    var setAccessPointMode = () => this.simpleExec(commands.setAccessPointMode(mode));
+
     var turnAccessPointOn = () => this.simpleExec(commands.turnAccessPointOn());
 
     var commitAndClosePromise = () => {
@@ -143,6 +146,7 @@ Tessel.prototype.createAccessPoint = function(opts) {
     };
 
     return setup()
+      .then(setAccessPointMode)
       .then(turnAccessPointOn)
       .then(commitAndClosePromise);
   };
@@ -160,8 +164,7 @@ Tessel.prototype.createAccessPoint = function(opts) {
       var setAccessPoint = () => {
         return this.simpleExec(commands.setAccessPoint())
           .then(() => this.simpleExec(commands.setAccessPointDevice()))
-          .then(() => this.simpleExec(commands.setAccessPointNetwork()))
-          .then(() => this.simpleExec(commands.setAccessPointMode()));
+          .then(() => this.simpleExec(commands.setAccessPointNetwork()));
       };
 
       var setLanNetwork = () => {

--- a/lib/tessel/commands.js
+++ b/lib/tessel/commands.js
@@ -149,8 +149,8 @@ module.exports.setAccessPointDevice = function() {
 module.exports.setAccessPointNetwork = function() {
   return ['uci', 'set', 'wireless.@wifi-iface[1].network=lan'];
 };
-module.exports.setAccessPointMode = function() {
-  return ['uci', 'set', 'wireless.@wifi-iface[1].mode=ap'];
+module.exports.setAccessPointMode = function(mode) {
+  return ['uci', 'set', `wireless.@wifi-iface[1].mode=${mode}`];
 };
 module.exports.setAccessPointSSID = function(ssid) {
   return ['uci', 'set', 'wireless.@wifi-iface[1].ssid=' + ssid];

--- a/test/unit/access-point.js
+++ b/test/unit/access-point.js
@@ -46,11 +46,12 @@ exports['Tessel.prototype.createAccessPoint'] = {
   },
 
   newAccessPoint: function(test) {
-    test.expect(20);
+    test.expect(21);
     var creds = {
       ssid: 'test',
-      pass: 'test-password',
-      security: 'psk2'
+      password: 'test-password',
+      security: 'psk2',
+      mode: 'ap'
     };
 
     // Immediately close any opened connections
@@ -94,8 +95,71 @@ exports['Tessel.prototype.createAccessPoint'] = {
         test.equal(this.reconnectDnsmasq.callCount, 1);
         test.equal(this.reconnectDhcp.callCount, 1);
         test.ok(this.setAccessPointSSID.lastCall.calledWith(creds.ssid));
-        test.ok(this.setAccessPointPassword.lastCall.calledWith(creds.pass));
+        test.ok(this.setAccessPointPassword.lastCall.calledWith(creds.password));
         test.ok(this.setAccessPointSecurity.lastCall.calledWith(creds.security));
+        test.ok(this.setAccessPointMode.lastCall.calledWith(creds.mode));
+
+        test.done();
+      })
+      .catch(error => {
+        test.ok(false, error.toString());
+        test.done();
+      });
+  },
+
+  newAdhoc: function(test) {
+    test.expect(21);
+    var creds = {
+      ssid: 'test',
+      password: 'test-password',
+      security: 'psk2',
+      mode: 'adhoc'
+    };
+
+    // Immediately close any opened connections
+    this.tessel._rps.on('control', () => {
+      setImmediate(() => {
+        this.tessel._rps.emit('close');
+      });
+    });
+
+    // tessel.receive is called twice but needs to be rejected the first time
+    var count = 0;
+    this.sandbox.stub(this.tessel, 'receive', function(remoteProcess, callback) {
+      if (typeof callback !== 'function') {
+        callback = function() {};
+      }
+      if (count === 0) {
+        count++;
+        return callback(new Error('uci: Entry not found'));
+      } else {
+        return callback(null, new Buffer(0));
+      }
+    });
+
+    this.tessel.createAccessPoint(creds)
+      .then(() => {
+        test.equal(this.getAccessPoint.callCount, 1);
+        test.equal(this.setAccessPoint.callCount, 1);
+        test.equal(this.setAccessPointDevice.callCount, 1);
+        test.equal(this.setAccessPointNetwork.callCount, 1);
+        test.equal(this.setAccessPointMode.callCount, 1);
+        test.equal(this.setAccessPointSSID.callCount, 1);
+        test.equal(this.setAccessPointPassword.callCount, 1);
+        test.equal(this.setAccessPointSecurity.callCount, 1);
+        test.equal(this.setLanNetwork.callCount, 1);
+        test.equal(this.setLanNetworkIfname.callCount, 1);
+        test.equal(this.setLanNetworkProto.callCount, 1);
+        test.equal(this.setLanNetworkIP.callCount, 1);
+        test.equal(this.setLanNetworkNetmask.callCount, 1);
+        test.equal(this.commitNetwork.callCount, 1);
+        test.equal(this.reconnectWifi.callCount, 1);
+        test.equal(this.reconnectDnsmasq.callCount, 1);
+        test.equal(this.reconnectDhcp.callCount, 1);
+        test.ok(this.setAccessPointSSID.lastCall.calledWith(creds.ssid));
+        test.ok(this.setAccessPointPassword.lastCall.calledWith(creds.password));
+        test.ok(this.setAccessPointSecurity.lastCall.calledWith(creds.security));
+        test.ok(this.setAccessPointMode.lastCall.calledWith(creds.mode));
 
         test.done();
       })
@@ -106,11 +170,12 @@ exports['Tessel.prototype.createAccessPoint'] = {
   },
 
   noPasswordNoSecurity: function(test) {
-    test.expect(9);
+    test.expect(10);
     var creds = {
       ssid: 'test',
-      pass: undefined,
-      security: undefined
+      password: undefined,
+      security: undefined,
+      mode: 'ap'
     };
 
     // Test is expecting two closes...;
@@ -126,6 +191,7 @@ exports['Tessel.prototype.createAccessPoint'] = {
         test.equal(this.setAccessPointSSID.callCount, 1);
         test.equal(this.setAccessPointPassword.callCount, 0);
         test.equal(this.setAccessPointSecurity.callCount, 1);
+        test.equal(this.setAccessPointMode.callCount, 1);
         test.equal(this.reconnectWifi.callCount, 1);
         test.equal(this.reconnectDnsmasq.callCount, 1);
         test.equal(this.reconnectDhcp.callCount, 1);
@@ -140,11 +206,12 @@ exports['Tessel.prototype.createAccessPoint'] = {
   },
 
   properCredentials: function(test) {
-    test.expect(10);
+    test.expect(11);
     var creds = {
       ssid: 'test',
-      pass: 'test-password',
-      security: 'psk2'
+      password: 'test-password',
+      security: 'psk2',
+      mode: 'ap'
     };
 
     // Test is expecting two closes...;
@@ -160,11 +227,12 @@ exports['Tessel.prototype.createAccessPoint'] = {
         test.equal(this.setAccessPointSSID.callCount, 1);
         test.equal(this.setAccessPointPassword.callCount, 1);
         test.equal(this.setAccessPointSecurity.callCount, 1);
+        test.equal(this.setAccessPointMode.callCount, 1);
         test.equal(this.reconnectWifi.callCount, 1);
         test.equal(this.reconnectDnsmasq.callCount, 1);
         test.equal(this.reconnectDhcp.callCount, 1);
         test.ok(this.setAccessPointSSID.lastCall.calledWith(creds.ssid));
-        test.ok(this.setAccessPointPassword.lastCall.calledWith(creds.pass));
+        test.ok(this.setAccessPointPassword.lastCall.calledWith(creds.password));
         test.ok(this.setAccessPointSecurity.lastCall.calledWith(creds.security));
         test.done();
       })
@@ -175,11 +243,12 @@ exports['Tessel.prototype.createAccessPoint'] = {
   },
 
   passwordNoSecurity: function(test) {
-    test.expect(10);
+    test.expect(11);
     var creds = {
       ssid: 'test',
-      pass: 'test-password',
-      security: undefined
+      password: 'test-password',
+      security: undefined,
+      mode: 'ap'
     };
 
     // Test is expecting two closes...;
@@ -195,11 +264,12 @@ exports['Tessel.prototype.createAccessPoint'] = {
         test.equal(this.setAccessPointSSID.callCount, 1);
         test.equal(this.setAccessPointPassword.callCount, 1);
         test.equal(this.setAccessPointSecurity.callCount, 1);
+        test.equal(this.setAccessPointMode.callCount, 1);
         test.equal(this.reconnectWifi.callCount, 1);
         test.equal(this.reconnectDnsmasq.callCount, 1);
         test.equal(this.reconnectDhcp.callCount, 1);
         test.ok(this.setAccessPointSSID.lastCall.calledWith(creds.ssid));
-        test.ok(this.setAccessPointPassword.lastCall.calledWith(creds.pass));
+        test.ok(this.setAccessPointPassword.lastCall.calledWith(creds.password));
         test.ok(this.setAccessPointSecurity.lastCall.calledWith('psk2'));
         test.done();
       })


### PR DESCRIPTION
This build adds an `adhoc` command, which acts as an alias for `ap` because the `adhoc` mode uses the same `wifi-face` and changes the `mode` property to "adhoc". 

After installing this branch, run `t2 adhoc --help` to get more information about using the command. 

**To test the command:**
Works best with 2 Tessels running an adhoc network. Instructions will be the same for both Tessels.

- install this branch locally
- run `t2 adhoc --ssid TestAdHoc --name <name of one tessel>`
- run `t2 adhoc --ssid TestAdHoc --name <name of other tessel>`
- both Tessels should have their amber LEDs on

You can make sure the adhoc connection works using `ssh` or `screen` to access one of the Tessel terminals and running `ping 192.168.1.101` and see successful data returns. 192.168.1.101 is the static IP address of the Tessel `lan` network. 