### PR TITLE
Controller: refuse to rename in controller (moves test to controller)

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -631,6 +631,10 @@ controller.rename = function(options) {
     })
     .then(() => {
       return controller.standardTesselCommand(options, (tessel) => {
+        if (options.newName === tessel.name) {
+          log.warn(`Name of device is already ${tessel.displayName}`);
+          return Promise.resolve();
+        }
         log.info(`Renaming ${tessel.displayName} to ${colors.magenta(options.newName)}`);
         return tessel.rename(options);
       });

--- a/lib/tessel/name.js
+++ b/lib/tessel/name.js
@@ -2,7 +2,7 @@
 // ...
 
 // Third Party Dependencies
-// ...
+const colors = require('colors');
 
 // Internal
 var commands = require('./commands');
@@ -63,13 +63,13 @@ Tessel.prototype.setName = function(name) {
   });
 };
 
-Tessel.prototype.rename = function(opts) {
+Tessel.prototype.rename = function(options) {
   return new Promise((resolve, reject) => {
 
     // If we are resetting this name to default
-    if (opts.reset) {
+    if (options.reset) {
       // Get the mac address from the device
-      return this._getMACAddress()
+      return this.getMACAddress()
         .then((addr) => {
 
           // Create the name with the default prefix
@@ -77,38 +77,30 @@ Tessel.prototype.rename = function(opts) {
 
           // Set the new name
           return this.setName(defaultName)
-            .then(function() {
-              log.info('Reset the name of the device to', defaultName);
+            .then(() => {
+              log.info(`Reset the name of the device to ${defaultName}`);
               resolve();
             });
         });
     } else {
 
-      if (!Tessel.isValidName(opts.newName)) {
+      if (!Tessel.isValidName(options.newName)) {
         return reject('Invalid name');
       }
 
       this.getName()
-        .then((oldName) => {
-          // Don't set the new name if it's the same as the old name
-          if (oldName === opts.newName) {
-            log.warn('Name of device is already', oldName);
-            // Finish the process
-            return resolve();
-          } else {
-            // Set the name with the provided arg
-            return this.setName(opts.newName)
-              .then(function() {
-                log.info('Changed name of device', oldName, 'to', opts.newName);
-                resolve();
-              });
-          }
+        .then(oldName => {
+          return this.setName(options.newName)
+            .then(() => {
+              log.info(`Changed name of device ${colors.magenta(oldName)} to ${colors.magenta(options.newName)}`);
+              resolve();
+            });
         });
     }
   });
 };
 
-Tessel.prototype._getMACAddress = function() {
+Tessel.prototype.getMACAddress = function() {
   return this.simpleExec(commands.getInterface('eth0'))
     .then(function fetchedInterface(interfaceInfo) {
       // Capture the mac address out of the info using a regexp

--- a/test/unit/controller.js
+++ b/test/unit/controller.js
@@ -2442,6 +2442,23 @@ exports['controller.rename'] = {
     done();
   },
 
+  willNotRenameSameAsCurrent(test) {
+    test.expect(2);
+
+    var options = {
+      newName: this.tessel.name,
+    };
+
+    controller.rename(options)
+      .then(() => {
+        // Assert that a warning was logged when
+        // the new name is the same as the old name
+        test.equal(this.warn.callCount, 1);
+        test.equal(this.warn.lastCall.args[0], 'Name of device is already TestTessel');
+        test.done();
+      });
+  },
+
   renameCallPipeline(test) {
     test.expect(4);
 

--- a/test/unit/name.js
+++ b/test/unit/name.js
@@ -8,7 +8,7 @@ exports['Tessel.prototype.rename'] = {
     this.getName = this.sandbox.stub(Tessel.prototype, 'getName').callsFake(() => {
       return Promise.resolve('TheFakeName');
     });
-    this._getMACAddress = this.sandbox.stub(Tessel.prototype, '_getMACAddress').callsFake(() => {
+    this.getMACAddress = this.sandbox.stub(Tessel.prototype, 'getMACAddress').callsFake(() => {
       return Promise.resolve('TheFakeMACAddress');
     });
     this.resetMDNS = this.sandbox.stub(Tessel.prototype, 'resetMDNS').callsFake(() => {
@@ -92,7 +92,7 @@ exports['Tessel.prototype.rename'] = {
         // - the mac address is requested
         // - setName is called
         // - the connection executes the setHostName command
-        test.equal(this._getMACAddress.callCount, 1);
+        test.equal(this.getMACAddress.callCount, 1);
         test.equal(this.setName.callCount, 1);
         test.equal(this.setHostname.callCount, 1);
         test.equal(this.commitHostname.callCount, 1);
@@ -125,20 +125,6 @@ exports['Tessel.prototype.rename'] = {
         test.equal(this.openStdinToFile.callCount, 1);
         test.ok(this.setHostname.lastCall.calledWith('ValidAndUnique'));
 
-        test.done();
-      });
-  },
-
-  validRenameSameAsCurrent(test) {
-    test.expect(1);
-
-    this.tessel.rename({
-        newName: 'TheFakeName'
-      })
-      .then(() => {
-        // When renamed with same current name:
-        // - warning is logged
-        test.equal(this.logWarn.callCount, 1);
         test.done();
       });
   },


### PR DESCRIPTION
- The makes "Tessel.prototype.rename" simpler in that it's only responsible for the actual rename operation now.
- No reason to pretend that "getMACAddress" is private, or even that it needs to be.