### PR TITLE
JS deployment: add bindings to compressionBlacklist

### DIFF
--- a/lib/tessel/deployment/lists/javascript.js
+++ b/lib/tessel/deployment/lists/javascript.js
@@ -54,6 +54,7 @@ module.exports = {
     },
   },
   compressionBlacklist: {
+    bindings: true,
     // Placeholder
   },
 


### PR DESCRIPTION
Fixes: https://github.com/rwaldron/tessel-io/issues/19

When using `node-serialport` in a project and running my code (`t2 run index.js`), I would encounter the following error:

```
INFO Looking for your Tessel...
INFO Connected to InGen.
INFO Building project.
INFO Writing project to RAM on InGen (784.896 kB)...
INFO Deployed.
INFO Running barcodescanner.js...
path.js:7
    throw new TypeError('Path must be a string. Received ' + inspect(path));
    ^

TypeError: Path must be a string. Received undefined
    at assertPath (path.js:7:11)
    at dirname (path.js:1324:5)
    at Function.exports.getRoot.r [as getRoot] (/tmp/remote-script/node_modules/bindings/bindings.js:1:1659)
    at exports (/tmp/remote-script/node_modules/bindings/bindings.js:1:879)
    at Object.<anonymous> (/tmp/remote-script/node_modules/serialport/lib/bindings/linux.js:1:103)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
```

Looking through the stack trace, I found the source of the issue in the `bindings` package, as used by `node-serialport` to use their native binary dependency. When running my code with `t2 run index.js --compress=false`, then everything worked as expected. 

This PR adds `bindings` to the `compressionBlacklist` so people can use `node-serialport` in projects without using the `--compress=false` flag. 