### PR TITLE
Use the sha when there is no "official" build version available.

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -1015,9 +1015,10 @@ controller.tesselEnvVersions = opts => {
           responses[2] => (string) process.version (on board)
          */
 
-        var cliVersion = require('../package.json').version;
-        var firmwareVersion = updates.findBuild(responses[0], 'sha', responses[1]).version;
-        var nodeVersion = responses[2];
+        const cliVersion = require('../package.json').version;
+        const build = updates.findBuild(responses[0], 'sha', responses[1]);
+        const firmwareVersion = (build && build.version) || responses[1];
+        const nodeVersion = responses[2];
 
         log.info('Tessel Environment Versions:');
         log.info(`t2-cli: ${cliVersion}`);

--- a/test/unit/controller.js
+++ b/test/unit/controller.js
@@ -613,6 +613,31 @@ exports['controller.tesselEnvVersions'] = {
         test.done();
       });
   },
+
+  // This happens with development builds.
+  noBuildVersionExistsForThisSha(test) {
+    test.expect(4);
+
+    const sha = '59ce9c97e275e6e970c1ee668e5591514eb1cd74';
+
+    this.fetchCurrentBuildInfo.restore();
+    this.sandbox.stub(this.tessel, 'fetchCurrentBuildInfo', () => Promise.resolve(sha));
+
+    var opts = {};
+
+    controller.tesselEnvVersions(opts)
+      .then(() => {
+        test.equal(this.info.getCall(0).args[0], 'Tessel Environment Versions:');
+        test.equal(this.info.getCall(1).args[0], 't2-cli: 0.1.4');
+        test.equal(this.info.getCall(2).args[0], `t2-firmware: ${sha}`);
+        test.equal(this.info.getCall(3).args[0], 'Node.js: 4.2.1');
+        test.done();
+      })
+      .catch(() => {
+        test.ok(false);
+        test.done();
+      });
+  },
 };
 
 exports['Tessel.list'] = {


### PR DESCRIPTION
This patch is best illustrated by the following screenshot: 

![](https://i.gyazo.com/4cfd370abdf09df09088ad755084b7a3.png)

Signed-off-by: Rick Waldron <waldron.rick@gmail.com>