### PR TITLE
Fixes broken call to runBuild for Rust code.

### DIFF
--- a/lib/tessel/deployment/rust.js
+++ b/lib/tessel/deployment/rust.js
@@ -78,10 +78,10 @@ exportables.tarBundle = function(opts) {
     return exportables.remoteRustCompilation(opts);
   } else {
     return rust.runBuild({
-      isCli: true,
-      binary: opts.resolvedEntryPoint,
-      path: opts.target
-    })
+        isCli: true,
+        binary: opts.resolvedEntryPoint,
+        path: opts.target
+      })
       .then(tarball => fs.readFileSync(tarball));
   }
 };

--- a/lib/tessel/deployment/rust.js
+++ b/lib/tessel/deployment/rust.js
@@ -77,7 +77,11 @@ exportables.tarBundle = function(opts) {
   if (opts.rustcc) {
     return exportables.remoteRustCompilation(opts);
   } else {
-    return rust.runBuild(true, opts.resolvedEntryPoint, opts.target)
+    return rust.runBuild({
+      isCli: true,
+      binary: opts.resolvedEntryPoint,
+      path: opts.target
+    })
       .then(tarball => fs.readFileSync(tarball));
   }
 };

--- a/test/unit/deployment/rust.js
+++ b/test/unit/deployment/rust.js
@@ -236,7 +236,7 @@ exports['deploy.rust'] = {
   },
 
   rustTarBundleLocal: function(test) {
-    test.expect(1);
+    test.expect(4);
 
     this.remoteRustCompilation = sandbox.stub(deployment.rs, 'remoteRustCompilation', () => Promise.resolve(null));
 
@@ -250,6 +250,13 @@ exports['deploy.rust'] = {
     deployment.rs.tarBundle(opts)
       .then((tarball) => {
         test.ok(Buffer.isBuffer(tarball), 'tarball should be buffer');
+        test.equal(this.remoteRustCompilation.callCount, 0);
+        test.equal(this.runBuild.callCount, 1);
+        test.deepEqual(this.runBuild.lastCall.args[0], {
+          isCli: true,
+          binary: undefined,
+          path: undefined
+        });
       }, error => {
         test.ok(false, error.toString());
       })
@@ -257,7 +264,7 @@ exports['deploy.rust'] = {
   },
 
   rustTarBundleRemote: function(test) {
-    test.expect(1);
+    test.expect(4);
 
     this.remoteRustCompilation = sandbox.stub(deployment.rs, 'remoteRustCompilation', () => Promise.resolve(new Buffer([])));
 
@@ -271,6 +278,9 @@ exports['deploy.rust'] = {
     deployment.rs.tarBundle(opts)
       .then((tarball) => {
         test.ok(Buffer.isBuffer(tarball), 'tarball should be buffer');
+        test.equal(this.runBuild.callCount, 0);
+        test.equal(this.remoteRustCompilation.callCount, 1);
+        test.deepEqual(this.remoteRustCompilation.lastCall.args[0], opts);
       }, error => {
         test.ok(false, error.toString());
       })


### PR DESCRIPTION
I missed an invocation of this method when changing the function signature.

I long for strong typing. :whine: