### PR TITLE
Upgrade to uglify-es. Fixes gh-1201

### DIFF
--- a/lib/tessel/deployment/javascript.js
+++ b/lib/tessel/deployment/javascript.js
@@ -5,7 +5,6 @@ var StringDecoder = require('string_decoder').StringDecoder;
 var zlib = require('zlib');
 
 // Third Party Dependencies
-var acorn = require('acorn');
 var bindings = require('bindings');
 var fs = require('fs-extra');
 var fsTemp = require('fs-temp');
@@ -16,7 +15,7 @@ var Reader = require('fstream').Reader;
 var request = require('request');
 var tags = require('common-tags');
 var tar = require('tar');
-var uglify = require('uglify-js');
+var uglify = require('uglify-es');
 var urljoin = require('url-join');
 
 // Internal
@@ -732,10 +731,10 @@ exportables.compress = function(source, options) {
   options = options || {
     compress: {},
     mangle: {},
-    special: {},
+    parse: {},
   };
 
-  var compress = {
+  const compress = {
     // ------
     booleans: true,
     cascade: true,
@@ -748,87 +747,51 @@ exportables.compress = function(source, options) {
     join_vars: true,
     loops: true,
     properties: true,
-    screw_ie8: true,
     sequences: true,
     unsafe: true,
+    // ------
+    dead_code: true,
+    unsafe_math: true,
+    keep_infinity: true,
     // ------
     keep_fargs: false,
     keep_fnames: false,
     warnings: false,
     drop_console: false,
   };
-  var mangle = {
-    sort: true,
+
+  const mangle = {
     toplevel: true,
   };
-  var special = {
-    rescope_after_mangle: false,
+
+  const parse = {
+    bare_returns: true,
+    shebang: true,
   };
 
   Object.assign(compress, options.compress || {});
   Object.assign(mangle, options.mangle || {});
-  Object.assign(special, options.special || {});
+  Object.assign(parse, options.parse || {});
 
-  var ast;
+  const uOptions = {
+    toplevel: true,
+    warnings: false,
+    compress,
+    mangle,
+    parse,
+  };
 
-  try {
-    // Attempt to use acorn, this will provide
-    // better support for modern Ecma-262
-    // (but unfortunately, not perfect)
-    ast = uglify.AST_Node.from_mozilla_ast(
-      acorn.parse(source, {
-        allowImportExportEverywhere: true,
-        allowReturnOutsideFunction: true,
-        ecmaVersion: 7,
-      })
-    );
-    // However, if it fails, also try uglify...
-  } catch (acornError) {
-    try {
-      // If uglify lands _better_ ES6 support sooner,
-      // this will handle that
-      ast = uglify.parse(source, {
-        bare_returns: true,
-        fromString: true,
-        warnings: false,
-      });
-    } catch (uglifyError) {
-      // If neither parser could parse the source,
-      // then we have to settle with deploying
-      // uncompressed code for this file. If there
-      // is a true syntax error, the program will fail
-      // to run on the device itself and that's
-      // a better strategy then trying to handle all
-      // the edge cases ourselves. This also means
-      // that ES6 code won't trigger false failures
-      // on minifier parsers that haven't been updated.
-      return source;
-    }
-  }
-  // Guard against internal Uglify exceptions that
-  // really shouldn't be our problem, but it happens.
-  try {
-    ast.figure_out_scope();
-    ast = ast.transform(uglify.Compressor(compress));
+  const result = uglify.minify(source, uOptions);
 
-    ast.figure_out_scope(mangle);
-    ast.compute_char_frequency(mangle);
-    ast.mangle_names(mangle);
+  // uglify-es does not throw...
 
-    /* istanbul ignore if */
-    if (special.rescope_after_mangle) {
-      ast.figure_out_scope(mangle);
-    }
-
-    var stream = uglify.OutputStream();
-
-    ast.print(stream);
-
-    return stream.toString();
-  } catch (error) {
-    /* istanbul ignore next */
+  // If there was an error, let the source
+  // proceed uncompressed.
+  if (result.error) {
     return source;
   }
+
+  return result.code;
 };
 
 module.exports = exportables;

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "sinon": "^1.14.1"
   },
   "dependencies": {
-    "acorn": "^3.0.2",
     "async": "^1.4.2",
     "bindings": "^1.2.1",
     "block-stream2": "^1.1.0",
@@ -83,7 +82,7 @@
     "tar": "^2.1.1",
     "tar-fs": "^1.13.2",
     "tar-stream": "^1.3.0",
-    "uglify-js": "^2.6.2",
+    "uglify-es": "^3.0.17",
     "unbzip2-stream": "^1.0.10",
     "update-notifier": "^1.0.2",
     "url-join": "0.0.1",

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -17,7 +17,6 @@
   "unused": true,
   "globals": {
     "_": true,
-    "acorn": true,
     "async": true,
     "bindings": true,
     "builtInRulesCount": true,

--- a/test/common/bootstrap.js
+++ b/test/common/bootstrap.js
@@ -19,7 +19,6 @@ global.Transform = stream.Transform;
 
 
 // Third Party Dependencies
-global.acorn = require('acorn');
 global.async = require('async');
 global.bindings = require('bindings');
 global.charSpinner = require('char-spinner');
@@ -43,7 +42,7 @@ global.sshpk = require('sshpk');
 global.ssh = require('ssh2');
 global.tags = require('common-tags');
 global.tar = require('tar');
-global.uglify = require('uglify-js');
+global.uglify = require('uglify-es');
 
 
 // Internal


### PR DESCRIPTION
This now means that code written with >= ES6 syntax features will be compressed. 

Signed-off-by: Rick Waldron <waldron.rick@gmail.com>