### PR TITLE
Automatically rebuild node-usb drivers after version mismatch error

### DIFF
--- a/lib/usb-connection.js
+++ b/lib/usb-connection.js
@@ -2,6 +2,7 @@
 var util = require('util');
 var stream = require('stream');
 var events = require('events');
+const { execSync } = require('child_process');
 
 var Duplex = stream.Duplex;
 var Emitter = events.EventEmitter;
@@ -34,12 +35,11 @@ try {
   if (!global.IS_TEST_ENV) {
     log.error('Node version mismatch for USB drivers.');
     log.info(tags.stripIndent `
-      To correct this issue, please run the following command:
+      Automatically rebuilding USB drivers for t2-cli to correct this issue. Please try running your command again.
 
-        npm rebuild --update-binary usb
-
-      This will rebuild the USB drivers for your version of Node.js
+      If the error persists, please file an issue at https://github.com/tessel/t2-cli/issues/new with this warning.
     `);
+    execSync(`cd ${__dirname} && npm rebuild --update-binary usb`);
     process.exit(1);
   }
 }

--- a/lib/usb-connection.js
+++ b/lib/usb-connection.js
@@ -32,6 +32,7 @@ try {
   isUSBAvailable = false;
 
   // do not exit the process during tests because usb is not needed to run them
+  /* istanbul ignore next */
   if (!global.IS_TEST_ENV) {
     log.error('Node version mismatch for USB drivers.');
     log.info(tags.stripIndent `


### PR DESCRIPTION
Fixes: https://github.com/tessel/t2-cli/issues/1411

Preview:

```
hipsterbrown:tessel-serialport $ ../t2-cli/bin/tessel-2.js list
ERR! Node version mismatch for USB drivers.
INFO Automatically rebuilding USB drivers for t2-cli to correct this issue. Please try running your command again.
INFO
INFO If the error persists, please file an issue at https://github.com/tessel/t2-cli/issues/new with this warning.
hipsterbrown:tessel-serialport $ ../t2-cli/bin/tessel-2.js list
INFO Searching for nearby Tessels...
 	USB	ava
hipsterbrown:tessel-serialport $
```