### PR TITLE
Call Tessel.setWiFiState with updated arguments

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -721,7 +721,7 @@ controller.connectToNetwork = function(options) {
 
 controller.setWiFiState = function(options) {
   options.authorized = true;
-  return controller.standardTesselCommand(options, (tessel) => tessel.setWiFiState(options.on));
+  return controller.standardTesselCommand(options, (tessel) => tessel.setWiFiState({ enable: options.on }));
 };
 
 controller.createAccessPoint = function(options) {


### PR DESCRIPTION
Currently, running `t2 wifi --off` returns the following output:

```
hipsterbrown:tessel-test (master) $ t2 wifi --off
INFO Looking for your Tessel...
INFO Connected to j5.
ERR! Error: Missing Wifi State: (empty).
```

This is due to the controller command not calling `tessel.setWiFiState` with the recently updated parameters.