### PR TITLE
t2 run/push: subargs issues. Fixes gh-1012

### DIFF
--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -565,6 +565,8 @@ module.exports = function(args) {
       args[i] = arg.slice(0, arg.length - 1);
       eIndexOfSA = i;
     }
+
+    args[i] = args[i].trim();
   }
 
   // If there are, remove them from the `args`
@@ -577,6 +579,33 @@ module.exports = function(args) {
     // Splice the subargs from the args that will be passed to nomnom,
     // store on parser so we can get to them later.
     parser.subargs = args.splice(sIndexOfSA, eIndexOfSA);
+
+    // When there is only one subarg, make sure that:
+    //
+    // 1. There is no leading `[`
+    // 2. It is not an empty string
+    //
+    // t2 run index.js [0] =>
+    // [ '0' ]
+    //
+    // t2 run index.js [] =>
+    // []
+    //
+    // t2 run index.js [ 0] =>
+    // [ '0' ]
+    //
+    // t2 run index.js [1   0] =>
+    // [ '1', '0' ]
+    //
+    if (parser.subargs.length === 1) {
+      // Removes errant leading `[`
+      if (parser.subargs[0].startsWith('[')) {
+        parser.subargs[0] = parser.subargs[0].slice(1);
+      }
+    }
+
+    // Clean out empty strings
+    parser.subargs = parser.subargs.filter(subarg => subarg);
   }
 
   // Clear the spec from one call to the next. This is
@@ -618,4 +647,5 @@ if (require.main === module) {
 
 if (global.IS_TEST_ENV) {
   module.exports.makeCommand = makeCommand;
+  module.exports.nomnom = parser;
 }

--- a/test/unit/bin-tessel-2.js
+++ b/test/unit/bin-tessel-2.js
@@ -1072,3 +1072,92 @@ exports['Tessel (cli: installer-*)'] = {
     });
   },
 };
+
+exports['Tessel (cli: [subargs])'] = {
+
+  setUp: function(done) {
+    this.sandbox = sinon.sandbox.create();
+    this.parse = this.sandbox.stub(cli.nomnom, 'parse');
+    done();
+  },
+
+  tearDown: function(done) {
+    this.sandbox.restore();
+    cli.nomnom.subargs = undefined;
+    done();
+  },
+
+  emptyNoWhitespace: function(test) {
+    test.expect(3);
+
+    // t2 run foo.js []
+    cli(['run', 'foo.js', '[]']);
+
+    test.equal(this.parse.callCount, 1);
+    test.deepEqual(this.parse.lastCall.args[0], ['run', 'foo.js']);
+    test.deepEqual(cli.nomnom.subargs, []);
+    test.done();
+  },
+
+  emptyWithWhitespace: function(test) {
+    test.expect(3);
+
+    // t2 run foo.js [ ]
+    cli(['run', 'foo.js', '[ ]']);
+
+    test.equal(this.parse.callCount, 1);
+    test.deepEqual(this.parse.lastCall.args[0], ['run', 'foo.js']);
+    test.deepEqual(cli.nomnom.subargs, []);
+    test.done();
+  },
+
+  emptySingleNoWhitespace: function(test) {
+    test.expect(3);
+
+    // t2 run foo.js [0]
+    cli(['run', 'foo.js', '[0]']);
+
+    test.equal(this.parse.callCount, 1);
+    test.deepEqual(this.parse.lastCall.args[0], ['run', 'foo.js']);
+    test.deepEqual(cli.nomnom.subargs, ['0']);
+    test.done();
+  },
+
+  emptySingleWithWhitespace: function(test) {
+    test.expect(3);
+
+    // t2 run foo.js [0 ]
+    cli(['run', 'foo.js', '[0', ']']);
+
+    test.equal(this.parse.callCount, 1);
+    test.deepEqual(this.parse.lastCall.args[0], ['run', 'foo.js']);
+    test.deepEqual(cli.nomnom.subargs, ['0']);
+    test.done();
+  },
+
+  emptyMultipleWithWhitespace: function(test) {
+    test.expect(3);
+
+    // t2 run foo.js [0 0  0    0]
+    cli(['run', 'foo.js', '[0', '0', '0', '0]']);
+
+    test.equal(this.parse.callCount, 1);
+    test.deepEqual(this.parse.lastCall.args[0], ['run', 'foo.js']);
+    test.deepEqual(cli.nomnom.subargs, ['0', '0', '0', '0']);
+    test.done();
+  },
+
+  emptyMultipleMixed: function(test) {
+    test.expect(3);
+
+    // t2 run foo.js [--foo=bar   0 x y z   --a true 1  2 3 ]
+    cli(['run', 'foo.js', '[--foo=bar', '0', 'x', 'y', 'z', '--a', 'true', '1', '2', '3', ']']);
+
+    test.equal(this.parse.callCount, 1);
+    test.deepEqual(this.parse.lastCall.args[0], ['run', 'foo.js']);
+    test.deepEqual(
+      cli.nomnom.subargs, ['--foo=bar', '0', 'x', 'y', 'z', '--a', 'true', '1', '2', '3']
+    );
+    test.done();
+  },
+};


### PR DESCRIPTION
Fixes:

- with only one arg will retain leading [
- with unnecessary whitespace will create empty strings

cc @HipsterBrown 

Signed-off-by: Rick Waldron <waldron.rick@gmail.com>