### PR TITLE
Remove crash handlers for testing

### DIFF
--- a/test/common/bootstrap.js
+++ b/test/common/bootstrap.js
@@ -208,3 +208,19 @@ global.processVersions = {
   modules: '46',
   openssl: '1.0.2d',
 };
+
+global.registeredProcessHandlers = 0;
+
+function removeCrashReporterHandlers(name, handlers) {
+  handlers.forEach(handler => {
+    if (handler.isCrashHandler) {
+      global.registeredProcessHandlers++;
+      process.removeListener(name, handler);
+    }
+  });
+}
+
+['unhandledRejection', 'uncaughtException'].forEach(name => {
+  var handlers = process._events[name];
+  removeCrashReporterHandlers(name, Array.isArray(handlers) ? handlers : [handlers]);
+});

--- a/test/unit/crash-reporter.js
+++ b/test/unit/crash-reporter.js
@@ -20,23 +20,7 @@ exports['CrashReporter'] = {
     test.expect(1);
 
     var expect = process.env.CI ? 0 : 2;
-    var tally = 0;
-
-    Object.keys(process._events).forEach(key => {
-      if (Array.isArray(process._events[key])) {
-        process._events[key].forEach(handler => {
-          if (handler.isCrashHandler) {
-            tally++;
-          }
-        });
-      } else {
-        if (process._events[key].isCrashHandler) {
-          tally++;
-        }
-      }
-    });
-
-    test.equal(tally, expect);
+    test.equal(global.registeredProcessHandlers, expect);
     test.done();
   }
 };


### PR DESCRIPTION
This will prevent development-time errors from being reported to the crash reporter. 

Signed-off-by: Rick Waldron <waldron.rick@gmail.com>