### PR TITLE
Updates package.json, changes supported Node versions to >=4.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "technical",
     "machine"
   ],
-  "author": "Technical Machine",
+  "author": "Tessel Project",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/tessel/t2-cli/issues"
@@ -85,7 +85,7 @@
   },
   "preferGlobal": true,
   "engines": {
-    "node": ">=4.2.0 <5.0"
+    "node": ">=4.2.0"
   },
   "contributors": [
     "Jon McKay <johnnyman727@gmail.com>",


### PR DESCRIPTION
Additionally, this allows users to install `t2-cli` with `yarn global add t2-cli`. `npm install -g` doesn't need the "engines" value to match your current Node version, but `yarn` enforces it.