### PR TITLE
Check if wireless.radio0 is disabled

### DIFF
--- a/lib/tessel/commands.js
+++ b/lib/tessel/commands.js
@@ -167,6 +167,9 @@ module.exports.turnAccessPointOn = function() {
 module.exports.turnAccessPointOff = function() {
   return ['uci', 'set', 'wireless.@wifi-iface[1].disabled=1'];
 };
+module.exports.turnRadioOn = function() {
+  return ['uci', 'set', 'wireless.radio0.disabled=0'];
+};
 module.exports.getAccessPointConfig = function() {
   return ['uci', 'show', 'wireless.@wifi-iface[1]'];
 };

--- a/lib/tessel/wifi.js
+++ b/lib/tessel/wifi.js
@@ -163,7 +163,18 @@ Tessel.prototype.setWiFiState = function(enable) {
   return new Promise((resolve, reject) => {
     return this.simpleExec(commands.turnOnWifi(enable))
       .then(() => this.simpleExec(commands.commitWirelessCredentials()))
-      .then(() => this.simpleExec(commands.reconnectWifi()))
+      .then(() => {
+        return this.simpleExec(commands.reconnectWifi())
+          .then((result) => {
+            // check if the actual wifi radio (wireless.radio0) is disabled
+            if (result.includes("'radio0' is disabled")) {
+              return this.simpleExec(commands.turnRadioOn())
+                .then(() => this.simpleExec(commands.commitWirelessCredentials()))
+                .then(() => this.simpleExec(commands.reconnectWifi()))
+                .catch(reject);
+            }
+          });
+      })
       .then(() => {
         var settle = (rejection) => {
           if (rejection) {


### PR DESCRIPTION
Fixes https://github.com/tessel/t2-cli/issues/972

Smoke test:

The only way I've figured out how to recreate this issue is to manually disable the `radio0` wireless interface. I would suggest doing this over USB using `dterm` or `screen` because an `ssh` session will cut off as soon as the radio is disabled, i.e. `screen /dev/tty.usb<tab complete from here>` and hit the "enter" key twice.

Once rooted into your Tessel, run the following commands:

```
uci set wireless.radio0.disabled='1'
uci commit wireless
```

While still rooted, running `wifi` should give you the error `'radio0' is disabled`. To leave the `screen` session, hit Control+a+\ then type "y".

Now that the wireless radio has been disabled:

1. Check out this branch
2. `npm link .` (if you haven't linked this locally yet)
3. `t2 wifi -n "Your Network Name" -p PasswordIfNeeded123`

You should get the following output:

```
hipsterbrown:t2-cli (handle-wifi-radio) $ t2 wifi -n "My Network Name" -p MyPassword
INFO Looking for your Tessel...
INFO Connected to tessel-router.
INFO Wifi Enabled.
INFO Wifi Connected. SSID: My Network Name, password: MyPassword, security: psk2
```

Let me know if there are any questions. 