### PR TITLE
Convert `t2 install-drivers` and `t2 install-homedir` to `t2 install X`. Fixes gh-1019

### DIFF
--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -89,23 +89,42 @@ function callControllerWith(methodName, options) {
     .then(module.exports.closeSuccessfulCommand, module.exports.closeFailedCommand);
 }
 
-parser.command('install-drivers')
+parser.command('install')
   .callback(options => {
     log.level(options.loglevel);
 
-    options.operation = 'drivers';
     callControllerWith('installer', options);
   })
-  .help('Install drivers');
+  .option('operation', {
+    position: 1,
+    require: true,
+    choices: ['drivers', 'homedir', 'rust-sdk']
+  })
+  .help(`
+    Install additional system dependencies
 
-parser.command('install-homedir')
+    drivers    Installs USB drivers on Linux hosts
+    homedir    Creates a '.tessel' sub directory in host HOME directory
+    rust-sdk   Installs the Rust SDK
+  `);
+
+parser.command('remove')
   .callback(options => {
     log.level(options.loglevel);
 
-    options.operation = 'homedir';
-    callControllerWith('installer', options);
+    callControllerWith('remover', options);
   })
-  .help('Install homedir: ~/.tessel');
+  .option('operation', {
+    position: 1,
+    require: true,
+    choices: ['rust-sdk']
+  })
+  .help(`
+    Remove additional system dependencies added by t2-cli
+
+    rust-sdk   Removes the Rust SDK
+  `);
+
 
 parser.command('crash-reporter')
   .callback(options => {

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -1075,6 +1075,12 @@ controller.crashReporter = function(options) {
 };
 
 controller.installer = function(options) {
+  options.action = 'install';
+  return installer[options.operation](options);
+};
+
+controller.remover = function(options) {
+  options.action = 'remove';
   return installer[options.operation](options);
 };
 

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -73,3 +73,15 @@ module.exports.homedir = function() {
     });
   });
 };
+
+// Special dashy spelling for user/developer kindness
+module.exports['rust-sdk'] = function(options) {
+  // This will require('./tessel/install/rust.js') and call functions as necessary
+
+  if (options.action === 'install') {
+    log.info('Installing rust sdk');
+  } else {
+    log.info('Removing rust sdk');
+  }
+  return Promise.resolve();
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./index.js",
   "scripts": {
     "test": "grunt test",
-    "postinstall": "t2 install-drivers --loglevel=error || true; t2 install-homedir --loglevel=error || true;"
+    "postinstall": "t2 install drivers --loglevel=error || true; t2 install homedir --loglevel=error || true;"
   },
   "bin": {
     "t2": "./bin/tessel-2.js"

--- a/test/unit/bin-tessel-2.js
+++ b/test/unit/bin-tessel-2.js
@@ -1021,6 +1021,7 @@ exports['Tessel (cli: installer-*)'] = {
 
     this.drivers = this.sandbox.stub(installer, 'drivers').returns(Promise.resolve());
     this.homedir = this.sandbox.stub(installer, 'homedir').returns(Promise.resolve());
+    this.rustsdk = this.sandbox.stub(installer, 'rust-sdk').returns(Promise.resolve());
     done();
   },
 
@@ -1034,10 +1035,50 @@ exports['Tessel (cli: installer-*)'] = {
 
     test.equal(
       cliPackageJson.scripts.postinstall,
-      't2 install-drivers --loglevel=error || true; t2 install-homedir --loglevel=error || true;'
+      't2 install drivers --loglevel=error || true; t2 install homedir --loglevel=error || true;'
     );
 
     test.done();
+  },
+
+  installRustSDK: function(test) {
+    test.expect(3);
+
+    var rustsdk = Promise.resolve();
+
+    this.rustsdk.restore();
+    this.rustsdk = this.sandbox.stub(installer, 'rust-sdk').returns(rustsdk);
+
+    cli(['install', 'rust-sdk']);
+
+    rustsdk.then(() => {
+      var options = this.rustsdk.lastCall.args[0];
+
+      test.equal(this.rustsdk.callCount, 1);
+      test.equal(options.operation, 'rust-sdk');
+      test.equal(options.action, 'install');
+      test.done();
+    });
+  },
+
+  removeRustSDK: function(test) {
+    test.expect(3);
+
+    var rustsdk = Promise.resolve();
+
+    this.rustsdk.restore();
+    this.rustsdk = this.sandbox.stub(installer, 'rust-sdk').returns(rustsdk);
+
+    cli(['remove', 'rust-sdk']);
+
+    rustsdk.then(() => {
+      var options = this.rustsdk.lastCall.args[0];
+
+      test.equal(this.rustsdk.callCount, 1);
+      test.equal(options.operation, 'rust-sdk');
+      test.equal(options.action, 'remove');
+      test.done();
+    });
   },
 
   callThroughNoOptions: function(test) {
@@ -1052,8 +1093,8 @@ exports['Tessel (cli: installer-*)'] = {
     this.drivers = this.sandbox.stub(installer, 'drivers').returns(dresolve);
     this.homedir = this.sandbox.stub(installer, 'homedir').returns(hresolve);
 
-    cli(['install-drivers']);
-    cli(['install-homedir']);
+    cli(['install', 'drivers']);
+    cli(['install', 'homedir']);
 
     test.equal(this.drivers.callCount, 1);
     test.equal(this.homedir.callCount, 1);
@@ -1062,8 +1103,8 @@ exports['Tessel (cli: installer-*)'] = {
       test.equal(this.drivers.callCount, 1);
       test.equal(this.homedir.callCount, 1);
 
-      test.equal(this.drivers.lastCall.args[0][0], 'install-drivers');
-      test.equal(this.homedir.lastCall.args[0][0], 'install-homedir');
+      test.equal(this.drivers.lastCall.args[0][0], 'install');
+      test.equal(this.homedir.lastCall.args[0][0], 'install');
 
       test.equal(this.drivers.lastCall.args[0].operation, 'drivers');
       test.equal(this.homedir.lastCall.args[0].operation, 'homedir');

--- a/test/unit/installer.js
+++ b/test/unit/installer.js
@@ -90,3 +90,43 @@ exports['installer.homedir'] = {
     });
   },
 };
+
+exports['installer.rust-sdk'] = {
+  setUp: function(done) {
+    this.sandbox = sinon.sandbox.create();
+    this.error = this.sandbox.stub(log, 'error');
+    this.info = this.sandbox.stub(log, 'info');
+
+    done();
+  },
+
+  tearDown: function(done) {
+    this.sandbox.restore();
+    done();
+  },
+
+  // For now we only care that this is defined, not that it does
+  // anything particularly useful. That will be filled in later.
+  //
+  install: function(test) {
+    test.expect(1);
+
+    installer['rust-sdk']({
+      action: 'install'
+    }).then(() => {
+      test.ok(true);
+      test.done();
+    });
+  },
+
+  remove: function(test) {
+    test.expect(1);
+
+    installer['rust-sdk']({
+      action: 'remove'
+    }).then(() => {
+      test.ok(true);
+      test.done();
+    });
+  },
+};


### PR DESCRIPTION
This blocks #1014

This will allow normalized CLI "install" or "remove" additions:

- `t2 install-drivers` => `t2 install drivers`
- `t2 install-homedir` => `t2 install homedir`

And future additions:

- `t2 install rust-sdk`
- `t2 remove rust-sdk`

Presently no "remove" command has been defined for `drivers` or `homedir` as it's unclear that those installables are subject to such operations.

Signed-off-by: Rick Waldron <waldron.rick@gmail.com>