### PR TITLE
better phrasing of t2 reboot

### DIFF
--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -195,7 +195,7 @@ makeCommand('reboot')
 
     callControllerWith('reboot', options);
   })
-  .help('Reboots Tessel');
+  .help('Reboot your Tessel');
 
 makeCommand('run')
   .callback(options => {


### PR DESCRIPTION
This is more in line with the rest of `t2 -h`:
```sh

Usage: t2 <command>

command     
  install-drivers     Install drivers
  install-homedir     Install homedir: ~/.tessel
  crash-reporter      Configure the Crash Reporter.
  provision           Authorize your computer to control the USB-connected Tessel
  restore             Restore your Tessel by installing the factory version of OpenWrt.
  restart             Restart a previously deployed script in RAM or Flash memory (does not rebundle)
  reboot              Reboot your Tessel
  run                 

```