### PR TITLE
package.json: lock in version of usb module until we know why it's messing with the logging.

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "unbzip2-stream": "^1.0.10",
     "update-notifier": "^1.0.2",
     "url-join": "0.0.1",
-    "usb": "^1.2.0",
+    "usb": "1.2.0",
     "usb-daemon-parser": "0.0.2"
   },
   "preferGlobal": true,


### PR DESCRIPTION
https://github.com/tessel/t2-cli/issues/1411#issuecomment-368668070