### PR TITLE
Hotfixes to Rust compilation.

### DIFF
--- a/lib/install/rust.js
+++ b/lib/install/rust.js
@@ -139,7 +139,7 @@ module.exports.toolchainPath = () => {
     var values = fs.readdirSync(sdkPlatformPath);
 
     for (var i = 0; i < values.length; i++) {
-      if (values[i].match(/^toolchain\-mipsel/)) {
+      if (values[i].startsWith('toolchain-mipsel')) {
         return resolve(path.join(sdkPlatformPath, values[i]));
       }
     }

--- a/lib/install/rust.js
+++ b/lib/install/rust.js
@@ -139,7 +139,7 @@ module.exports.toolchainPath = () => {
     var values = fs.readdirSync(sdkPlatformPath);
 
     for (var i = 0; i < values.length; i++) {
-      if (values[i].match(/^toolchain\-/)) {
+      if (values[i].match(/^toolchain\-mipsel/)) {
         return resolve(path.join(sdkPlatformPath, values[i]));
       }
     }
@@ -304,7 +304,7 @@ function extract(checksumVerify, filename, sdkStream, root, strip, name, decompr
 }
 
 function extractTools(checksumVerify, filename, sdkStream) {
-  var root = path.join(SDK_PATHS.sdk, 'macos');
+  var root = path.join(SDK_PATHS.sdk, getPlatform());
   return extract(checksumVerify, filename, sdkStream, root, 2, 'Tessel build tools', bz2());
 }
 

--- a/lib/tessel/deployment/rust.js
+++ b/lib/tessel/deployment/rust.js
@@ -1,5 +1,6 @@
 // System Objects
 var http = require('http');
+var querystring = require('querystring');
 var url = require('url');
 
 // Third Party Dependencies
@@ -113,7 +114,7 @@ exportables.remoteRustCompilation = (opts) => {
     var options = {
       host: destination.hostname,
       port: destination.port,
-      path: '/rust-compile',
+      path: '/rust-compile?target=' + querystring.escape(opts.resolvedEntryPoint),
       method: 'POST',
       headers: {
         'Content-Type': 'application/octet-stream',

--- a/lib/tessel/deployment/rust.js
+++ b/lib/tessel/deployment/rust.js
@@ -114,7 +114,7 @@ exportables.remoteRustCompilation = (opts) => {
     var options = {
       host: destination.hostname,
       port: destination.port,
-      path: '/rust-compile?target=' + querystring.escape(opts.resolvedEntryPoint),
+      path: `/rust-compile?target=${querystring.escape(opts.resolvedEntryPoint)}`,
       method: 'POST',
       headers: {
         'Content-Type': 'application/octet-stream',

--- a/lib/tessel/deployment/rust.js
+++ b/lib/tessel/deployment/rust.js
@@ -71,7 +71,7 @@ exportables.preBundle = function(opts) {
 // executable.
 exportables.tarBundle = function(opts) {
   if (opts.rustcc === true) {
-    opts.rustcc = 'http://rustcc.tessel.io:49160';
+    opts.rustcc = 'http://rustcc.tessel.io';
   }
 
   if (opts.rustcc) {

--- a/test/unit/cargo-tessel.js
+++ b/test/unit/cargo-tessel.js
@@ -33,8 +33,13 @@ exports['Cargo Subcommand (cargo tessel ...)'] = {
     bresolve.then(() => {
       test.equal(console.log.callCount, 1);
       test.equal(console.log.lastCall.args[0], tarball);
-      test.deepEqual(this.parse.lastCall.args, [['build']]);
-      test.deepEqual(this.runBuild.lastCall.args, [ { isCli: false, binary: undefined } ]);
+      test.deepEqual(this.parse.lastCall.args, [
+        ['build']
+      ]);
+      test.deepEqual(this.runBuild.lastCall.args, [{
+        isCli: false,
+        binary: undefined
+      }]);
       test.done();
     });
   },
@@ -46,12 +51,18 @@ exports['Cargo Subcommand (cargo tessel ...)'] = {
 
     this.install = this.sandbox.stub(rust.cargo, 'install').returns(iresolve);
 
-    cargo.nomnom.globalOpts({subcommand: 'install'});
+    cargo.nomnom.globalOpts({
+      subcommand: 'install'
+    });
     cargo(['sdk', 'install']);
 
     iresolve.then(() => {
       test.equal(this.install.callCount, 1);
-      test.deepEqual(this.install.lastCall.args[0], { '0': 'sdk', subcommand: 'install', _: [ 'sdk', 'install' ] });
+      test.deepEqual(this.install.lastCall.args[0], {
+        '0': 'sdk',
+        subcommand: 'install',
+        _: ['sdk', 'install']
+      });
       test.done();
     });
   },
@@ -62,12 +73,18 @@ exports['Cargo Subcommand (cargo tessel ...)'] = {
 
     this.uninstall = this.sandbox.stub(rust.cargo, 'uninstall').returns(iresolve);
 
-    cargo.nomnom.globalOpts({subcommand: 'uninstall'});
+    cargo.nomnom.globalOpts({
+      subcommand: 'uninstall'
+    });
     cargo(['sdk', 'uninstall']);
 
     iresolve.then(() => {
       test.equal(this.uninstall.callCount, 1);
-      test.deepEqual(this.uninstall.lastCall.args[0], { '0': 'sdk', subcommand: 'uninstall', _: [ 'sdk', 'uninstall' ] });
+      test.deepEqual(this.uninstall.lastCall.args[0], {
+        '0': 'sdk',
+        subcommand: 'uninstall',
+        _: ['sdk', 'uninstall']
+      });
       test.done();
     });
   },

--- a/test/unit/deployment/rust.js
+++ b/test/unit/deployment/rust.js
@@ -62,14 +62,15 @@ exports['deploy.rust'] = {
           hostname: hostname,
           port: port
         }),
-        target: DEPLOY_DIR_RS
+        target: DEPLOY_DIR_RS,
+        resolvedEntryPoint: 'charmander',
       })
       .then(() => {
         // Check the options of the call to http
         test.equal(this.httpRequest.callCount, 1);
         test.equal(this.httpRequest.lastCall.args[0].host, hostname);
         test.equal(this.httpRequest.lastCall.args[0].port, port);
-        test.equal(this.httpRequest.lastCall.args[0].path, '/rust-compile');
+        test.equal(this.httpRequest.lastCall.args[0].path, '/rust-compile?target=charmander');
         test.equal(this.httpRequest.lastCall.args[0].method, 'POST');
 
         // Make sure tar pack was called with the correct target


### PR DESCRIPTION
This PR makes the CLI work with the cross compilation server (now live). It does the following:

* Fixes rust SDK installation on Linux, which was incorrect.
* Fixes a bug where the Linux toolchain couldn't be found due to a generous regex.
* Passes the `target` name to the Rust cross-compilation server.
* Removes the port from `rustcc.tessel.io` and defaults to port 80.

This is ready to merge whenever and a new release should be cut after that, enabling the `--rustcc` switch to cross-compile Rust binaries.