### PR TITLE
t2 run/push: add node_modules/**/socket.io-client/dist/socket.io.min.js to deployment "includes" whitelist

### DIFF
--- a/lib/tessel/deployment/lists/javascript.js
+++ b/lib/tessel/deployment/lists/javascript.js
@@ -4,6 +4,7 @@ module.exports = {
     'node_modules/**/mime/types/*.types',
     'node_modules/**/negotiator/**/*.js',
     'node_modules/**/socket.io-client/socket.io.js',
+    'node_modules/**/socket.io-client/dist/socket.io.min.js',
   ],
 
   ignores: [

--- a/test/unit/deployment/javascript.js
+++ b/test/unit/deployment/javascript.js
@@ -2818,6 +2818,7 @@ exports['deployment.js.lists'] = {
       'node_modules/**/mime/types/*.types',
       'node_modules/**/negotiator/**/*.js',
       'node_modules/**/socket.io-client/socket.io.js',
+      'node_modules/**/socket.io-client/dist/socket.io.min.js',
     ];
 
     test.deepEqual(lists.includes, includes);


### PR DESCRIPTION
This was caused by: https://github.com/socketio/socket.io-client/commit/3ba3fe3034a3564b3313bff8ef03386dd1c7e9cf

Signed-off-by: Rick Waldron <waldron.rick@gmail.com>