### PR TITLE
Upgrade uglify-es

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "tar": "^2.1.1",
     "tar-fs": "^1.13.2",
     "tar-stream": "^1.3.0",
-    "uglify-es": "3.1.3",
+    "uglify-es": "3.2.0",
     "uglify-js": "3.1.3",
     "unbzip2-stream": "^1.0.10",
     "update-notifier": "^1.0.2",

--- a/test/unit/deployment/javascript.js
+++ b/test/unit/deployment/javascript.js
@@ -1279,7 +1279,7 @@ exports['deployment.js.tarBundle'] = {
 
       const minified = this.compress.lastCall.returnValue;
 
-      test.equal(minified, 'const e=require("tessel"),{2:o,3:l}=e.led;o.on(),setInterval(()=>{o.toggle(),l.toggle()},100),console.log(`I\'m blinking! (Press CTRL + C to stop)`);');
+      test.equal(minified, 'const e=require("tessel"),{2:o,3:l}=e.led;o.on(),setInterval(()=>{o.toggle(),l.toggle()},100),console.log("I\'m blinking! (Press CTRL + C to stop)");');
 
       // Extract and inspect the bundle...
       extract(bundle, (error, entries) => {


### PR DESCRIPTION
I'm running into a bunch of issues when trying to run my app on the tessel. After a bunch of digging, I found out that my code was being run through uglify-es. 

Unfortunately, the version that is bundled with the t2-cli does weird things to my code. For instance:
```js
const contentLength = response.headers['content-length'];
const length = contentLength && Number(contentLength);
```

turns into

```js
var u = (t.headers["content-length"], contentLength && +contentLength);
```

...which results in `ReferenceError: contentLength is not defined`

I upgraded `uglify-es` to the latest version, and all the build problems went away.

I could of course pass `--compress=false`  on every build, but as a library author, it would be nice not having to ask the users to do so.
