### PR TITLE
t2 run/push: check both module's found path and our own pre-compiled module known path. Fixes gh-990

### DIFF
--- a/lib/tessel/deployment/javascript.js
+++ b/lib/tessel/deployment/javascript.js
@@ -79,7 +79,7 @@ exportables.postRun = function(tessel, options) {
   return Promise.resolve();
 };
 
-function logMissingBinaryModuleWarning(name) {
+exportables.logMissingBinaryModuleWarning = function(name) {
   var warning = tags.stripIndent `
     Pre-compiled module is missing: ${name}.
     This might be caused by any of the following:
@@ -94,7 +94,7 @@ function logMissingBinaryModuleWarning(name) {
     `;
 
   log.warn(warning.trim());
-}
+};
 
 exportables.resolveBinaryModules = function(opts) {
   var cwd = process.cwd();
@@ -346,6 +346,7 @@ exportables.injectBinaryModules = function(globRoot, tempBundlePath, options) {
     // For every binary module in use...
     binaryModulesUsed.forEach(details => {
       if (details.resolved) {
+        var isCopied = false;
         var translations = binaryPathTranslations.slice().concat(
           lists.binaryPathTranslations[details.name] || []
         );
@@ -362,18 +363,33 @@ exportables.injectBinaryModules = function(globRoot, tempBundlePath, options) {
           return accum.replace(translation.find, translation.replace);
         }, tempTargetBinaryPath);
 
-        fs.copySync(sourceBinaryPath, tempTargetBinaryPath);
+        try {
+          fs.copySync(sourceBinaryPath, tempTargetBinaryPath);
+          isCopied = true;
+        } catch (error) {
+          sourceBinaryPath = path.join(details.extractPath, details.buildType, details.binName);
 
-        // Also ensure that package.json was copied.
-        fs.copySync(
-          path.join(globRoot, details.modulePath, 'package.json'),
-          path.join(tempTargetModulePath, 'package.json')
-        );
-      } else {
-        if (!details.ignored) {
-          logMissingBinaryModuleWarning(details.name);
+          try {
+            fs.copySync(sourceBinaryPath, tempTargetBinaryPath);
+            isCopied = true;
+          } catch (error) {
+            exportables.logMissingBinaryModuleWarning(details.name);
+            log.error(error);
+          }
         }
+
+        if (isCopied) {
+          // Also ensure that package.json was copied.
+          fs.copySync(
+            path.join(globRoot, details.modulePath, 'package.json'),
+            path.join(tempTargetModulePath, 'package.json')
+          );
+        }
+      } else {
         // In the future we may allow users to log the ignored modules here
+        if (!details.ignored) {
+          exportables.logMissingBinaryModuleWarning(details.name);
+        }
       }
     });
 


### PR DESCRIPTION
## Smoke Test

Run this: 

```
mkdir t2-990 && cd t2-990 && t2 init && npm install sqlite3@3.1.4
echo "var sqlite = require('sqlite3'); console.log('success, closing now');" > index.js
t2 run index.js

```

Result **WITHOUT** this patch: 

```
INFO Initializing new Tessel project for JavaScript...
INFO Created package.json.
INFO Created .tesselinclude.
INFO Wrote "Hello World" to index.js
-
> sqlite3@3.1.4 install /Users/rwaldron/robotz/t2-990/node_modules/sqlite3
> node-pre-gyp install --fallback-to-build

[sqlite3] Success: "/Users/rwaldron/robotz/t2-990/node_modules/sqlite3/lib/binding/node-v46-darwin-x64/node_sqlite3.node" is installed via remote
sqlite3@3.1.4 node_modules/sqlite3
└── nan@2.3.5
INFO Looking for your Tessel...
INFO Connected to sonny.
INFO Building project.
ERR! Error: ENOENT: no such file or directory, stat '/Users/rwaldron/.tessel/binaries/sqlite3-3.1.4-Release-node-v46-linux-mipsel/node-v46-linux-mipsel/node_sqlite3.node'
```



Result **WITH** this patch: 


```
INFO Initializing new Tessel project for JavaScript...
INFO Created package.json.
INFO Created .tesselinclude.
INFO Wrote "Hello World" to index.js
-
> sqlite3@3.1.4 install /Users/rwaldron/robotz/t2-990/node_modules/sqlite3
> node-pre-gyp install --fallback-to-build

[sqlite3] Success: "/Users/rwaldron/robotz/t2-990/node_modules/sqlite3/lib/binding/node-v46-darwin-x64/node_sqlite3.node" is installed via remote
sqlite3@3.1.4 node_modules/sqlite3
└── nan@2.3.5
INFO Looking for your Tessel...
INFO Connected to sonny.
INFO Building project.
INFO Writing project to RAM on sonny (1802.24 kB)...
INFO Deployed.
INFO Running index.js...
success, closing now
```

