### PR TITLE
[WIP] makes tesselUpdateWithVersion return promise

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -979,21 +979,20 @@ controller.updateWithRemoteBuilds = function(opts, tessel) {
 };
 
 controller.updateTesselWithVersion = function(opts, tessel, currentVersion, build) {
-
+  return new Promise((resolve, reject) => {
   // Fetch the requested build
-  return updates.fetchBuild(build)
-    .then(function startUpdate(image) {
-      // Update Tessel with it
-      return tessel.update(opts, image)
-        // Log that the update completed
-        .then(function logCompletion() {
-          if (!opts.force) {
-            log.info('Updated', tessel.name, 'from ', currentVersion, ' to ', build.version);
-          } else {
-            log.info('Force updated', tessel.name, 'to version', build.version);
-          }
-        });
-    });
+    updates.fetchBuild(build).then(image => {
+        // Update Tessel with it
+        tessel.update(opts, image).then(() => {
+            if (!opts.force) {
+              log.info('Updated', tessel.name, 'from ', currentVersion, ' to ', build.version);
+            } else {
+              log.info('Force updated', tessel.name, 'to version', build.version);
+            }
+            resolve();
+          });
+      });
+  });
 };
 
 controller.tesselEnvVersions = opts => {


### PR DESCRIPTION
When updating a tessel's firmware, tesselUpdateWithVersion was
not returning a promise which caused the whole update to never resolve,
although the update succeeded.  This ultimately caused the spinner to remain
active and prevented the process from exiting.

Fixes #852