### PR TITLE
Add module "base64id" to compression blacklist. Fixes gh-1345

### DIFF
--- a/lib/tessel/deployment/lists/javascript.js
+++ b/lib/tessel/deployment/lists/javascript.js
@@ -55,5 +55,6 @@ module.exports = {
   },
   compressionBlacklist: {
     bindings: true,
+    base64id: true,
   },
 };


### PR DESCRIPTION
## Smoke Test

1. Create a new project directory and cd into it
2. Run `t2 init`
3. Run `npm install base64id`
3. Run `echo "console.log(require('base64id').getRandomBytes());" > index.js`
4. Run `t2 run index.js`
5. You should expect to see: 
```
INFO Looking for your Tessel...
INFO Connected to sumobot.
INFO Building project.
INFO Writing project to RAM on sumobot (3.072 kB)...
INFO Deployed.
INFO Running index.js...
<Buffer ec 96 4b ce 52 58 6f 0e ff d1 ac 6a>
```

(Not exactly, because you'll have different bytes)