### PR TITLE
Include connection type with crash report. Fixes #1172

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -18,7 +18,11 @@ var updates = require('./update-fetch');
 var provision = require('./tessel/provision');
 var Tessel = require('./tessel/tessel');
 
-var controller = {};
+var controller = {
+  // This will be assigned with the Tessel that is found or selected.
+  tessel: null,
+};
+
 var responses = {
   noAuth: 'No Authorized Tessels Found.',
   auth: 'No Tessels Found.'
@@ -318,41 +322,39 @@ Tessel.get = function(opts) {
 4. All the open Tessel connections are closed
 5. The command returns from whence it came (so the process can be closed)
 */
-controller.standardTesselCommand = function(opts, command) {
-  return new Promise(function(resolve, reject) {
+controller.standardTesselCommand = function(options, command) {
+  return new Promise((resolve, reject) => {
     // Fetch a Tessel
-    return controller.get(opts)
+    return controller.get(options)
       // Once we have it
-      .then(function(tessel) {
+      .then((tessel) => {
+        // Make the active tessel available controller-wide.
+        // This will be used by "out of reach" operations,
+        // such as crash reporting (which responds to uncaught
+        // exceptions for the process and will be out of scope)
+        controller.tessel = tessel;
+
         // Create a promise for a sigint
-        var sigintPromise = new Promise(function(resolve) {
-          process.once('SIGINT', resolve);
-        });
+        var sigintPromise = new Promise(resolve => process.once('SIGINT', resolve));
         // It doesn't matter whether the sigint finishes first or the provided command
         Promise.race([sigintPromise, command(tessel)])
           // Once one completes
-          .then(function(optionalValue) {
+          .then(optionalValue => {
             // Close the open Tessel connection
             return controller.closeTesselConnections([tessel])
               // Then resolve with the optional value
-              .then(function closeComplete() {
-                return resolve(optionalValue);
-              });
+              .then(() => resolve(optionalValue));
           })
           // If something threw an error
-          .catch(function(err) {
+          .catch(error => {
             // Still close the open connections
             return controller.closeTesselConnections([tessel])
               // Then reject with the error
-              .then(function closeComplete() {
-                return reject(err);
-              });
+              .then(() => reject(error));
           });
       })
       .catch(reject);
-  }).catch(function(error) {
-    return Promise.reject(error);
-  });
+  }).catch(error => Promise.reject(error));
 };
 
 /*

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -454,7 +454,10 @@ controller.runHeuristics = function(opts, tessels) {
       }
 
       // If an environment variable was set and it equals this Tessel
-      if (process.env.TESSEL && process.env.TESSEL === tessel.name) {
+      /* istanbul ignore if */
+      if (process.env.TESSEL &&
+        /* istanbul ignore next */
+        process.env.TESSEL === tessel.name) {
         // Mark the priority level
         entry.priority = ENV_OPTION_PRIORITY;
         return collector.concat([entry]);
@@ -503,17 +506,20 @@ controller.runHeuristics = function(opts, tessels) {
           }
         }
         // If this is a LAN Tessel
-        else if (collectorEntry.priority === LAN_CONN_PRIORITY) {
-          // And we haven't found any other Tessels
-          if (lanFound === false) {
-            // Mark it as found and continue
-            lanFound = true;
-          }
-          // We have multiple LAN Tessels which is an issue
-          // If a USB connection wasn't found, we have too much ambiguity
-          else if (!usbFound) {
-            // Return nothing because the user needs to be more specific
-            return Promise.reject(new controller.HeuristicAmbiguityError());
+        else {
+          /* istanbul ignore else */
+          if (collectorEntry.priority === LAN_CONN_PRIORITY) {
+            // And we haven't found any other Tessels
+            if (lanFound === false) {
+              // Mark it as found and continue
+              lanFound = true;
+            }
+            // We have multiple LAN Tessels which is an issue
+            // If a USB connection wasn't found, we have too much ambiguity
+            else if (!usbFound) {
+              // Return nothing because the user needs to be more specific
+              return Promise.reject(new controller.HeuristicAmbiguityError());
+            }
           }
         }
       }
@@ -567,67 +573,58 @@ controller.provisionTessel = function(opts) {
 };
 
 
-controller.restoreTessel = function(opts) {
-  opts.usb = true;
-  opts.lan = false;
-  opts.altSetting = 1;
-  return controller.get(opts).then((tessel) => {
+controller.restoreTessel = function(options) {
+  options.usb = true;
+  options.lan = false;
+  options.altSetting = 1;
+  return controller.get(options).then((tessel) => {
     return new Promise((resolve, reject) => {
-      return tessel.restore(opts).then(resolve).catch(reject);
+      return tessel.restore(options).then(resolve).catch(reject);
     });
   });
 };
 
-controller.deploy = function(opts) {
-  opts.authorized = true;
-  return controller.standardTesselCommand(opts, function(tessel) {
-    // Deploy a path to Tessel
-    return tessel.deploy(opts);
-  });
+controller.deploy = function(options) {
+  options.authorized = true;
+  return controller.standardTesselCommand(options, (tessel) => tessel.deploy(options));
 };
 
-controller.restart = function(opts) {
-  opts.authorized = true;
-  return controller.standardTesselCommand(opts, function(tessel) {
-    // Tell Tessel to restart an existing script
-    return tessel.restart(opts);
-  });
+controller.restart = function(options) {
+  options.authorized = true;
+  return controller.standardTesselCommand(options, (tessel) => tessel.restart(options));
 };
 
-controller.eraseScript = function(opts) {
-  opts.authorized = true;
-  return controller.standardTesselCommand(opts, function(tessel) {
-    // Tell Tessel to erase any pushed script
-    return tessel.eraseScript(opts, false);
-  });
+controller.eraseScript = function(options) {
+  options.authorized = true;
+  return controller.standardTesselCommand(options, (tessel) => tessel.eraseScript(options, false));
 };
 
-controller.renameTessel = function(opts) {
-  opts = opts || {};
-  opts.authorized = true;
+controller.renameTessel = function(options) {
+  options = options || {};
+  options.authorized = true;
   // Grab the preferred tessel
-  return new Promise(function(resolve, reject) {
-      if (!opts.reset && !opts.newName) {
+  return new Promise((resolve, reject) => {
+      if (!options.reset && !options.newName) {
         reject('A new name must be provided.');
       } else {
-        if (!opts.reset && !Tessel.isValidName(opts.newName)) {
-          reject('Invalid name: ' + opts.newName + '. The name must be a valid hostname string. See http://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_host_names.');
+        if (!options.reset && !Tessel.isValidName(options.newName)) {
+          reject(`Invalid name: ${options.newName}. The name must be a valid hostname string. See http://en.wikipedia.org/wiki/Hostname#Restrictions_on_valid_host_names.`);
         } else {
           resolve();
         }
       }
     })
-    .then(function executeRename() {
-      return controller.standardTesselCommand(opts, function(tessel) {
-        log.info(`Renaming ${tessel.name} to ${opts.newName}`);
-        return tessel.rename(opts);
+    .then(() => {
+      return controller.standardTesselCommand(options, (tessel) => {
+        log.info(`Renaming ${tessel.name} to ${options.newName}`);
+        return tessel.rename(options);
       });
     });
 };
 
-controller.printAvailableNetworks = function(opts) {
-  opts.authorized = true;
-  return controller.standardTesselCommand(opts, (tessel) => {
+controller.printAvailableNetworks = function(options) {
+  options.authorized = true;
+  return controller.standardTesselCommand(options, (tessel) => {
     log.info('Scanning for visible networks...');
 
     // Ask Tessel what networks it finds in a scan
@@ -643,9 +640,9 @@ controller.printAvailableNetworks = function(opts) {
   });
 };
 
-controller.getWifiInfo = function(opts) {
-  opts.authorized = true;
-  return controller.standardTesselCommand(opts, function(tessel) {
+controller.getWifiInfo = function(options) {
+  options.authorized = true;
+  return controller.standardTesselCommand(options, function(tessel) {
     return tessel.getWifiInfo()
       .then(function(network) {
         // Grab inet lines, flatmap them, remove empty
@@ -676,17 +673,17 @@ controller.getWifiInfo = function(opts) {
         log.info('Signal Strength: (' + network.quality + '/' + network.quality_max + ')');
         log.info('Bitrate: ' + Math.round(network.bitrate / 1000) + 'mbps');
       })
-      .then(function() {
+      .then(() => {
         return controller.closeTesselConnections([tessel]);
       });
   });
 };
 
-controller.connectToNetwork = function(opts) {
-  opts.authorized = true;
-  var ssid = opts.ssid;
-  var password = opts.password;
-  var security = opts.security;
+controller.connectToNetwork = function(options) {
+  options.authorized = true;
+  var ssid = options.ssid;
+  var password = options.password;
+  var security = options.security;
   var securityOptions = ['none', 'wep', 'psk', 'psk2', 'wpa', 'wpa2'];
   return new Promise(function(resolve, reject) {
       if (!ssid) {
@@ -707,24 +704,20 @@ controller.connectToNetwork = function(opts) {
       resolve();
     })
     .then(() => {
-      return controller.standardTesselCommand(opts, (tessel) => {
-        return tessel.connectToNetwork(opts);
-      });
+      return controller.standardTesselCommand(options, (tessel) => tessel.connectToNetwork(options));
     });
 };
 
-controller.setWiFiState = function(opts) {
-  opts.authorized = true;
-  return controller.standardTesselCommand(opts, (tessel) => {
-    return tessel.setWiFiState(opts.on);
-  });
+controller.setWiFiState = function(options) {
+  options.authorized = true;
+  return controller.standardTesselCommand(options, (tessel) => tessel.setWiFiState(options.on));
 };
 
-controller.createAccessPoint = function(opts) {
-  opts.authorized = true;
-  var ssid = opts.ssid;
-  var password = opts.password;
-  var security = opts.security;
+controller.createAccessPoint = function(options) {
+  options.authorized = true;
+  var ssid = options.ssid;
+  var password = options.password;
+  var security = options.security;
   var securityOptions = ['none', 'wep', 'psk', 'psk2'];
 
   return new Promise((resolve, reject) => {
@@ -769,25 +762,23 @@ controller.createAccessPoint = function(opts) {
       resolve();
     })
     .then(() => {
-      return controller.standardTesselCommand(opts, (tessel) => {
-        return tessel.createAccessPoint(opts);
-      });
+      return controller.standardTesselCommand(options, (tessel) => tessel.createAccessPoint(options));
     });
 };
 
-controller.enableAccessPoint = function(opts) {
-  opts.authorized = true;
-  return controller.standardTesselCommand(opts, (tessel) => tessel.enableAccessPoint());
+controller.enableAccessPoint = function(options) {
+  options.authorized = true;
+  return controller.standardTesselCommand(options, (tessel) => tessel.enableAccessPoint());
 };
 
-controller.disableAccessPoint = function(opts) {
-  opts.authorized = true;
-  return controller.standardTesselCommand(opts, (tessel) => tessel.disableAccessPoint());
+controller.disableAccessPoint = function(options) {
+  options.authorized = true;
+  return controller.standardTesselCommand(options, (tessel) => tessel.disableAccessPoint());
 };
 
-controller.getAccessPointInfo = function(opts) {
-  opts.authorized = true;
-  return controller.standardTesselCommand(opts, (tessel) => {
+controller.getAccessPointInfo = function(options) {
+  options.authorized = true;
+  return controller.standardTesselCommand(options, (tessel) => {
     return tessel.getAccessPointInfo()
       .then((ap) => {
         if (ap.ssid) {
@@ -810,20 +801,20 @@ controller.getAccessPointInfo = function(opts) {
 /*
   The T2 root command is used to login into the Tessel's root shell.
 */
-controller.root = function(opts) {
+controller.root = function(options) {
   // Only give us LAN connections
-  opts.lan = true;
+  options.lan = true;
   // We must already be authorized
-  opts.authorized = true;
+  options.authorized = true;
   // Disable USB flag if passed
-  if (opts.usb) {
-    opts.usb = false;
+  if (options.usb) {
+    options.usb = false;
     log.warn('You are trying to connect to Tessel via USB, but this command only works with Wifi.');
     log.warn('I will use Wifi to try and look for your Tessel.');
   }
 
   // Fetch a Tessel
-  return controller.standardTesselCommand(opts, function(tessel) {
+  return controller.standardTesselCommand(options, function(tessel) {
     log.info('Starting SSH Session on Tessel. Type "exit" at the prompt to end.');
     return new Promise(function(resolve, reject) {
       // Spawn a new SSH process

--- a/lib/crash-reporter.js
+++ b/lib/crash-reporter.js
@@ -22,6 +22,7 @@ var CRASH_PROMPT_MESSAGE = `\nSubmit Crash Report to help Tessel Developers impr
 var CRASH_REPORTER_BASE_URL = `http://${remote.CRASH_REPORTER_HOSTNAME}`;
 
 // override for testing
+/* istanbul ignore if */
 if (process.env.DEV_MODE === 'true') {
   CRASH_REPORTER_BASE_URL = 'http://localhost:8080';
 }
@@ -61,6 +62,7 @@ CrashReporter.sanitize.redactions = [
   (stack) => {
     var index = __dirname.indexOf('t2-cli');
 
+    /* istanbul ignore else */
     if (index !== -1) {
       stack = stack.replace(new RegExp(escape(__dirname.slice(0, index)), 'g'), '');
     }
@@ -88,8 +90,7 @@ CrashReporter.prompt = function() {
             }
           });
           prompt.then(selection => {
-            var selected = selection['selected'];
-            if (selected === false) {
+            if (selection.selected === false) {
               resolve(false);
             } else {
               return Preferences.write(CRASH_REPORTER_PROMPT, 'false')
@@ -119,6 +120,7 @@ CrashReporter.submit = function(report, opts) {
       if (success) {
         return Preferences.read(CRASH_REPORTER_PREFERENCE, 'on')
           .then(value => {
+            /* istanbul ignore else */
             if (value === 'on') {
               var labels = tags.stripIndent `
                 ${packageJson.name},
@@ -198,18 +200,19 @@ CrashReporter.test = () => {
   return Promise.reject(new Error('Testing the crash reporter'));
 };
 
-var onError = error => {
+CrashReporter.onerror = error => {
   // log the error as sometimes we might be swallowing
   // unhandled remote node exceptions
   log.error('Detected CLI crash', error, error.stack);
   return CrashReporter.submit(error.stack);
 };
 
-onError.isCrashHandler = true;
+CrashReporter.onerror.isCrashHandler = true;
 
+/* istanbul ignore else */
 if (!process.env.CI) {
-  process.on('unhandledRejection', onError);
-  process.on('uncaughtException', onError);
+  process.on('unhandledRejection', CrashReporter.onerror);
+  process.on('uncaughtException', CrashReporter.onerror);
 }
 
 module.exports = CrashReporter;

--- a/lib/crash-reporter.js
+++ b/lib/crash-reporter.js
@@ -110,6 +110,10 @@ CrashReporter.submit = function(report, opts) {
 
   const silent = (opts.silent || false);
 
+  // This is buried within the submit function because
+  // it creates a circular dependency at the top level.
+  const tessel = require('./controller').tessel;
+
   return CrashReporter.prompt()
     .then(success => {
       if (success) {
@@ -123,6 +127,10 @@ CrashReporter.submit = function(report, opts) {
                 OS platform: ${os.platform()},
                 OS release: ${os.release()}
               `;
+
+              if (tessel) {
+                labels += `,\nConnection Type: ${tessel.connectionType}`;
+              }
 
               var argv = CrashReporter.sanitize(opts.argv || process.argv.slice(2).join(', '));
               var stack = CrashReporter.sanitize(report.stack || String(report));

--- a/test/unit/crash-reporter.js
+++ b/test/unit/crash-reporter.js
@@ -5,7 +5,7 @@ require('../common/bootstrap');
 /*global Preferences */
 
 exports['CrashReporter'] = {
-  surface: function(test) {
+  surface(test) {
     test.expect(6);
     test.equal(typeof CrashReporter.on, 'function');
     test.equal(typeof CrashReporter.off, 'function');
@@ -16,7 +16,7 @@ exports['CrashReporter'] = {
     test.done();
   },
 
-  noProcessExceptionOrRejectionHandlers: function(test) {
+  noProcessExceptionOrRejectionHandlers(test) {
     test.expect(1);
 
     var expect = process.env.CI ? 0 : 2;
@@ -42,19 +42,19 @@ exports['CrashReporter'] = {
 };
 
 exports['CrashReporter.on'] = {
-  setUp: function(done) {
+  setUp(done) {
     this.sandbox = sinon.sandbox.create();
     this.error = this.sandbox.stub(log, 'error');
     this.pWrite = this.sandbox.stub(Preferences, 'write').returns(Promise.resolve());
     done();
   },
 
-  tearDown: function(done) {
+  tearDown(done) {
     this.sandbox.restore();
     done();
   },
 
-  onSuccess: function(test) {
+  onSuccess(test) {
     test.expect(1);
 
     CrashReporter.on().then(() => {
@@ -63,7 +63,7 @@ exports['CrashReporter.on'] = {
     });
   },
 
-  onFailure: function(test) {
+  onFailure(test) {
     test.expect(2);
     this.pWrite.restore();
     this.pWrite = this.sandbox.stub(Preferences, 'write').returns(Promise.reject());
@@ -79,19 +79,19 @@ exports['CrashReporter.on'] = {
 };
 
 exports['CrashReporter.off'] = {
-  setUp: function(done) {
+  setUp(done) {
     this.sandbox = sinon.sandbox.create();
     this.error = this.sandbox.stub(log, 'error');
     this.pWrite = this.sandbox.stub(Preferences, 'write').returns(Promise.resolve());
     done();
   },
 
-  tearDown: function(done) {
+  tearDown(done) {
     this.sandbox.restore();
     done();
   },
 
-  offSuccess: function(test) {
+  offSuccess(test) {
     test.expect(1);
 
     CrashReporter.off().then(() => {
@@ -100,7 +100,7 @@ exports['CrashReporter.off'] = {
     });
   },
 
-  offFailure: function(test) {
+  offFailure(test) {
     test.expect(2);
     this.pWrite.restore();
     this.pWrite = this.sandbox.stub(Preferences, 'write').returns(Promise.reject());
@@ -116,7 +116,7 @@ exports['CrashReporter.off'] = {
 };
 
 exports['CrashReporter.submit'] = {
-  setUp: function(done) {
+  setUp(done) {
     this.sandbox = sinon.sandbox.create();
     this.error = this.sandbox.stub(log, 'error');
     this.logInfo = this.sandbox.stub(log, 'info');
@@ -131,12 +131,12 @@ exports['CrashReporter.submit'] = {
     done();
   },
 
-  tearDown: function(done) {
+  tearDown(done) {
     this.sandbox.restore();
     done();
   },
 
-  submit: function(test) {
+  submit(test) {
     test.expect(8);
 
     var report = 'Error: undefined is not a function';
@@ -154,7 +154,7 @@ exports['CrashReporter.submit'] = {
     });
   },
 
-  sanitizes: function(test) {
+  sanitizes(test) {
     test.expect(5);
 
     this.crPost.restore();
@@ -175,7 +175,7 @@ exports['CrashReporter.submit'] = {
     });
   },
 
-  optionsSilentDefaultsFalse: function(test) {
+  optionsSilentDefaultsFalse(test) {
     test.expect(1);
 
     this.crPost.restore();
@@ -190,7 +190,7 @@ exports['CrashReporter.submit'] = {
     });
   },
 
-  optionsSilent: function(test) {
+  optionsSilent(test) {
     test.expect(1);
 
     this.crPost.restore();
@@ -207,7 +207,7 @@ exports['CrashReporter.submit'] = {
     });
   },
 
-  forwardsRealArgv: function(test) {
+  forwardsRealArgv(test) {
     test.expect(2);
 
     this.crPost.restore();
@@ -233,7 +233,7 @@ exports['CrashReporter.submit'] = {
     });
   },
 
-  sanitizesRealArgv: function(test) {
+  sanitizesRealArgv(test) {
     test.expect(1);
 
     this.crPost.restore();
@@ -258,7 +258,7 @@ exports['CrashReporter.submit'] = {
     });
   },
 
-  sanitizesArgv1: function(test) {
+  sanitizesArgv1(test) {
     test.expect(1);
 
     this.crPost.restore();
@@ -276,7 +276,7 @@ exports['CrashReporter.submit'] = {
     });
   },
 
-  sanitizesArgv2: function(test) {
+  sanitizesArgv2(test) {
     test.expect(1);
 
     this.crPost.restore();
@@ -294,7 +294,7 @@ exports['CrashReporter.submit'] = {
     });
   },
 
-  sanitizesArgv3: function(test) {
+  sanitizesArgv3(test) {
     test.expect(1);
 
     this.crPost.restore();
@@ -312,7 +312,7 @@ exports['CrashReporter.submit'] = {
     });
   },
 
-  sanitizesArgv4: function(test) {
+  sanitizesArgv4(test) {
     test.expect(1);
 
     this.crPost.restore();
@@ -330,11 +330,69 @@ exports['CrashReporter.submit'] = {
     });
   },
 
+  labelsWithConnectionType(test) {
+    test.expect(7);
+
+    this.crPost.restore();
+    this.crPost = this.sandbox.stub(CrashReporter, 'post').returns(Promise.resolve());
+
+    // We don't need an _actual_ tessel object to test this,
+    // just something that *looks like* a tessel object.
+    controller.tessel = {
+      connectionType: 'FOO'
+    };
+
+    CrashReporter.submit(new Error('This happened'), {
+      silent: true,
+      argv: ''
+    }).then(() => {
+      var labels = this.crPost.lastCall.args[0].split(',\n');
+
+      test.equal(labels[0], 't2-cli');
+      test.equal(labels[1].startsWith('CLI version: '), true);
+      test.equal(labels[2].startsWith('Node version: '), true);
+      test.equal(labels[3].startsWith('OS platform: '), true);
+      test.equal(labels[4].startsWith('OS release: '), true);
+      test.equal(labels[5].startsWith('Connection Type: '), true);
+      test.equal(labels[5].endsWith('FOO'), true);
+
+      test.done();
+    }).catch(error => {
+      test.ok(false, error.message);
+      test.done();
+    });
+  },
+
+  labelsWithoutConnectionType(test) {
+    test.expect(6);
+
+    this.crPost.restore();
+    this.crPost = this.sandbox.stub(CrashReporter, 'post').returns(Promise.resolve());
+
+    CrashReporter.submit(new Error('This happened'), {
+      silent: true,
+      argv: ''
+    }).then(() => {
+      var labels = this.crPost.lastCall.args[0].split(',\n');
+
+      test.equal(labels[0], 't2-cli');
+      test.equal(labels[1].startsWith('CLI version: '), true);
+      test.equal(labels[2].startsWith('Node version: '), true);
+      test.equal(labels[3].startsWith('OS platform: '), true);
+      test.equal(labels[4].startsWith('OS release: '), true);
+      test.equal(labels.indexOf('Connection Type: '), -1);
+
+      test.done();
+    }).catch(error => {
+      test.ok(false, error.message);
+      test.done();
+    });
+  },
 };
 
 
 exports['CrashReporter.sanitize'] = {
-  setUp: function(done) {
+  setUp(done) {
     this.sandbox = sinon.sandbox.create();
     this.error = this.sandbox.stub(log, 'error');
     this.logInfo = this.sandbox.stub(log, 'info');
@@ -348,12 +406,12 @@ exports['CrashReporter.sanitize'] = {
     done();
   },
 
-  tearDown: function(done) {
+  tearDown(done) {
     this.sandbox.restore();
     done();
   },
 
-  dirname: function(test) {
+  dirname(test) {
     test.expect(2);
 
     this.crPost.restore();
@@ -371,7 +429,7 @@ exports['CrashReporter.sanitize'] = {
     });
   },
 
-  filename: function(test) {
+  filename(test) {
     test.expect(2);
 
     this.crPost.restore();
@@ -389,7 +447,7 @@ exports['CrashReporter.sanitize'] = {
     });
   },
 
-  home: function(test) {
+  home(test) {
     test.expect(2);
 
     this.crPost.restore();
@@ -409,7 +467,7 @@ exports['CrashReporter.sanitize'] = {
 };
 
 exports['CrashReporter.post'] = {
-  setUp: function(done) {
+  setUp(done) {
     this.sandbox = sinon.sandbox.create();
     this.error = this.sandbox.stub(log, 'error');
     this.logInfo = this.sandbox.stub(log, 'info');
@@ -428,12 +486,12 @@ exports['CrashReporter.post'] = {
     done();
   },
 
-  tearDown: function(done) {
+  tearDown(done) {
     this.sandbox.restore();
     done();
   },
 
-  post: function(test) {
+  post(test) {
     test.expect(5);
 
     var labels = 'foo';
@@ -450,7 +508,7 @@ exports['CrashReporter.post'] = {
     });
   },
 
-  postWithBadResponse: function(test) {
+  postWithBadResponse(test) {
     test.expect(2);
 
     this.request.restore();
@@ -471,7 +529,7 @@ exports['CrashReporter.post'] = {
 };
 
 exports['CrashReporter.status'] = {
-  setUp: function(done) {
+  setUp(done) {
     this.sandbox = sinon.sandbox.create();
     this.logInfo = this.sandbox.stub(log, 'info');
     this.prefLoad = this.sandbox.stub(Preferences, 'load', () => {
@@ -482,12 +540,12 @@ exports['CrashReporter.status'] = {
     done();
   },
 
-  tearDown: function(done) {
+  tearDown(done) {
     this.sandbox.restore();
     done();
   },
 
-  status: function(test) {
+  status(test) {
     test.expect(1);
 
     CrashReporter.status().then(() => {


### PR DESCRIPTION
Adds connectionType as a label in a crash report. This is achieved by making the active Tessel object accessible to scopes outside of the command execution promise chain.

Signed-off-by: Rick Waldron <waldron.rick@gmail.com>