### PR TITLE
Allow passing binary options directly to node or python binary.

### DIFF
--- a/bin/tessel-2.js
+++ b/bin/tessel-2.js
@@ -27,12 +27,14 @@ const pkg = require('../package.json');
  * Can be removed once https://github.com/npm/write-file-atomic/issues/11
  * has been resolved.
  */
+/* istanbul ignore else */
 if (!isRoot()) {
   try {
     updateNotifier({
       pkg
     }).notify();
   } catch (err) {
+    /* istanbul ignore next */
     CrashReporter.submit(err.stack, {
       silent: true
     });
@@ -204,6 +206,9 @@ makeCommand('run')
     options.push = false;
     // Overridden in tarBundle if options.full is `true`
     options.slim = true;
+    // binopts will come from an actual option,
+    // whereas subargs are custom parsed
+    options.binopts = options.binopts || [];
     options.subargs = parser.subargs || [];
 
     callControllerWith('deploy', options);
@@ -241,6 +246,13 @@ makeCommand('run')
   .option('rustcc', {
     flag: true,
     help: 'Specify the location and port of the Rust cross-compilation server.'
+  })
+  .option('binopts', {
+    default: [],
+    transform(binopts) {
+      return binopts.split(/,|\s+/).filter(Boolean);
+    },
+    help: 'Arguments sent to the binary (e.g. Node.js, Python)'
   })
   .help(`
     Deploy an application to Tessel and run it.
@@ -261,6 +273,9 @@ makeCommand('push')
     options.push = true;
     // Overridden in tarBundle if options.full is `true`
     options.slim = true;
+    // binopts will come from an actual option,
+    // whereas subargs are custom parsed
+    options.binopts = options.binopts || [];
     options.subargs = parser.subargs || [];
 
     callControllerWith('deploy', options);
@@ -298,6 +313,13 @@ makeCommand('push')
   .option('rustcc', {
     flag: true,
     help: 'Specify the location and port of the Rust cross-compilation server.'
+  })
+  .option('binopts', {
+    default: [],
+    transform(binopts) {
+      return binopts.split(/,|\s+/).filter(Boolean);
+    },
+    help: 'Arguments sent to the binary (e.g. Node.js, Python)'
   })
   .help(`
     Pushes the file/dir to Flash memory to be run anytime the Tessel is powered,

--- a/lib/tessel/commands.js
+++ b/lib/tessel/commands.js
@@ -1,197 +1,231 @@
-/**
- * Application specific deployment commands
- *
- * Language: *
- *
- */
-module.exports.app = {
-  // Note: These should be converted to method shorthand
-  // once t2-cli moves to Node 6
-  stop: () => ['/etc/init.d/tessel-app', 'stop'],
-  start: () => ['/etc/init.d/tessel-app', 'start'],
-  disable: () => ['/etc/init.d/tessel-app', 'disable'],
-  enable: () => ['/etc/init.d/tessel-app', 'enable'],
-};
+'use strict';
 
-/**
- * Language specific deployment commands
- *
- */
-module.exports.js = {
-  execute: (filepath, relpath, args) => ['node', filepath + relpath].concat(args),
-};
+function normalizeOptions(options) {
+  options = options || {};
+  options.binopts = options.binopts || [];
+  options.subargs = options.subargs || [];
+  return options;
+}
 
-module.exports.rs = {
-  execute: (filepath, relpath, args) => [filepath + relpath].concat(args),
-};
+function flatten() {
+  let args = Array.from(arguments);
+  let result = [];
+  for (let arg of args) {
+    if (Array.isArray(arg)) {
+      result = result.concat(flatten.apply(null, arg));
+    } else {
+      result.push(arg);
+    }
+  }
+  return result;
+}
 
-module.exports.py = {
-  execute: (filepath, relpath, args) => ['python', filepath + relpath].concat(args),
-};
+module.exports = {
+  /**
+   * Application specific deployment commands
+   *
+   * Language: *
+   *
+   */
+  app: {
+    stop() {
+      return ['/etc/init.d/tessel-app', 'stop'];
+    },
+    start() {
+      return ['/etc/init.d/tessel-app', 'start'];
+    },
+    disable() {
+      return ['/etc/init.d/tessel-app', 'disable'];
+    },
+    enable() {
+      return ['/etc/init.d/tessel-app', 'enable'];
+    },
+  },
+  /**
+   * Language specific deployment commands
+   *
+   */
+  js: {
+    execute(rootpath, relpath, options) {
+      options = normalizeOptions(options);
+      return flatten(['node', options.binopts, rootpath + relpath, options.subargs]);
+    },
+  },
+  rs: {
+    execute(rootpath, relpath, options) {
+      options = normalizeOptions(options);
+      return flatten([rootpath + relpath, options.subargs]);
+    },
+  },
+  py: {
+    execute(rootpath, relpath, options) {
+      options = normalizeOptions(options);
+      return flatten(['python', options.binopts, rootpath + relpath, options.subargs]);
+    },
+  },
+  readFile(filepath) {
+    return ['cat', filepath];
+  },
+  scanWiFi() {
+    return ['iwinfo', 'wlan0', 'scan'];
+  },
+  getWifiInfo() {
+    return ['ubus', 'call', 'iwinfo', 'info', '{"device":"wlan0"}'];
+  },
+  getIPAddress() {
+    return ['ifconfig', 'wlan0'];
+  },
+  deleteFolder(filepath) {
+    return ['rm', '-rf', filepath];
+  },
+  createFolder(filepath) {
+    return ['mkdir', '-p', filepath];
+  },
+  moveFolder(source, destination) {
+    return ['mv', source, destination];
+  },
+  untarStdin(filepath) {
+    return ['tar', '-x', '-C', filepath];
+  },
+  openStdinToFile(filepath) {
+    return ['dd', 'of=' + filepath];
+  },
+  appendStdinToFile(filepath) {
+    return ['tee', '-a', filepath];
+  },
+  chmod(permission, filepath) {
+    return ['chmod', permission, filepath];
+  },
+  connectedNetworkStatus() {
+    return ['ubus', 'call', 'network.interface.lan', 'status'];
+  },
+  setNetworkSSID(ssid) {
+    return ['uci', 'set', 'wireless.@wifi-iface[0].ssid=' + ssid];
+  },
+  setNetworkPassword(password) {
+    return ['uci', 'set', 'wireless.@wifi-iface[0].key=' + password];
+  },
+  setNetworkEncryption(encryption) {
+    return ['uci', 'set', 'wireless.@wifi-iface[0].encryption=' + encryption];
+  },
+  turnOnWifi(enabled) {
+    return ['uci', 'set', 'wireless.@wifi-iface[0].disabled=' + Number(enabled ? 0 : 1).toString()];
+  },
+  commitWirelessCredentials() {
+    return ['uci', 'commit', 'wireless'];
+  },
+  reconnectWifi() {
+    return ['wifi'];
+  },
+  ensureFileExists(filepath) {
+    return ['touch', filepath];
+  },
+  getHostname() {
+    return ['uci', 'get', 'system.@system[0].hostname'];
+  },
+  setHostname(hostname) {
+    return ['uci', 'set', 'system.@system[0].hostname=' + hostname];
+  },
+  commitHostname() {
+    return ['uci', 'commit', 'system'];
+  },
+  getInterface(interfaceName) {
+    return ['ifconfig', interfaceName];
+  },
+  callMDNSDaemon(action) {
+    return ['/etc/init.d/mdnsd', action];
+  },
+  callTesselMDNS(action) {
+    return ['/etc/init.d/tessel-mdns', action];
+  },
+  sysupgrade(path) {
+    return ['sysupgrade', path];
+  },
+  sysupgradeNoSaveConfig(path) {
+    return ['sysupgrade', '-n', path];
+  },
+  getMemoryInfo() {
+    return ['cat', '/proc/meminfo'];
+  },
+  ubusListen() {
+    return ['ubus', 'listen'];
+  },
+  setLanNetwork() {
+    return ['uci', 'set', 'network.lan=interface'];
+  },
+  setLanNetworkIfname() {
+    return ['uci', 'set', 'network.lan.ifname=wlan0'];
+  },
+  setLanNetworkProto() {
+    return ['uci', 'set', 'network.lan.proto=static'];
+  },
+  setLanNetworkIP() {
+    return ['uci', 'set', 'network.lan.ipaddr=192.168.1.101'];
+  },
+  setLanNetworkNetmask() {
+    return ['uci', 'set', 'network.lan.netmask=255.255.255.0'];
+  },
+  commitNetwork() {
+    return ['uci', 'commit', 'network'];
+  },
+  getAccessPoint() {
+    return ['uci', 'get', 'wireless.@wifi-iface[1]'];
+  },
+  getAccessPointSSID() {
+    return ['uci', 'get', 'wireless.@wifi-iface[1].ssid'];
+  },
+  setAccessPoint() {
+    return ['uci', 'add', 'wireless', 'wifi-iface'];
+  },
+  setAccessPointDevice() {
+    return ['uci', 'set', 'wireless.@wifi-iface[1].device=radio0'];
+  },
+  setAccessPointNetwork() {
+    return ['uci', 'set', 'wireless.@wifi-iface[1].network=lan'];
+  },
+  setAccessPointMode() {
+    return ['uci', 'set', 'wireless.@wifi-iface[1].mode=ap'];
+  },
+  setAccessPointSSID(ssid) {
+    return ['uci', 'set', 'wireless.@wifi-iface[1].ssid=' + ssid];
+  },
+  setAccessPointPassword(password) {
+    return ['uci', 'set', 'wireless.@wifi-iface[1].key=' + password];
+  },
+  setAccessPointSecurity(security) {
+    return ['uci', 'set', 'wireless.@wifi-iface[1].encryption=' + security];
+  },
+  turnAccessPointOn() {
+    return ['uci', 'set', 'wireless.@wifi-iface[1].disabled=0'];
+  },
+  turnAccessPointOff() {
+    return ['uci', 'set', 'wireless.@wifi-iface[1].disabled=1'];
+  },
+  turnRadioOn() {
+    return ['uci', 'set', 'wireless.radio0.disabled=0'];
+  },
+  getAccessPointConfig() {
+    return ['uci', 'show', 'wireless.@wifi-iface[1]'];
+  },
+  getAccessPointIP() {
+    return ['uci', 'get', 'network.lan.ipaddr'];
+  },
+  reconnectDnsmasq() {
+    return ['/etc/init.d/dnsmasq', 'restart'];
+  },
+  reconnectDhcp() {
+    return ['/etc/init.d/odhcpd', 'restart'];
+  },
+  /*
+   1. Create a GPIO entry for the SAMD21 RESET pin
+   2. Make that GPIO an output
+   3. Pull the output low to reset the SAMD21 (see NOTE below)
+   4. Reboot the MediaTek
 
-module.exports.readFile = function(filepath) {
-  return ['cat', filepath];
-};
-module.exports.scanWiFi = function() {
-  return ['iwinfo', 'wlan0', 'scan'];
-};
-module.exports.getWifiInfo = function() {
-  return ['ubus', 'call', 'iwinfo', 'info', '{"device":"wlan0"}'];
-};
-module.exports.getIPAddress = function() {
-  return ['ifconfig', 'wlan0'];
-};
-module.exports.deleteFolder = function(filepath) {
-  return ['rm', '-rf', filepath];
-};
-module.exports.createFolder = function(filepath) {
-  return ['mkdir', '-p', filepath];
-};
-module.exports.moveFolder = function(source, destination) {
-  return ['mv', source, destination];
-};
-module.exports.untarStdin = function(filepath) {
-  return ['tar', '-x', '-C', filepath];
-};
-module.exports.openStdinToFile = function(filepath) {
-  return ['dd', 'of=' + filepath];
-};
-module.exports.appendStdinToFile = function(filepath) {
-  return ['tee', '-a', filepath];
-};
-module.exports.chmod = function(permission, filepath) {
-  return ['chmod', permission, filepath];
-};
-module.exports.connectedNetworkStatus = function() {
-  return ['ubus', 'call', 'network.interface.lan', 'status'];
-};
-module.exports.setNetworkSSID = function(ssid) {
-  return ['uci', 'set', 'wireless.@wifi-iface[0].ssid=' + ssid];
-};
-module.exports.setNetworkPassword = function(password) {
-  return ['uci', 'set', 'wireless.@wifi-iface[0].key=' + password];
-};
-module.exports.setNetworkEncryption = function(encryption) {
-  return ['uci', 'set', 'wireless.@wifi-iface[0].encryption=' + encryption];
-};
-module.exports.turnOnWifi = function(enabled) {
-  return ['uci', 'set', 'wireless.@wifi-iface[0].disabled=' + Number(enabled ? 0 : 1).toString()];
-};
-module.exports.commitWirelessCredentials = function() {
-  return ['uci', 'commit', 'wireless'];
-};
-module.exports.reconnectWifi = function() {
-  return ['wifi'];
-};
-module.exports.ensureFileExists = function(filepath) {
-  return ['touch', filepath];
-};
-module.exports.getHostname = function() {
-  return ['uci', 'get', 'system.@system[0].hostname'];
-};
-module.exports.setHostname = function(hostname) {
-  return ['uci', 'set', 'system.@system[0].hostname=' + hostname];
-};
-module.exports.commitHostname = function() {
-  return ['uci', 'commit', 'system'];
-};
-module.exports.getInterface = function(interfaceName) {
-  return ['ifconfig', interfaceName];
-};
-module.exports.callMDNSDaemon = function(action) {
-  return ['/etc/init.d/mdnsd', action];
-};
-module.exports.callTesselMDNS = function(action) {
-  return ['/etc/init.d/tessel-mdns', action];
-};
-module.exports.sysupgrade = function(path) {
-  return ['sysupgrade', path];
-};
-module.exports.sysupgradeNoSaveConfig = function(path) {
-  return ['sysupgrade', '-n', path];
-};
-module.exports.getMemoryInfo = function() {
-  return ['cat', '/proc/meminfo'];
-};
-module.exports.ubusListen = function() {
-  return ['ubus', 'listen'];
-};
-module.exports.setLanNetwork = function() {
-  return ['uci', 'set', 'network.lan=interface'];
-};
-module.exports.setLanNetworkIfname = function() {
-  return ['uci', 'set', 'network.lan.ifname=wlan0'];
-};
-module.exports.setLanNetworkProto = function() {
-  return ['uci', 'set', 'network.lan.proto=static'];
-};
-module.exports.setLanNetworkIP = function() {
-  return ['uci', 'set', 'network.lan.ipaddr=192.168.1.101'];
-};
-module.exports.setLanNetworkNetmask = function() {
-  return ['uci', 'set', 'network.lan.netmask=255.255.255.0'];
-};
-module.exports.commitNetwork = function() {
-  return ['uci', 'commit', 'network'];
-};
-module.exports.getAccessPoint = function() {
-  return ['uci', 'get', 'wireless.@wifi-iface[1]'];
-};
-module.exports.getAccessPointSSID = function() {
-  return ['uci', 'get', 'wireless.@wifi-iface[1].ssid'];
-};
-module.exports.setAccessPoint = function() {
-  return ['uci', 'add', 'wireless', 'wifi-iface'];
-};
-module.exports.setAccessPointDevice = function() {
-  return ['uci', 'set', 'wireless.@wifi-iface[1].device=radio0'];
-};
-module.exports.setAccessPointNetwork = function() {
-  return ['uci', 'set', 'wireless.@wifi-iface[1].network=lan'];
-};
-module.exports.setAccessPointMode = function() {
-  return ['uci', 'set', 'wireless.@wifi-iface[1].mode=ap'];
-};
-module.exports.setAccessPointSSID = function(ssid) {
-  return ['uci', 'set', 'wireless.@wifi-iface[1].ssid=' + ssid];
-};
-module.exports.setAccessPointPassword = function(password) {
-  return ['uci', 'set', 'wireless.@wifi-iface[1].key=' + password];
-};
-module.exports.setAccessPointSecurity = function(security) {
-  return ['uci', 'set', 'wireless.@wifi-iface[1].encryption=' + security];
-};
-module.exports.turnAccessPointOn = function() {
-  return ['uci', 'set', 'wireless.@wifi-iface[1].disabled=0'];
-};
-module.exports.turnAccessPointOff = function() {
-  return ['uci', 'set', 'wireless.@wifi-iface[1].disabled=1'];
-};
-module.exports.turnRadioOn = function() {
-  return ['uci', 'set', 'wireless.radio0.disabled=0'];
-};
-module.exports.getAccessPointConfig = function() {
-  return ['uci', 'show', 'wireless.@wifi-iface[1]'];
-};
-module.exports.getAccessPointIP = function() {
-  return ['uci', 'get', 'network.lan.ipaddr'];
-};
-module.exports.reconnectDnsmasq = function() {
-  return ['/etc/init.d/dnsmasq', 'restart'];
-};
-module.exports.reconnectDhcp = function() {
-  return ['/etc/init.d/odhcpd', 'restart'];
-};
-
-/*
- 1. Create a GPIO entry for the SAMD21 RESET pin
- 2. Make that GPIO an output
- 3. Pull the output low to reset the SAMD21 (see NOTE below)
- 4. Reboot the MediaTek
-
- NOTE: To reset the SAMD21, the SAMD21 RESET pin must be toggled low then high. By rebooting the MediaTek,
- SAMD21 RESET pin is set back to a high state thus completing the SAMD21 reset sequence.
- */
-module.exports.reboot = function() {
-  return ['sh', '-c', 'echo 39 > /sys/class/gpio/export && echo out > /sys/class/gpio/gpio39/direction && echo 0 > /sys/class/gpio/gpio39/value && reboot'];
+   NOTE: To reset the SAMD21, the SAMD21 RESET pin must be toggled low then high. By rebooting the MediaTek,
+   SAMD21 RESET pin is set back to a high state thus completing the SAMD21 reset sequence.
+   */
+  reboot() {
+    return ['sh', '-c', 'echo 39 > /sys/class/gpio/export && echo out > /sys/class/gpio/gpio39/direction && echo 0 > /sys/class/gpio/gpio39/value && reboot'];
+  },
 };

--- a/lib/tessel/deploy.js
+++ b/lib/tessel/deploy.js
@@ -129,6 +129,7 @@ Tessel.prototype.deploy = function(opts) {
 
   // Resolve the application's language/runtime
   opts.lang = deployment.resolveLanguage(opts.lang || opts.entryPoint);
+  opts.binopts = opts.binopts || [];
   opts.subargs = opts.subargs || [];
 
   return new Promise((resolve, reject) => {
@@ -392,7 +393,7 @@ exportables.run = function(tessel, options) {
 
     return preRun.then(() => {
       tessel.connection.exec(
-        commands[lang.meta.extname].execute(Tessel.REMOTE_RUN_PATH, options.resolvedEntryPoint, options.subargs), {
+        commands[lang.meta.extname].execute(Tessel.REMOTE_RUN_PATH, options.resolvedEntryPoint, options), {
           pty: true
         }, (error, remoteProcess) => {
           /* istanbul ignore if */

--- a/lib/tessel/deployment/javascript.js
+++ b/lib/tessel/deployment/javascript.js
@@ -61,7 +61,7 @@ var exportables = {
     shell(options) {
       return tags.stripIndent `
         #!/bin/sh
-        exec node /app/remote-script/${options.resolvedEntryPoint} ${options.subargs.join(' ')}
+        exec node ${options.binopts.join(' ')} /app/remote-script/${options.resolvedEntryPoint} ${options.subargs.join(' ')}
       `;
     },
   },

--- a/lib/tessel/deployment/python.js
+++ b/lib/tessel/deployment/python.js
@@ -40,7 +40,7 @@ var exportables = {
       /* istanbul ignore next */
       return tags.stripIndent `
         #!/bin/sh
-        exec python /app/remote-script/${options.resolvedEntryPoint} ${options.subargs.join(' ')}
+        exec python ${options.binopts.join(' ')} /app/remote-script/${options.resolvedEntryPoint} ${options.subargs.join(' ')}
       `;
     },
   },

--- a/lib/usb-connection.js
+++ b/lib/usb-connection.js
@@ -33,7 +33,7 @@ try {
   // do not exit the process during tests because usb is not needed to run them
   if (!global.IS_TEST_ENV) {
     log.error('Node version mismatch for USB drivers.');
-    log.info(tags.stripIndent`
+    log.info(tags.stripIndent `
       To correct this issue, please run the following command:
 
         npm rebuild --update-binary usb

--- a/test/unit/bin-tessel-2.js
+++ b/test/unit/bin-tessel-2.js
@@ -436,7 +436,7 @@ exports['Tessel (t2: root)'] = {
 };
 
 exports['Tessel (t2: run)'] = {
-  setUp: function(done) {
+  setUp(done) {
     this.sandbox = sinon.sandbox.create();
     this.spinnerStart = this.sandbox.stub(log.spinner, 'start');
     this.spinnerStop = this.sandbox.stub(log.spinner, 'stop');
@@ -447,12 +447,12 @@ exports['Tessel (t2: run)'] = {
     done();
   },
 
-  tearDown: function(done) {
+  tearDown(done) {
     this.sandbox.restore();
     done();
   },
 
-  defaultOptions: function(test) {
+  defaultOptions(test) {
     test.expect(6);
 
     t2(['run', 'index.js']);
@@ -473,7 +473,7 @@ exports['Tessel (t2: run)'] = {
     setImmediate(test.done);
   },
 
-  fullSetTrue_slimOverriddenLater: function(test) {
+  fullSetTrue_slimOverriddenLater(test) {
     test.expect(5);
 
     t2(['run', 'index.js', '--full=true']);
@@ -492,10 +492,40 @@ exports['Tessel (t2: run)'] = {
 
     setImmediate(test.done);
   },
+
+  binopts(test) {
+    test.expect(3);
+
+    t2(['run', 'index.js', '--binopts="--a"']);
+
+    test.equal(this.deploy.callCount, 1);
+
+    var args = this.deploy.lastCall.args[0];
+
+    test.deepEqual(args.binopts, ['--a']);
+    test.ok(!args.push);
+
+    setImmediate(test.done);
+  },
+
+  binoptsList(test) {
+    test.expect(3);
+
+    t2(['run', 'index.js', '--binopts=--a,--b,--c']);
+
+    test.equal(this.deploy.callCount, 1);
+
+    var args = this.deploy.lastCall.args[0];
+
+    test.deepEqual(args.binopts, ['--a', '--b', '--c']);
+    test.ok(!args.push);
+
+    setImmediate(test.done);
+  },
 };
 
 exports['Tessel (t2: push)'] = {
-  setUp: function(done) {
+  setUp(done) {
     this.sandbox = sinon.sandbox.create();
     this.spinnerStart = this.sandbox.stub(log.spinner, 'start');
     this.spinnerStop = this.sandbox.stub(log.spinner, 'stop');
@@ -506,12 +536,12 @@ exports['Tessel (t2: push)'] = {
     done();
   },
 
-  tearDown: function(done) {
+  tearDown(done) {
     this.sandbox.restore();
     done();
   },
 
-  defaultOptions: function(test) {
+  defaultOptions(test) {
     test.expect(6);
 
     t2(['push', 'index.js']);
@@ -532,7 +562,7 @@ exports['Tessel (t2: push)'] = {
     setImmediate(test.done);
   },
 
-  fullSetTrue_slimOverriddenLater: function(test) {
+  fullSetTrue_slimOverriddenLater(test) {
     test.expect(5);
 
     t2(['push', 'index.js', '--full=true']);
@@ -547,6 +577,36 @@ exports['Tessel (t2: push)'] = {
     test.ok(args.lanPrefer);
     test.ok(args.push);
     test.ok(args.slim);
+
+    setImmediate(test.done);
+  },
+
+  binopts(test) {
+    test.expect(3);
+
+    t2(['push', 'index.js', '--binopts="--a"']);
+
+    test.equal(this.deploy.callCount, 1);
+
+    var args = this.deploy.lastCall.args[0];
+
+    test.deepEqual(args.binopts, ['--a']);
+    test.ok(args.push);
+
+    setImmediate(test.done);
+  },
+
+  binoptsList(test) {
+    test.expect(3);
+
+    t2(['push', 'index.js', '--binopts=--a,--b,--c']);
+
+    test.equal(this.deploy.callCount, 1);
+
+    var args = this.deploy.lastCall.args[0];
+
+    test.deepEqual(args.binopts, ['--a', '--b', '--c']);
+    test.ok(args.push);
 
     setImmediate(test.done);
   },

--- a/test/unit/commands.js
+++ b/test/unit/commands.js
@@ -1,0 +1,371 @@
+'use strict';
+
+// Test dependencies are required and exposed in common/bootstrap.js
+require('../common/bootstrap');
+
+exports['commands.app'] = {
+
+  stop(test) {
+    test.expect(1);
+    test.deepEqual(commands.app.stop(), ['/etc/init.d/tessel-app', 'stop']);
+    test.done();
+  },
+  start(test) {
+    test.expect(1);
+    test.deepEqual(commands.app.start(), ['/etc/init.d/tessel-app', 'start']);
+    test.done();
+  },
+  disable(test) {
+    test.expect(1);
+    test.deepEqual(commands.app.disable(), ['/etc/init.d/tessel-app', 'disable']);
+    test.done();
+  },
+  enable(test) {
+    test.expect(1);
+    test.deepEqual(commands.app.enable(), ['/etc/init.d/tessel-app', 'enable']);
+    test.done();
+  },
+};
+
+exports['commands.*.execute(...) (* = lang)'] = {
+
+  js(test) {
+    test.expect(6);
+
+    let noOptions = commands.js.execute('/rootpath/', 'relpath');
+    let noExtraArgs = commands.js.execute('/rootpath/', 'relpath', {});
+    let noBinArgs = commands.js.execute('/rootpath/', 'relpath', {
+      subargs: []
+    });
+    let noSubArgs = commands.js.execute('/rootpath/', 'relpath', {
+      binopts: []
+    });
+    let emptyExtraArgs = commands.js.execute('/rootpath/', 'relpath', {
+      binopts: [],
+      subargs: []
+    });
+    let extraArgs = commands.js.execute('/rootpath/', 'relpath', {
+      binopts: ['--harmony'],
+      subargs: ['--foo']
+    });
+
+    test.deepEqual(noOptions, ['node', '/rootpath/relpath']);
+    test.deepEqual(noExtraArgs, ['node', '/rootpath/relpath']);
+    test.deepEqual(noBinArgs, ['node', '/rootpath/relpath']);
+    test.deepEqual(noSubArgs, ['node', '/rootpath/relpath']);
+    test.deepEqual(emptyExtraArgs, ['node', '/rootpath/relpath']);
+    test.deepEqual(extraArgs, ['node', '--harmony', '/rootpath/relpath', '--foo']);
+    test.done();
+  },
+  rs(test) {
+    test.expect(4);
+
+    let noOptions = commands.rs.execute('/rootpath/', 'relpath');
+    let noExtraArgs = commands.rs.execute('/rootpath/', 'relpath', {});
+    let emptyExtraArgs = commands.rs.execute('/rootpath/', 'relpath', {
+      subargs: []
+    });
+    let extraArgs = commands.rs.execute('/rootpath/', 'relpath', {
+      subargs: ['--foo']
+    });
+
+    test.deepEqual(noOptions, ['/rootpath/relpath']);
+    test.deepEqual(noExtraArgs, ['/rootpath/relpath']);
+    test.deepEqual(emptyExtraArgs, ['/rootpath/relpath']);
+    test.deepEqual(extraArgs, ['/rootpath/relpath', '--foo']);
+    test.done();
+  },
+  py(test) {
+    test.expect(6);
+
+    let noOptions = commands.py.execute('/rootpath/', 'relpath');
+    let noExtraArgs = commands.py.execute('/rootpath/', 'relpath', {});
+    let noBinArgs = commands.py.execute('/rootpath/', 'relpath', {
+      subargs: []
+    });
+    let noSubArgs = commands.py.execute('/rootpath/', 'relpath', {
+      binopts: []
+    });
+    let emptyExtraArgs = commands.py.execute('/rootpath/', 'relpath', {
+      binopts: [],
+      subargs: []
+    });
+    let extraArgs = commands.py.execute('/rootpath/', 'relpath', {
+      binopts: ['-R'],
+      subargs: ['--foo']
+    });
+
+    test.deepEqual(noOptions, ['python', '/rootpath/relpath']);
+    test.deepEqual(noExtraArgs, ['python', '/rootpath/relpath']);
+    test.deepEqual(noBinArgs, ['python', '/rootpath/relpath']);
+    test.deepEqual(noSubArgs, ['python', '/rootpath/relpath']);
+    test.deepEqual(emptyExtraArgs, ['python', '/rootpath/relpath']);
+    test.deepEqual(extraArgs, ['python', '-R', '/rootpath/relpath', '--foo']);
+    test.done();
+  },
+};
+
+
+exports['commands.*'] = {
+
+  scanWiFi(test) {
+    test.expect(1);
+    test.deepEqual(commands.scanWiFi(), ['iwinfo', 'wlan0', 'scan']);
+    test.done();
+  },
+  getWifiInfo(test) {
+    test.expect(1);
+    test.deepEqual(commands.getWifiInfo(), ['ubus', 'call', 'iwinfo', 'info', '{"device":"wlan0"}']);
+    test.done();
+  },
+  getIPAddress(test) {
+    test.expect(1);
+    test.deepEqual(commands.getIPAddress(), ['ifconfig', 'wlan0']);
+    test.done();
+  },
+  connectedNetworkStatus(test) {
+    test.expect(1);
+    test.deepEqual(commands.connectedNetworkStatus(), ['ubus', 'call', 'network.interface.lan', 'status']);
+    test.done();
+  },
+  commitWirelessCredentials(test) {
+    test.expect(1);
+    test.deepEqual(commands.commitWirelessCredentials(), ['uci', 'commit', 'wireless']);
+    test.done();
+  },
+  reconnectWifi(test) {
+    test.expect(1);
+    test.deepEqual(commands.reconnectWifi(), ['wifi']);
+    test.done();
+  },
+  getHostname(test) {
+    test.expect(1);
+    test.deepEqual(commands.getHostname(), ['uci', 'get', 'system.@system[0].hostname']);
+    test.done();
+  },
+  commitHostname(test) {
+    test.expect(1);
+    test.deepEqual(commands.commitHostname(), ['uci', 'commit', 'system']);
+    test.done();
+  },
+  getMemoryInfo(test) {
+    test.expect(1);
+    test.deepEqual(commands.getMemoryInfo(), ['cat', '/proc/meminfo']);
+    test.done();
+  },
+  ubusListen(test) {
+    test.expect(1);
+    test.deepEqual(commands.ubusListen(), ['ubus', 'listen']);
+    test.done();
+  },
+  setLanNetwork(test) {
+    test.expect(1);
+    test.deepEqual(commands.setLanNetwork(), ['uci', 'set', 'network.lan=interface']);
+    test.done();
+  },
+  setLanNetworkIfname(test) {
+    test.expect(1);
+    test.deepEqual(commands.setLanNetworkIfname(), ['uci', 'set', 'network.lan.ifname=wlan0']);
+    test.done();
+  },
+  setLanNetworkProto(test) {
+    test.expect(1);
+    test.deepEqual(commands.setLanNetworkProto(), ['uci', 'set', 'network.lan.proto=static']);
+    test.done();
+  },
+  setLanNetworkIP(test) {
+    test.expect(1);
+    test.deepEqual(commands.setLanNetworkIP(), ['uci', 'set', 'network.lan.ipaddr=192.168.1.101']);
+    test.done();
+  },
+  setLanNetworkNetmask(test) {
+    test.expect(1);
+    test.deepEqual(commands.setLanNetworkNetmask(), ['uci', 'set', 'network.lan.netmask=255.255.255.0']);
+    test.done();
+  },
+  commitNetwork(test) {
+    test.expect(1);
+    test.deepEqual(commands.commitNetwork(), ['uci', 'commit', 'network']);
+    test.done();
+  },
+  getAccessPoint(test) {
+    test.expect(1);
+    test.deepEqual(commands.getAccessPoint(), ['uci', 'get', 'wireless.@wifi-iface[1]']);
+    test.done();
+  },
+  getAccessPointSSID(test) {
+    test.expect(1);
+    test.deepEqual(commands.getAccessPointSSID(), ['uci', 'get', 'wireless.@wifi-iface[1].ssid']);
+    test.done();
+  },
+  setAccessPoint(test) {
+    test.expect(1);
+    test.deepEqual(commands.setAccessPoint(), ['uci', 'add', 'wireless', 'wifi-iface']);
+    test.done();
+  },
+  setAccessPointDevice(test) {
+    test.expect(1);
+    test.deepEqual(commands.setAccessPointDevice(), ['uci', 'set', 'wireless.@wifi-iface[1].device=radio0']);
+    test.done();
+  },
+  setAccessPointNetwork(test) {
+    test.expect(1);
+    test.deepEqual(commands.setAccessPointNetwork(), ['uci', 'set', 'wireless.@wifi-iface[1].network=lan']);
+    test.done();
+  },
+  setAccessPointMode(test) {
+    test.expect(1);
+    test.deepEqual(commands.setAccessPointMode(), ['uci', 'set', 'wireless.@wifi-iface[1].mode=ap']);
+    test.done();
+  },
+  turnAccessPointOn(test) {
+    test.expect(1);
+    test.deepEqual(commands.turnAccessPointOn(), ['uci', 'set', 'wireless.@wifi-iface[1].disabled=0']);
+    test.done();
+  },
+  turnAccessPointOff(test) {
+    test.expect(1);
+    test.deepEqual(commands.turnAccessPointOff(), ['uci', 'set', 'wireless.@wifi-iface[1].disabled=1']);
+    test.done();
+  },
+  turnRadioOn(test) {
+    test.expect(1);
+    test.deepEqual(commands.turnRadioOn(), ['uci', 'set', 'wireless.radio0.disabled=0']);
+    test.done();
+  },
+  getAccessPointConfig(test) {
+    test.expect(1);
+    test.deepEqual(commands.getAccessPointConfig(), ['uci', 'show', 'wireless.@wifi-iface[1]']);
+    test.done();
+  },
+  getAccessPointIP(test) {
+    test.expect(1);
+    test.deepEqual(commands.getAccessPointIP(), ['uci', 'get', 'network.lan.ipaddr']);
+    test.done();
+  },
+  reconnectDnsmasq(test) {
+    test.expect(1);
+    test.deepEqual(commands.reconnectDnsmasq(), ['/etc/init.d/dnsmasq', 'restart']);
+    test.done();
+  },
+  reconnectDhcp(test) {
+    test.expect(1);
+    test.deepEqual(commands.reconnectDhcp(), ['/etc/init.d/odhcpd', 'restart']);
+    test.done();
+  },
+  reboot(test) {
+    test.expect(1);
+    test.deepEqual(commands.reboot(), ['sh', '-c', 'echo 39 > /sys/class/gpio/export && echo out > /sys/class/gpio/gpio39/direction && echo 0 > /sys/class/gpio/gpio39/value && reboot']);
+    test.done();
+  },
+  readFile(test) {
+    test.expect(1);
+    test.deepEqual(commands.readFile('filepath'), ['cat', 'filepath']);
+    test.done();
+  },
+  deleteFolder(test) {
+    test.expect(1);
+    test.deepEqual(commands.deleteFolder('filepath'), ['rm', '-rf', 'filepath']);
+    test.done();
+  },
+  createFolder(test) {
+    test.expect(1);
+    test.deepEqual(commands.createFolder('filepath'), ['mkdir', '-p', 'filepath']);
+    test.done();
+  },
+  moveFolder(test) {
+    test.expect(1);
+    test.deepEqual(commands.moveFolder('source', 'destination'), ['mv', 'source', 'destination']);
+    test.done();
+  },
+  untarStdin(test) {
+    test.expect(1);
+    test.deepEqual(commands.untarStdin('filepath'), ['tar', '-x', '-C', 'filepath']);
+    test.done();
+  },
+  openStdinToFile(test) {
+    test.expect(1);
+    test.deepEqual(commands.openStdinToFile('filepath'), ['dd', 'of=filepath']);
+    test.done();
+  },
+  appendStdinToFile(test) {
+    test.expect(1);
+    test.deepEqual(commands.appendStdinToFile('filepath'), ['tee', '-a', 'filepath']);
+    test.done();
+  },
+  chmod(test) {
+    test.expect(1);
+    test.deepEqual(commands.chmod('+x', 'filepath'), ['chmod', '+x', 'filepath']);
+    test.done();
+  },
+  setNetworkSSID(test) {
+    test.expect(1);
+    test.deepEqual(commands.setNetworkSSID('ssid'), ['uci', 'set', 'wireless.@wifi-iface[0].ssid=ssid']);
+    test.done();
+  },
+  setNetworkPassword(test) {
+    test.expect(1);
+    test.deepEqual(commands.setNetworkPassword('key'), ['uci', 'set', 'wireless.@wifi-iface[0].key=key']);
+    test.done();
+  },
+  setNetworkEncryption(test) {
+    test.expect(1);
+    test.deepEqual(commands.setNetworkEncryption('encryption'), ['uci', 'set', 'wireless.@wifi-iface[0].encryption=encryption']);
+    test.done();
+  },
+  turnOnWifi(test) {
+    test.expect(2);
+    test.deepEqual(commands.turnOnWifi(0), ['uci', 'set', 'wireless.@wifi-iface[0].disabled=1']);
+    test.deepEqual(commands.turnOnWifi(1), ['uci', 'set', 'wireless.@wifi-iface[0].disabled=0']);
+    test.done();
+  },
+  ensureFileExists(test) {
+    test.expect(1);
+    test.deepEqual(commands.ensureFileExists('filepath'), ['touch', 'filepath']);
+    test.done();
+  },
+  setHostname(test) {
+    test.expect(1);
+    test.deepEqual(commands.setHostname('hostname'), ['uci', 'set', 'system.@system[0].hostname=hostname']);
+    test.done();
+  },
+  getInterface(test) {
+    test.expect(1);
+    test.deepEqual(commands.getInterface('interfaceName'), ['ifconfig', 'interfaceName']);
+    test.done();
+  },
+  callMDNSDaemon(test) {
+    test.expect(1);
+    test.deepEqual(commands.callMDNSDaemon('action'), ['/etc/init.d/mdnsd', 'action']);
+    test.done();
+  },
+  callTesselMDNS(test) {
+    test.expect(1);
+    test.deepEqual(commands.callTesselMDNS('action'), ['/etc/init.d/tessel-mdns', 'action']);
+    test.done();
+  },
+  sysupgrade(test) {
+    test.expect(1);
+    test.deepEqual(commands.sysupgrade('path'), ['sysupgrade', 'path']);
+    test.done();
+  },
+  sysupgradeNoSaveConfig(test) {
+    test.deepEqual(commands.sysupgradeNoSaveConfig('path'), ['sysupgrade', '-n', 'path']);
+    test.done();
+  },
+  setAccessPointSSID(test) {
+    test.expect(1);
+    test.deepEqual(commands.setAccessPointSSID('ssid'), ['uci', 'set', 'wireless.@wifi-iface[1].ssid=ssid']);
+    test.done();
+  },
+  setAccessPointPassword(test) {
+    test.expect(1);
+    test.deepEqual(commands.setAccessPointPassword('password'), ['uci', 'set', 'wireless.@wifi-iface[1].key=password']);
+    test.done();
+  },
+  setAccessPointSecurity(test) {
+    test.expect(1);
+    test.deepEqual(commands.setAccessPointSecurity('security'), ['uci', 'set', 'wireless.@wifi-iface[1].encryption=security']);
+    test.done();
+  },
+};

--- a/test/unit/deploy.js
+++ b/test/unit/deploy.js
@@ -289,6 +289,7 @@ exports['Tessel.prototype.deploy'] = {
     deployTestCode(this.tessel, {
       push: true,
       single: false,
+      binopts: [],
       subargs: [],
     }, (error) => {
       if (error) {
@@ -519,18 +520,18 @@ exports['deploy.start'] = {
 
 
 exports['deploy.run'] = {
-  setUp: function(done) {
+  setUp(done) {
     this.info = sandbox.stub(log, 'info');
     this.tessel = TesselSimulator();
     done();
   },
-  tearDown: function(done) {
+  tearDown(done) {
     this.tessel.mockClose();
     sandbox.restore();
     done();
   },
 
-  runResolveEntryPoint: function(test) {
+  runResolveEntryPoint(test) {
     test.expect(1);
 
     var entryPoint = 'foo';
@@ -546,12 +547,13 @@ exports['deploy.run'] = {
       subargs: ['--key=value'],
     }).then(() => {
       test.deepEqual(
-        this.exec.lastCall.args[0], [deployment.js.meta.binary, Tessel.REMOTE_RUN_PATH + entryPoint, '--key=value']);
+        this.exec.lastCall.args[0], ['node', '/tmp/remote-script/foo', '--key=value']
+      );
       test.done();
     });
   },
 
-  runResolveEntryPointWithPreRun: function(test) {
+  runResolveEntryPointWithPreRun(test) {
     test.expect(2);
 
     var entryPoint = 'foo';
@@ -579,13 +581,12 @@ exports['deploy.run'] = {
     deploy.run(this.tessel, {
       entryPoint: entryPoint,
       lang: deployment.rs,
-      subargs: [],
     }).then(() => {
       test.done();
     });
   },
 
-  runPostRunExistsLAN: function(test) {
+  runPostRunExistsLAN(test) {
     test.expect(1);
 
     this.tessel.connection.connectionType = 'LAN';
@@ -599,14 +600,13 @@ exports['deploy.run'] = {
     deploy.run(this.tessel, {
       resolvedEntryPoint: 'foo',
       lang: deployment.js,
-      subargs: [],
     }).then(() => {
       test.equal(this.postRun.callCount, 1);
       test.done();
     });
   },
 
-  runPostRunExistsUSB: function(test) {
+  runPostRunExistsUSB(test) {
     test.expect(1);
 
     this.tessel.connection.connectionType = 'USB';
@@ -628,18 +628,18 @@ exports['deploy.run'] = {
 };
 
 exports['deploy.createShellScript'] = {
-  setUp: function(done) {
+  setUp(done) {
     this.info = sandbox.stub(log, 'info');
     this.tessel = TesselSimulator();
     done();
   },
-  tearDown: function(done) {
+  tearDown(done) {
     this.tessel.mockClose();
     sandbox.restore();
     done();
   },
 
-  remoteShellScriptPathIsNotPathNormalized: function(test) {
+  remoteShellScriptPathIsNotPathNormalized(test) {
     test.expect(2);
 
     this.exec = sandbox.stub(this.tessel.connection, 'exec', (command, callback) => {
@@ -650,6 +650,7 @@ exports['deploy.createShellScript'] = {
     var opts = {
       lang: deployment.js,
       resolvedEntryPoint: 'foo',
+      binopts: [],
       subargs: ['--key=value'],
     };
 
@@ -658,9 +659,8 @@ exports['deploy.createShellScript'] = {
       test.deepEqual(this.exec.lastCall.args[0], ['chmod', '+x', '/app/start']);
       test.done();
     });
-  }
+  },
 };
-
 
 exports['Tessel.REMOTE_*_PATH'] = {
   expectedPaths: function(test) {


### PR DESCRIPTION
Enables the following run/push capabilities: 

```
t2 run index.js --binopts="--any --options --supported" 
```

Which will be run on the device as: 

```
node --any --options --supported /path/to/index.js
```


And: 

```
t2 push index.js --binopts="--any --options --supported" 
```

Which will be create a shell script containing: 

```
#!/bin/sh
exec node --any --options --supported /path/to/index.js
```


This feature was requested by @huseyinkozan here: https://github.com/tessel/openwrt-tessel/pull/76#issuecomment-329253906


--------------------------


## Smoke Test

### t2 run

1. Create a new project directory and cd into it
2. Run `t2 init`
3. Run `echo "console.log(typeof gc);" > index.js`
4. Run `t2 run index.js --binopts="--expose_gc"`
5. You should expect to see: 
```
INFO Looking for your Tessel...
INFO Connected to sumobot.
INFO Building project.
INFO Writing project to RAM on sumobot (3.072 kB)...
INFO Deployed.
INFO Running index.js...
function
```


### t2 push

This is more involved...

1. Create a new project directory and cd into it
2. Run `t2 init`
3. Open `index.js` and paste the following program: 
```js
const tessel = require('tessel');

if (typeof gc === 'function') {
  // Turn one of the LEDs on to start.
  tessel.led[2].on();

  // Blink!
  setInterval(() => {
    tessel.led[2].toggle();
    tessel.led[3].toggle();
  }, 100);
}
```
4. Run `t2 push index.js --binopts="--expose_gc"`
5. You should expect to see: 
```
INFO Looking for your Tessel...
INFO Connected to sumobot.
INFO Building project.
INFO Writing project to Flash on sumobot (3.072 kB)...
INFO Deployed.
INFO Your Tessel may now be untethered.
INFO The application will run whenever Tessel boots up.
INFO      To remove this application, use "t2 erase".
INFO Running index.js...
```
And the Tessel 2 itself should behave as seen here: https://www.youtube.com/watch?v=2OZYQVZPBmc
