### PR TITLE
t2 push: Remove default rustcc url. Fixes gh-1136

### DIFF
--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -296,7 +296,7 @@ makeCommand('push')
     help: 'Compression steps during deployment. To skip compression, use --compress=false.'
   })
   .option('rustcc', {
-    default: 'http://192.241.138.79:49160',
+    flag: true,
     help: 'Specify the location and port of the Rust cross-compilation server.'
   })
   .help(`

--- a/test/unit/bin-tessel-2.js
+++ b/test/unit/bin-tessel-2.js
@@ -453,7 +453,7 @@ exports['Tessel (t2: run)'] = {
   },
 
   defaultOptions: function(test) {
-    test.expect(5);
+    test.expect(6);
 
     t2(['run', 'index.js']);
 
@@ -467,6 +467,8 @@ exports['Tessel (t2: run)'] = {
     test.equal(args.lanPrefer, false);
     test.equal(args.full, false);
     test.equal(args.push, false);
+    test.ok(!args.rustcc);
+
 
     setImmediate(test.done);
   },
@@ -510,7 +512,7 @@ exports['Tessel (t2: push)'] = {
   },
 
   defaultOptions: function(test) {
-    test.expect(5);
+    test.expect(6);
 
     t2(['push', 'index.js']);
 
@@ -525,6 +527,7 @@ exports['Tessel (t2: push)'] = {
     test.ok(args.push);
 
     test.ok(!args.full);
+    test.ok(!args.rustcc);
 
     setImmediate(test.done);
   },


### PR DESCRIPTION
Signed-off-by: Rick Waldron <waldron.rick@gmail.com>