### PR TITLE
t2 version should return at least the CLI version

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -1002,6 +1002,9 @@ controller.updateTesselWithVersion = function(opts, tessel, currentVersion, buil
 
 controller.tesselEnvVersions = opts => {
   opts.authorized = true;
+
+  const cliVersion = require('../package.json').version;
+
   return controller.standardTesselCommand(opts, tessel => {
     return new Promise((resolve, reject) => {
       Promise.all([
@@ -1015,7 +1018,6 @@ controller.tesselEnvVersions = opts => {
           responses[2] => (string) process.version (on board)
          */
 
-        const cliVersion = require('../package.json').version;
         const build = updates.findBuild(responses[0], 'sha', responses[1]);
         const firmwareVersion = (build && build.version) || responses[1];
         const nodeVersion = responses[2];
@@ -1030,6 +1032,17 @@ controller.tesselEnvVersions = opts => {
         // then this whole operation should fail.
       }, reject).catch(reject);
     });
+  })
+  .catch((error) => {
+    // if no tessels are found, default to cli version
+    if (error.includes(responses.noAuth) || error.includes(responses.auth)) {
+
+      log.info('Tessel Environment Versions:');
+      log.info(`t2-cli: ${cliVersion}`);
+      log.info(`${error}`);
+      return Promise.resolve();
+    }
+    return Promise.reject(error);
   });
 };
 

--- a/test/unit/controller.js
+++ b/test/unit/controller.js
@@ -593,6 +593,42 @@ exports['controller.tesselEnvVersions'] = {
       });
   },
 
+  requestVersionWithoutTessel(test) {
+    test.expect(7);
+
+    const message = 'No Tessels Found.';
+    
+    this.standardTesselCommand.restore();
+    this.standardTesselCommand = this.sandbox.stub(controller, 'standardTesselCommand', () => {
+      return Promise.reject(message);
+    });
+
+    const opts = {};
+
+    controller.tesselEnvVersions(opts)
+      .then(() => {
+        // Version command was sent
+        test.equal(this.standardTesselCommand.callCount, 1);
+
+        test.equal(this.fetchCurrentBuildInfo.callCount, 0);
+        test.equal(this.fetchNodeProcessVersion.callCount, 0);
+
+        // Make sure we have some output
+        test.equal(this.info.callCount, 3);
+
+        test.equal(this.info.getCall(0).args[0], `Tessel Environment Versions:`);
+        // Output of CLI version to console
+        test.equal(this.info.getCall(1).args[0], `t2-cli: ${this.packageJsonVersion}`);
+        // Output 'No Tessels Found' message
+        test.equal(this.info.getCall(2).args[0], message);
+        test.done();
+      })
+      .catch(() => {
+        test.ok(false, 'tesselEnvVersions was expected to succeed');
+        test.done();
+      });
+  },
+
   requestVersionsFailure(test) {
     test.expect(1);
 


### PR DESCRIPTION
Right now when `t2 version` is run with no Tessels connected via USB or LAN, the command will end with `WARN No Tessels Found.` or `WARN No Authorizes Tessels Found.`. This patch allows the CLI version to be displayed if no Tessels are found. 

New output:

```
hipsterbrown:t2-cli (t2-version-cli-only) $ t2 version
INFO Looking for your Tessel...
INFO Tessel Environment Versions:
INFO t2-cli: 0.1.5
INFO No Authorized Tessels Found.
hipsterbrown:t2-cli (t2-version-cli-only) $
```