### PR TITLE
Updates warning with instructions to rebuild usb drivers without reinstalling t2-cli

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -12,14 +12,13 @@ var semver = require('semver');
 
 // Internal
 var CrashReporter = require('./crash-reporter');
-var discover = require('./discover');
 var init = require('./init');
 var installer = require('./installer');
 var log = require('./log');
 var Menu = require('./menu');
 var updates = require('./update-fetch');
-var provision = require('./tessel/provision');
 var Tessel = require('./tessel/tessel');
+var provision = require('./tessel/provision');
 
 var controller = {
   // This will be assigned with the Tessel that is found or selected.
@@ -86,6 +85,8 @@ controller.setupLocal = function(opts) {
 
 
 Tessel.list = function(opts) {
+  var discover = require('./discover');
+
   return new Promise(function(resolve, reject) {
     // Grab all attached Tessels
     log.info('Searching for nearby Tessels...');
@@ -181,6 +182,8 @@ Tessel.list = function(opts) {
 };
 
 Tessel.get = function(options) {
+  var discover = require('./discover');
+
   return new Promise((resolve, reject) => {
     log.info('Looking for your Tessel...');
     // Collection variable as more Tessels are found

--- a/lib/usb-connection.js
+++ b/lib/usb-connection.js
@@ -7,7 +7,7 @@ var Duplex = stream.Duplex;
 var Emitter = events.EventEmitter;
 
 // Third Party Dependencies
-// ...
+const tags = require('common-tags');
 
 // Internal
 var DFU = require('./dfu');
@@ -22,14 +22,26 @@ function debugCommands(message) {
   log.debug(`(commands:usb) ${message}`);
 }
 
-var haveusb = true;
+var isUSBAvailable = true;
 try {
   var usb = require('usb');
   var VENDOR_REQ_OUT = usb.LIBUSB_REQUEST_TYPE_VENDOR | usb.LIBUSB_RECIPIENT_DEVICE | usb.LIBUSB_ENDPOINT_OUT;
   // var VENDOR_REQ_IN  = usb.LIBUSB_REQUEST_TYPE_VENDOR | usb.LIBUSB_RECIPIENT_DEVICE | usb.LIBUSB_ENDPOINT_IN;
-} catch (e) {
-  haveusb = false;
-  log.error('WARNING: No USB controller found on this system. Please run npm install -g t2-cli to compile USB drivers for your version of node');
+} catch (error) {
+  isUSBAvailable = false;
+
+  // do not exit the process during tests because usb is not needed to run them
+  if (!global.IS_TEST_ENV) {
+    log.error('Node version mismatch for USB drivers.');
+    log.info(tags.stripIndent`
+      To correct this issue, please run the following command:
+
+        npm rebuild --update-binary usb
+
+      This will rebuild the USB drivers for your version of Node.js
+    `);
+    process.exit(1);
+  }
 }
 
 var Daemon = require('./usb/usb-daemon');
@@ -408,7 +420,7 @@ USB.Scanner.prototype.start = function() {
     }
   };
 
-  if (haveusb) {
+  if (isUSBAvailable) {
     usb.getDeviceList().forEach(deviceInspector);
 
     usb.on('attach', deviceInspector);
@@ -416,7 +428,7 @@ USB.Scanner.prototype.start = function() {
 };
 
 USB.Scanner.prototype.stop = function() {
-  if (haveusb) {
+  if (isUSBAvailable) {
     usb.removeAllListeners('attach');
   }
 };


### PR DESCRIPTION
This PR proposes a new solution to the "WARNING: Please run npm install -g t2-cli to compile USB drivers for the newer version of node" issue. (More details [here](https://github.com/tessel/t2-cli/issues/1071))

The error message will now show: **"ERR! Node version mismatch for USB drivers. Please run "npm rebuild --update-binary usb" to rebuild the USB drivers for your version of node"**

<del> `t2 rebuild` is new command that programmatically calls `npm rebuild usb --update-binary` so users don't have to completely reinstall the CLI. </del>

Edit: After a conversation with @rwaldron, I learned that `npm rebuild --update-binary usb` can be called from anywhere. So instead of adding this responsibility to this CLI, we can simply inform the user to call the `npm rebuild` command manually. 

Preview:

```
hipsterbrown:tessel-test $ t2 list
ERR! Node version mismatch for USB drivers.
INFO To correct this issue, please run the following command:
INFO
INFO   npm rebuild --update-binary usb
INFO
INFO This will rebuild the USB drivers for your version of Node.js
hipsterbrown:tessel-test $ npm rebuild --update-binary usb

> usb@1.2.0 install /Users/hipsterbrown/Projects/tessel-test/node_modules/t2-cli/node_modules/usb
> node-pre-gyp install --fallback-to-build

[usb] Success: "/Users/hipsterbrown/Projects/t2-cli/node_modules/usb/src/binding/usb_bindings.node" is installed via remote
usb@1.2.0 /Users/hipsterbrown/Projects/tessel-test/node_modules/t2-cli/node_modules/usb
hipsterbrown:tessel-test $ t2 list
INFO Searching for nearby Tessels...
WARN No Tessels Found.
hipsterbrown:tessel-test $
```