### PR TITLE
Update to support Node 6.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ os:
   - linux
   - osx
 node_js:
-  - "4"
-  - "5"
+  - 4
+  - 5
+  - 6
 env:
   - CXX=g++-4.8
 addons:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
   matrix:
     - nodejs_version: 4
     - nodejs_version: 5
+    - nodejs_version: 6
 
 platform:
   - x86

--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -19,11 +19,6 @@ const CLI_ENTRYPOINT = 'cli.entrypoint';
 // Check for updates
 const pkg = require('../package.json');
 
-if (parseInt(process.versions.node) > 5) {
-  log.error('Tessel 2 CLI (t2-cli) is supported for use with the Node.js 4.x.x LTS Release.');
-  process.exit();
-}
-
 /*
  * If a command has been run with root,
  * do not try to read the update-notifier config file.

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "uglify-js": "^2.6.2",
     "update-notifier": "^0.6.3",
     "url-join": "0.0.1",
-    "usb": "1.1.2",
+    "usb": "^1.2.0",
     "usb-daemon-parser": "0.0.2"
   },
   "preferGlobal": true,


### PR DESCRIPTION
* Updates node-usb to 1.2.0, which has published binaries on Node 6 across all platforms (and publishes its binaries on Github)
* Instructs Travis and Appveyor to test on these versions.

Supercedes #832 