### PR TITLE
Buffer: migrate new Buffer() to Buffer.alloc, Buffer.from, etc.

### DIFF
--- a/lib/dfu.js
+++ b/lib/dfu.js
@@ -123,7 +123,7 @@ DFU.prototype.dnload = function(data, callback, statuscb) {
             statuscb(data.length, data.length);
           }
 
-          this.dnloadChunk(seq, new Buffer(0), (error) => {
+          this.dnloadChunk(seq, Buffer.alloc(0), (error) => {
             if (error) {
               return callback(error);
             }

--- a/lib/tessel/deploy.js
+++ b/lib/tessel/deploy.js
@@ -463,7 +463,7 @@ exportables.createShellScript = function(tessel, opts) {
         });
       });
 
-      remoteProcess.stdin.end(new Buffer(opts.lang.meta.shell(opts).trim()));
+      remoteProcess.stdin.end(Buffer.from(opts.lang.meta.shell(opts).trim()));
     });
   });
 };

--- a/lib/tessel/deployment/rust.js
+++ b/lib/tessel/deployment/rust.js
@@ -170,7 +170,7 @@ exportables.remoteRustCompilation = (opts) => {
             // If the binary was provided
             else {
               // All was successful and we can return
-              return resolve(new Buffer(result.binary, 'base64'));
+              return resolve(Buffer.from(result.binary, 'base64'));
             }
           });
       });

--- a/lib/tessel/erase.js
+++ b/lib/tessel/erase.js
@@ -12,9 +12,7 @@ var Tessel = require('./tessel');
 Tessel.prototype.eraseScript = function() {
   log.info('Erasing files from Flash...');
   return this.simpleExec(commands.app.stop())
-    .then(() => {
-      return this.simpleExec(commands.app.disable());
-    })
+    .then(() => this.simpleExec(commands.app.disable()))
     .then(() => {
       return this.simpleExec(commands.deleteFolder(Tessel.REMOTE_APP_PATH))
         .then(function erased() {
@@ -28,7 +26,7 @@ Tessel.prototype.eraseScript = function() {
         return Promise.reject('No files have been pushed. Run `t2 push FILE` to push to Flash.');
       } else {
         // Otherwise this is an unexpected error
-        return Promise.reject('An unexpected error occurred:' + error.message);
+        return Promise.reject(`An unexpected error occurred:${error.message}`);
       }
     });
 };

--- a/lib/tessel/restore.js
+++ b/lib/tessel/restore.js
@@ -76,25 +76,22 @@ function address(addr) {
   return [(addr >> 24) & 0xFF, (addr >> 16) & 0xFF, (addr >> 8) & 0xFF, addr & 0xFF];
 }
 
-function toBuffer() {
-  return Buffer.concat(Array.from(arguments).map(
-    (arg) => Array.isArray(arg) ? new Buffer(arg) : arg
-  ));
-}
-
 function randUint8() {
   return Math.round(Math.random() * 255);
 }
 
 // Generate a mediatek factory partition
 // TODO: Find reference
+const PARTITION_HEAD = Buffer.from([0x20, 0x76, 0x03, 0x01]);
+const PARTITION_BODY = Buffer.allocUnsafe(30).fill(0xFF);
+
 exportables.partition = function(mac1, mac2) {
-  return toBuffer(
-    [0x20, 0x76, 0x03, 0x01],
-    mac1,
-    Array(30).fill(0xFF),
-    mac2
-  );
+  return Buffer.concat([
+    PARTITION_HEAD,
+    Buffer.from(mac1),
+    PARTITION_BODY,
+    Buffer.from(mac2)
+  ]);
 };
 
 exportables.transaction = function(usb, bytesOrCommand, readLength, statusPoll, writeEnable) {
@@ -112,7 +109,7 @@ exportables.transaction = function(usb, bytesOrCommand, readLength, statusPoll, 
 
   var flags = Number(statusPoll) | (Number(writeEnable) << 1);
   var hdr = [(readLength >> 0) & 0xFF, (readLength >> 8) & 0xFF, (readLength >> 16) & 0xFF, flags];
-  var data = toBuffer(hdr, bytesOrCommand);
+  var data = Buffer.from([...hdr, ...bytesOrCommand]);
 
   return new Promise((resolve, reject) => {
     usb.epOut.transfer(data, (error) => {
@@ -218,7 +215,7 @@ exportables.write = function(usb, offset, buffer) {
 
 // Write a 256 Byte Page to Flash
 exportables.writePage = function(usb, start, page) {
-  var buffer = toBuffer([0x12], address(start), page);
+  var buffer = Buffer.concat([Buffer.from([0x12, ...address(start)]), page]);
   return exportables.transaction(usb, buffer, 0, true, true);
 };
 
@@ -258,7 +255,7 @@ exportables.flash = function(tessel, buffers) {
         // LIBUSB_RECIPIENT_DEVICE = 0x00
         // LIBUSB_ENDPOINT_OUT = 0x00
         // VENDOR_REQ_OUT = (LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_DEVICE | LIBUSB_ENDPOINT_OUT)
-        usb.device.controlTransfer(0x40, REQ_RESET, 0, 0, new Buffer(0));
+        usb.device.controlTransfer(0x40, REQ_RESET, 0, 0, Buffer.alloc(0));
         return resolve();
       }).catch(reject);
   });

--- a/lib/tessel/tessel.js
+++ b/lib/tessel/tessel.js
@@ -91,7 +91,7 @@ Object.defineProperties(Tessel.prototype, {
 
 Tessel.prototype.receive = function(remote, callback) {
   var error = '';
-  var received = new Buffer(0);
+  var received = Buffer.alloc(0);
 
   remote.stderr.on('data', function(buffer) {
     error += buffer.toString();

--- a/lib/update-fetch.js
+++ b/lib/update-fetch.js
@@ -72,8 +72,8 @@ exportables.requestBuildList = function() {
 };
 
 exportables.loadLocalBinaries = function(options) {
-  var openwrtUpdateLoad = Promise.resolve(new Buffer(0));
-  var firmwareUpdateLoad = Promise.resolve(new Buffer(0));
+  var openwrtUpdateLoad = Promise.resolve(Buffer.alloc(0));
+  var firmwareUpdateLoad = Promise.resolve(Buffer.alloc(0));
 
   if (options['openwrt-path']) {
     openwrtUpdateLoad = exportables.loadLocalBinary(options['openwrt-path']);

--- a/lib/usb-connection.js
+++ b/lib/usb-connection.js
@@ -2,7 +2,9 @@
 var util = require('util');
 var stream = require('stream');
 var events = require('events');
-const { execSync } = require('child_process');
+const {
+  execSync
+} = require('child_process');
 
 var Duplex = stream.Duplex;
 var Emitter = events.EventEmitter;
@@ -285,7 +287,7 @@ USB.Connection.prototype.enterBootloader = function() {
     .then(() => {
       // Tell the mcu to go into bootloader mode
       return new Promise((resolve, reject) => {
-        this.device.controlTransfer(VENDOR_REQ_OUT, REQ_BOOT, 0, 0, new Buffer(0), function(err) {
+        this.device.controlTransfer(VENDOR_REQ_OUT, REQ_BOOT, 0, 0, Buffer.alloc(0), function(err) {
           if (err) {
             reject(err);
           } else {

--- a/lib/usb/usb-process.js
+++ b/lib/usb/usb-process.js
@@ -317,7 +317,7 @@ RemoteReadableStream.prototype.ack = function(numToAck) {
   // Add the number to the credit count
   this.credit += numToAck;
   // Allocate a buffer for the data
-  var ackAmountBuf = new Buffer(4);
+  var ackAmountBuf = Buffer.alloc(4);
   // Write the number as an unsigned 32 but int into the buffer
   ackAmountBuf.writeUInt32LE(numToAck, 0);
   // Create a header for this ack

--- a/test/common/bootstrap.js
+++ b/test/common/bootstrap.js
@@ -112,7 +112,7 @@ util.inherits(global.Request, global.Stream);
 global.DEPLOY_DIR_JS = path.join(process.cwd(), 'test/unit/', 'tmp');
 global.DEPLOY_FILE_JS = path.join(global.DEPLOY_DIR_JS, 'app.js');
 global.jsCodeContents = 'console.log("testing deploy");';
-global.jsCodeReference = new Buffer(global.jsCodeContents);
+global.jsCodeReference = Buffer.from(global.jsCodeContents);
 
 global.DEPLOY_DIR_RS = path.join(process.cwd(), 'test/unit/fixtures', 'rust-deploy-template');
 

--- a/test/unit/access-point.js
+++ b/test/unit/access-point.js
@@ -68,7 +68,7 @@ exports['Tessel.prototype.createAccessPoint'] = {
         count++;
         return callback(new Error('uci: Entry not found'));
       } else {
-        return callback(null, new Buffer(0));
+        return callback(null, Buffer.alloc(0));
       }
     });
 
@@ -239,7 +239,7 @@ exports['Tessel.prototype.enableAccessPoint'] = {
 
     this.tessel._rps.on('control', (command) => {
       if (command.toString() === 'uci show wireless.@wifi-iface[1]') {
-        var info = new Buffer(tags.stripIndent `
+        var info = Buffer.from(tags.stripIndent `
           wireless.cfg053579.ssid='${results.ssid}'
           wireless.cfg053579.key='${results.key}'
           wireless.cfg053579.encryption='${results.encryption}'
@@ -250,7 +250,7 @@ exports['Tessel.prototype.enableAccessPoint'] = {
           this.tessel._rps.emit('close');
         });
       } else if (command.toString() === 'uci get network.lan.ipaddr') {
-        var ipInfo = new Buffer(`${results.ip}\n`);
+        var ipInfo = Buffer.from(`${results.ip}\n`);
 
         setImmediate(() => {
           this.tessel._rps.stdout.emit('data', ipInfo);
@@ -290,7 +290,7 @@ exports['Tessel.prototype.enableAccessPoint'] = {
     // Test is expecting two closes...;
     this.tessel._rps.on('control', (command) => {
       if (command.toString() === 'uci show wireless.@wifi-iface[1]') {
-        var info = new Buffer(tags.stripIndent `
+        var info = Buffer.from(tags.stripIndent `
           wireless.cfg053579.key='${results.key}'
           wireless.cfg053579.encryption='${results.encryption}'
           wireless.cfg053579.disabled='1'`);
@@ -300,7 +300,7 @@ exports['Tessel.prototype.enableAccessPoint'] = {
           this.tessel._rps.emit('close');
         });
       } else if (command.toString() === 'uci get network.lan.ipaddr') {
-        var ipInfo = new Buffer(`${results.ip}\n`);
+        var ipInfo = Buffer.from(`${results.ip}\n`);
 
         setImmediate(() => {
           this.tessel._rps.stdout.emit('data', ipInfo);
@@ -402,7 +402,7 @@ exports['Tessel.prototype.getAccessPointInfo'] = {
     // Test is expecting two closes...;
     this.tessel._rps.on('control', (command) => {
       if (command.toString() === 'uci show wireless.@wifi-iface[1]') {
-        var info = new Buffer(tags.stripIndent `
+        var info = Buffer.from(tags.stripIndent `
           wireless.cfg053579.ssid='${results.ssid}'
           wireless.cfg053579.key='${results.key}'
           wireless.cfg053579.encryption='${results.encryption}'
@@ -413,7 +413,7 @@ exports['Tessel.prototype.getAccessPointInfo'] = {
           this.tessel._rps.emit('close');
         });
       } else if (command.toString() === 'uci get network.lan.ipaddr') {
-        var ipInfo = new Buffer(`${results.ip}\n`);
+        var ipInfo = Buffer.from(`${results.ip}\n`);
 
         setImmediate(() => {
           this.tessel._rps.stdout.emit('data', ipInfo);
@@ -428,13 +428,13 @@ exports['Tessel.prototype.getAccessPointInfo'] = {
     });
 
     this.tessel.getAccessPointInfo()
-      .then((info) => {
+      .then(info => {
         test.equal(this.getAccessPointConfig.callCount, 1);
         test.equal(this.getAccessPointIP.callCount, 1);
         test.deepEqual(info, results);
         test.done();
       })
-      .catch(function(error) {
+      .catch(error => {
         test.fail(error);
         test.done();
       });
@@ -453,14 +453,14 @@ exports['Tessel.prototype.getAccessPointInfo'] = {
     // Test is expecting two closes...;
     this.tessel._rps.on('control', (command) => {
       if (command.toString() === 'uci show wireless.@wifi-iface[1]') {
-        var info = new Buffer(`wireless.cfg053579.disabled='1'`);
+        var info = Buffer.from(`wireless.cfg053579.disabled='1'`);
 
         setImmediate(() => {
           this.tessel._rps.stdout.emit('data', info);
           this.tessel._rps.emit('close');
         });
       } else if (command.toString() === 'uci get network.lan.ipaddr') {
-        var ipInfo = new Buffer(`${results.ip}\n`);
+        var ipInfo = Buffer.from(`${results.ip}\n`);
 
         setImmediate(() => {
           this.tessel._rps.stdout.emit('data', ipInfo);
@@ -475,13 +475,13 @@ exports['Tessel.prototype.getAccessPointInfo'] = {
     });
 
     this.tessel.getAccessPointInfo()
-      .then((info) => {
+      .then(info => {
         test.equal(this.getAccessPointConfig.callCount, 1);
         test.equal(this.getAccessPointIP.callCount, 1);
         test.deepEqual(info, results);
         test.done();
       })
-      .catch(function(error) {
+      .catch(error => {
         test.fail(error);
         test.done();
       });

--- a/test/unit/cargo-tessel.js
+++ b/test/unit/cargo-tessel.js
@@ -20,7 +20,7 @@ exports['Cargo Subcommand (cargo tessel ...)'] = {
   build(test) {
     test.expect(4);
 
-    var tarball = new Buffer([0x00]);
+    var tarball = Buffer.from([0x00]);
     var bresolve = Promise.resolve(tarball);
 
     // Prevent the tarball from being logged

--- a/test/unit/constructor.js
+++ b/test/unit/constructor.js
@@ -87,7 +87,7 @@ exports['Tessel.prototype.receive'] = {
       test.done();
     });
 
-    this.rps.stderr.emit('data', new Buffer('Some Error'));
+    this.rps.stderr.emit('data', Buffer.from('Some Error'));
     this.rps.emit('close');
   },
 
@@ -99,7 +99,7 @@ exports['Tessel.prototype.receive'] = {
       test.done();
     });
 
-    this.rps.stdout.emit('data', new Buffer('Some Data'));
+    this.rps.stdout.emit('data', Buffer.from('Some Data'));
     this.rps.emit('close');
   },
 };
@@ -151,7 +151,7 @@ exports['Tessel.prototype.simpleExec'] = {
     });
 
     setImmediate(() => {
-      this.rps.stderr.emit('data', new Buffer('Some Error'));
+      this.rps.stderr.emit('data', Buffer.from('Some Error'));
       this.rps.emit('close');
     });
   },
@@ -167,7 +167,7 @@ exports['Tessel.prototype.simpleExec'] = {
     });
 
     setImmediate(() => {
-      this.rps.stdout.emit('data', new Buffer('Some Data'));
+      this.rps.stdout.emit('data', Buffer.from('Some Data'));
       this.rps.emit('close');
     });
   },

--- a/test/unit/deploy.js
+++ b/test/unit/deploy.js
@@ -477,7 +477,7 @@ exports['Tessel.prototype.restart'] = {
       });
 
     setImmediate(() => {
-      this.tessel._rps.stderr.emit('data', new Buffer('No such file or directory'));
+      this.tessel._rps.stderr.emit('data', Buffer.from('No such file or directory'));
       this.tessel._rps.emit('close');
     });
   },

--- a/test/unit/deployment/javascript.js
+++ b/test/unit/deployment/javascript.js
@@ -8,7 +8,7 @@ process.on('uncaughtException', function(err) {
 });
 
 var codeContents = 'console.log("testing deploy");';
-var reference = new Buffer(codeContents);
+var reference = Buffer.from(codeContents);
 var lists = deployment.js.lists;
 var listRuleLength = lists.includes.length + lists.ignores.length + lists.disallowed.length;
 var sandbox = sinon.sandbox.create();
@@ -446,7 +446,7 @@ exports['deployment.js.compress with uglify.es.minify()'] = {
 
   minifyFromBuffer(test) {
     test.expect(1);
-    test.equal(deployment.js.compress('es', new Buffer(codeContents)), codeContents);
+    test.equal(deployment.js.compress('es', Buffer.from(codeContents)), codeContents);
     test.done();
   },
 
@@ -658,7 +658,7 @@ exports['deployment.js.compress with uglify.js.minify()'] = {
 
   minifyFromBuffer(test) {
     test.expect(1);
-    test.equal(deployment.js.compress('js', new Buffer(codeContents)), codeContents);
+    test.equal(deployment.js.compress('js', Buffer.from(codeContents)), codeContents);
     test.done();
   },
 
@@ -2409,7 +2409,7 @@ exports['deployment.js.preBundle'] = {
       entryPoint: ''
     }));
     this.resolveBinaryModules = sandbox.stub(deployment.js, 'resolveBinaryModules').returns(Promise.resolve());
-    this.tarBundle = sandbox.stub(deployment.js, 'tarBundle').returns(Promise.resolve(new Buffer([0x00])));
+    this.tarBundle = sandbox.stub(deployment.js, 'tarBundle').returns(Promise.resolve(Buffer.from([0x00])));
     this.pathResolve = sandbox.stub(path, 'resolve');
 
 
@@ -2805,7 +2805,7 @@ exports['deployment.js.resolveBinaryModules'] = {
     this.spawnSync = sandbox.stub(cp, 'spawnSync').callsFake(() => {
       return {
         output: [
-          null, new Buffer('{"targets": [{"target_name": "missing","sources": ["capture.c", "missing.cc"]}]}', 'utf8')
+          null, Buffer.from('{"targets": [{"target_name": "missing","sources": ["capture.c", "missing.cc"]}]}', 'utf8')
         ]
       };
     });

--- a/test/unit/deployment/rust.js
+++ b/test/unit/deployment/rust.js
@@ -43,7 +43,7 @@ exports['deploy.rust'] = {
       error: undefined,
       stderr: '',
       stdout: 'Compilation was wildly successful',
-      binary: new Buffer('compiled binary', 'base64'),
+      binary: Buffer.from('compiled binary', 'base64'),
     });
 
     // Buffer to store incoming chunks of the tarred project directory
@@ -178,7 +178,7 @@ exports['deploy.rust'] = {
 
       handler(emitter);
 
-      emitter.emit('data', new Buffer('{'));
+      emitter.emit('data', Buffer.from('{'));
       emitter.emit('end');
 
       var duplex = stream.Duplex();
@@ -223,7 +223,7 @@ exports['deploy.rust'] = {
 
       handler(emitter);
 
-      emitter.emit('data', new Buffer('{}'));
+      emitter.emit('data', Buffer.from('{}'));
       emitter.emit('error', 'DEAD!');
 
       var duplex = stream.Duplex();
@@ -312,7 +312,7 @@ exports['deploy.rust'] = {
     var result = JSON.stringify({
       stderr: stderr,
       stdout: '',
-      binary: new Buffer(0),
+      binary: Buffer.alloc(0),
     });
 
     // When we get a write to the post request
@@ -401,7 +401,7 @@ exports['deploy.rust'] = {
   rustTarBundleRemote(test) {
     test.expect(4);
 
-    this.remoteRustCompilation = sandbox.stub(deployment.rs, 'remoteRustCompilation').callsFake(() => Promise.resolve(new Buffer([])));
+    this.remoteRustCompilation = sandbox.stub(deployment.rs, 'remoteRustCompilation').callsFake(() => Promise.resolve(Buffer.from([])));
 
     this.runBuild = sandbox.stub(rust, 'runBuild').callsFake(() => Promise.resolve(null));
 

--- a/test/unit/erase.js
+++ b/test/unit/erase.js
@@ -69,13 +69,40 @@ exports['Tessel.prototype.erase'] = {
       })
       // If it fails (as it should)
       .catch((err) => {
-        test.ok(err);
+        test.ok(err.includes('No files have been pushed'));
         // Pass the test
         test.done();
       });
 
     // Write the error message we get when there is no code in flash
     this.tessel._rps.stderr.push('Command failed: Not found');
+
+    // End the process once the error has time to propogate
+    setImmediate(() => {
+      this.tessel._rps.emit('close');
+    });
+  },
+
+  unexpectedError(test) {
+    test.expect(1);
+
+    // Attempt to erase the script
+    this.tessel.eraseScript()
+      // If it completes without issue
+      .then(() => {
+        // Fail the test
+        test.ok(false, 'Error should have been returned on useless flash erase');
+        test.done();
+      })
+      // If it fails (as it should)
+      .catch((err) => {
+        test.ok(err.includes('An unexpected error occurred'));
+        // Pass the test
+        test.done();
+      });
+
+    // Write the error message we get when there is no code in flash
+    this.tessel._rps.stderr.push('Unexpected');
 
     // End the process once the error has time to propogate
     setImmediate(() => {

--- a/test/unit/restore.js
+++ b/test/unit/restore.js
@@ -9,8 +9,8 @@ exports['Tessel.prototype.restore'] = {
     this.warn = this.sandbox.stub(log, 'warn');
     this.info = this.sandbox.stub(log, 'info');
     this.images = {
-      uboot: new Buffer('uboot'),
-      squashfs: new Buffer('squashfs'),
+      uboot: Buffer.from('uboot'),
+      squashfs: Buffer.from('squashfs'),
     };
     this.status = this.sandbox.stub(restore, 'status').callsFake(() => Promise.resolve(0));
     this.fetchRestore = this.sandbox.stub(updates, 'fetchRestore').callsFake(() => {
@@ -68,7 +68,7 @@ exports['Tessel.prototype.restore'] = {
     this.flash = this.sandbox.stub(restore, 'flash').callsFake(() => Promise.resolve());
     this.transaction = this.sandbox.stub(restore, 'transaction').callsFake((usb, bytesOrCommand) => {
       if (bytesOrCommand === 0x9F) {
-        return Promise.resolve(new Buffer([0x01, 0x02, 0x19]));
+        return Promise.resolve(Buffer.from([0x01, 0x02, 0x19]));
       }
 
       return Promise.resolve();
@@ -93,8 +93,8 @@ exports['restore.*'] = {
     this.warn = this.sandbox.stub(log, 'warn');
     this.info = this.sandbox.stub(log, 'info');
     this.images = {
-      uboot: new Buffer('uboot'),
-      squashfs: new Buffer('squashfs'),
+      uboot: Buffer.from('uboot'),
+      squashfs: Buffer.from('squashfs'),
     };
     this.status = this.sandbox.stub(restore, 'status').callsFake(() => Promise.resolve(0));
     this.fetchRestore = this.sandbox.stub(updates, 'fetchRestore').callsFake(() => {
@@ -116,7 +116,7 @@ exports['restore.*'] = {
   validateDeviceIdSuccess(test) {
     test.expect(1);
 
-    this.transaction = this.sandbox.stub(restore, 'transaction').callsFake(() => Promise.resolve(new Buffer([0x01, 0x02, 0x19])));
+    this.transaction = this.sandbox.stub(restore, 'transaction').callsFake(() => Promise.resolve(Buffer.from([0x01, 0x02, 0x19])));
 
     restore.validateDeviceId({})
       .then(() => {
@@ -128,7 +128,7 @@ exports['restore.*'] = {
   validateDeviceIdFailure(test) {
     test.expect(1);
 
-    this.transaction = this.sandbox.stub(restore, 'transaction').callsFake(() => Promise.resolve(new Buffer([0x00, 0x00, 0x00])));
+    this.transaction = this.sandbox.stub(restore, 'transaction').callsFake(() => Promise.resolve(Buffer.from([0x00, 0x00, 0x00])));
 
     restore.validateDeviceId({})
       .catch((error) => {
@@ -193,8 +193,8 @@ exports['restore.transaction'] = {
     this.warn = this.sandbox.stub(log, 'warn');
     this.info = this.sandbox.stub(log, 'info');
     this.images = {
-      uboot: new Buffer('uboot'),
-      squashfs: new Buffer('squashfs'),
+      uboot: Buffer.from('uboot'),
+      squashfs: Buffer.from('squashfs'),
     };
     this.status = this.sandbox.stub(restore, 'status').callsFake(() => Promise.resolve(0));
     this.fetchRestore = this.sandbox.stub(updates, 'fetchRestore').callsFake(() => {
@@ -213,9 +213,9 @@ exports['restore.transaction'] = {
     this.usb.epIn.transfer = this.sandbox.spy((data, callback) => {
       callback(null, this.usb.epIn._mockbuffer);
     });
-    this.usb.epIn._mockdata = new Buffer('mockbuffer');
+    this.usb.epIn._mockdata = Buffer.from('mockbuffer');
 
-    this.expectedBuffer = new Buffer([0x00, 0x00, 0x00, 0x00, 0xFF]);
+    this.expectedBuffer = Buffer.from([0x00, 0x00, 0x00, 0x00, 0xFF]);
     done();
   },
 
@@ -248,7 +248,7 @@ exports['restore.transaction'] = {
   transactionAcceptsBuffer(test) {
     test.expect(2);
 
-    restore.transaction(this.usb, new Buffer([0xFF])).then(() => {
+    restore.transaction(this.usb, Buffer.from([0xFF])).then(() => {
       test.equal(this.usb.epOut.transfer.lastCall.args[0].equals(this.expectedBuffer), true);
       test.equal(this.usb.epIn.transfer.callCount, 0);
       test.done();
@@ -382,8 +382,8 @@ exports['restore.flash'] = {
     this.warn = this.sandbox.stub(log, 'warn');
     this.info = this.sandbox.stub(log, 'info');
     this.images = {
-      uboot: new Buffer('uboot'),
-      squashfs: new Buffer('squashfs'),
+      uboot: Buffer.from('uboot'),
+      squashfs: Buffer.from('squashfs'),
     };
     this.partition = this.sandbox.spy(restore, 'partition');
     this.status = this.sandbox.stub(restore, 'status').callsFake(() => Promise.resolve(0));
@@ -402,14 +402,14 @@ exports['restore.flash'] = {
     this.usb.epIn.transfer = this.sandbox.spy((data, callback) => {
       callback(null, this.usb.epIn._mockbuffer);
     });
-    this.usb.epIn._mockdata = new Buffer('mockbuffer');
+    this.usb.epIn._mockdata = Buffer.from('mockbuffer');
 
     this.tessel.usbConnection.device = {
       controlTransfer() {}
     };
 
     this.tick = this.sandbox.stub(Progress.prototype, 'tick');
-    this.expectedBuffer = new Buffer([0x00, 0x00, 0x00, 0x00, 0xFF]);
+    this.expectedBuffer = Buffer.from([0x00, 0x00, 0x00, 0x00, 0xFF]);
     done();
   },
 
@@ -470,8 +470,8 @@ exports['restore.write'] = {
     this.warn = this.sandbox.stub(log, 'warn');
     this.info = this.sandbox.stub(log, 'info');
     this.images = {
-      uboot: new Buffer('uboot'),
-      squashfs: new Buffer('squashfs'),
+      uboot: Buffer.from('uboot'),
+      squashfs: Buffer.from('squashfs'),
     };
     this.writePage = this.sandbox.stub(restore, 'writePage').callsFake(() => Promise.resolve());
     this.waitTransactionComplete = this.sandbox.stub(restore, 'waitTransactionComplete').callsFake(() => Promise.resolve());
@@ -488,7 +488,7 @@ exports['restore.write'] = {
 
     this.tick = this.sandbox.stub(Progress.prototype, 'tick');
 
-    restore.write({}, 0, new Buffer(256)).then(() => {
+    restore.write({}, 0, Buffer.alloc(256)).then(() => {
       test.equal(this.tick.callCount, 1);
       test.equal(this.writePage.callCount, 1);
       test.equal(this.waitTransactionComplete.callCount, 1);

--- a/test/unit/update.js
+++ b/test/unit/update.js
@@ -118,8 +118,8 @@ exports['controller.update'] = {
     });
 
     var binaries = {
-      firmware: new Buffer(0),
-      openwrt: new Buffer(0)
+      firmware: Buffer.alloc(0),
+      openwrt: Buffer.alloc(0)
     };
 
     this.fetchBuild = this.sandbox.stub(updates, 'fetchBuild').callsFake(function() {
@@ -198,8 +198,8 @@ exports['controller.update'] = {
     });
 
     var binaries = {
-      firmware: new Buffer(0),
-      openwrt: new Buffer(0)
+      firmware: Buffer.alloc(0),
+      openwrt: Buffer.alloc(0)
     };
 
     this.fetchBuild = this.sandbox.stub(updates, 'fetchBuild').callsFake(function() {
@@ -250,8 +250,8 @@ exports['controller.update'] = {
     });
 
     var binaries = {
-      firmware: new Buffer(0),
-      openwrt: new Buffer(0)
+      firmware: Buffer.alloc(0),
+      openwrt: Buffer.alloc(0)
     };
 
     this.fetchBuild = this.sandbox.stub(updates, 'fetchBuild').callsFake(function() {
@@ -291,8 +291,8 @@ exports['controller.update'] = {
     });
 
     var binaries = {
-      firmware: new Buffer(0),
-      openwrt: new Buffer(0)
+      firmware: Buffer.alloc(0),
+      openwrt: Buffer.alloc(0)
     };
 
     this.fetchBuild = this.sandbox.stub(updates, 'fetchBuild').callsFake(function() {
@@ -343,8 +343,8 @@ exports['controller.update'] = {
     });
 
     var binaries = {
-      firmware: new Buffer(0),
-      openwrt: new Buffer(0)
+      firmware: Buffer.alloc(0),
+      openwrt: Buffer.alloc(0)
     };
 
     this.fetchBuild = this.sandbox.stub(updates, 'fetchBuild').callsFake(function() {
@@ -390,8 +390,8 @@ exports['controller.update'] = {
     });
 
     var binaries = {
-      firmware: new Buffer(0),
-      openwrt: new Buffer(0)
+      firmware: Buffer.alloc(0),
+      openwrt: Buffer.alloc(0)
     };
 
     this.fetchBuild = this.sandbox.stub(updates, 'fetchBuild').callsFake(function() {
@@ -440,8 +440,8 @@ exports['controller.update'] = {
     });
 
     var binaries = {
-      firmware: new Buffer(0),
-      openwrt: new Buffer(0)
+      firmware: Buffer.alloc(0),
+      openwrt: Buffer.alloc(0)
     };
 
     this.fetchBuild = this.sandbox.stub(updates, 'fetchBuild').callsFake(function() {
@@ -505,8 +505,8 @@ exports['controller.update'] = {
     });
 
     var binaries = {
-      firmware: new Buffer(0),
-      openwrt: new Buffer(0)
+      firmware: Buffer.alloc(0),
+      openwrt: Buffer.alloc(0)
     };
 
     this.fetchBuild = this.sandbox.stub(updates, 'fetchBuild').callsFake(function() {
@@ -551,8 +551,8 @@ exports['controller.update'] = {
     });
 
     var binaries = {
-      firmware: new Buffer(0),
-      openwrt: new Buffer(0)
+      firmware: Buffer.alloc(0),
+      openwrt: Buffer.alloc(0)
     };
 
     this.fetchBuild = this.sandbox.stub(updates, 'fetchBuild').callsFake(function() {
@@ -601,8 +601,8 @@ exports['controller.update'] = {
     });
 
     var binaries = {
-      firmware: new Buffer(0),
-      openwrt: new Buffer(0)
+      firmware: Buffer.alloc(0),
+      openwrt: Buffer.alloc(0)
     };
 
     this.fetchCurrentBuildInfo.restore();
@@ -644,7 +644,7 @@ exports['controller.update'] = {
       end: () => Promise.resolve()
     });
 
-    this.loadLocalBinary = this.sandbox.stub(updates, 'loadLocalBinary').returns(Promise.resolve(new Buffer(0)));
+    this.loadLocalBinary = this.sandbox.stub(updates, 'loadLocalBinary').returns(Promise.resolve(Buffer.alloc(0)));
 
     var opts = {
       lanPrefer: true,
@@ -710,7 +710,7 @@ exports['controller.update'] = {
       end: () => Promise.resolve()
     });
 
-    this.loadLocalBinary = this.sandbox.stub(updates, 'loadLocalBinary').returns(Promise.resolve(new Buffer(0)));
+    this.loadLocalBinary = this.sandbox.stub(updates, 'loadLocalBinary').returns(Promise.resolve(Buffer.alloc(0)));
 
     var opts = {
       lanPrefer: true,
@@ -741,7 +741,7 @@ exports['controller.update'] = {
       end: () => Promise.resolve()
     });
 
-    this.loadLocalBinary = this.sandbox.stub(updates, 'loadLocalBinary').returns(Promise.resolve(new Buffer(0)));
+    this.loadLocalBinary = this.sandbox.stub(updates, 'loadLocalBinary').returns(Promise.resolve(Buffer.alloc(0)));
 
     var opts = {
       lanPrefer: true,
@@ -842,8 +842,8 @@ exports['Tessel.update'] = {
     this.fixOldUpdateScripts = sinon.stub(this.tessel, 'fixOldUpdateScripts').returns(Promise.resolve());
 
     this.newImage = {
-      openwrt: new Buffer(1),
-      firmware: new Buffer(1)
+      openwrt: Buffer.alloc(1),
+      firmware: Buffer.alloc(1)
     };
 
     this.processExit = this.sandbox.stub(process, 'exit');
@@ -863,7 +863,7 @@ exports['Tessel.update'] = {
     this.exec = this.sandbox.stub(this.tessel.connection, 'exec').callsFake((command, handler) => {
       handler(null, this.tessel._rps);
       setImmediate(() => {
-        this.tessel._rps.stdout.emit('data', new Buffer('Upgrade completed'));
+        this.tessel._rps.stdout.emit('data', Buffer.from('Upgrade completed'));
         this.tessel._rps.emit('close');
       });
     });
@@ -889,7 +889,7 @@ exports['Tessel.update'] = {
     this.exec = this.sandbox.stub(this.tessel.connection, 'exec').callsFake((command, handler) => {
       handler(null, this.tessel._rps);
       setImmediate(() => {
-        this.tessel._rps.stdout.emit('data', new Buffer('Upgrade completed'));
+        this.tessel._rps.stdout.emit('data', Buffer.from('Upgrade completed'));
         this.tessel._rps.emit('close');
       });
     });

--- a/test/unit/usb-connection.js
+++ b/test/unit/usb-connection.js
@@ -366,7 +366,7 @@ exports['USB.Connection.prototype._receiveMessages'] = {
 
     this.usbConnection._receiveMessages();
 
-    this.usbConnection.epIn.emit('data', new Buffer([0xff, 0xff]));
+    this.usbConnection.epIn.emit('data', Buffer.from([0xff, 0xff]));
     test.equal(this.usbConnection._readableState.length, 2);
     test.done();
   },

--- a/test/unit/wifi.js
+++ b/test/unit/wifi.js
@@ -232,7 +232,7 @@ exports['Tessel.prototype.findAvailableNetworks'] = {
     this.tessel._rps.on('control', (command) => {
       if (command.toString() === commands.scanWiFi().join(' ')) {
         setImmediate(() => {
-          this.tessel._rps.stderr.emit('data', new Buffer(errorMessage));
+          this.tessel._rps.stderr.emit('data', Buffer.from(errorMessage));
           this.tessel._rps.emit('close');
         });
       } else {
@@ -261,7 +261,7 @@ exports['Tessel.prototype.findAvailableNetworks'] = {
     this.tessel._rps.on('control', (command) => {
       if (command.toString() === commands.scanWiFi().join(' ')) {
         setImmediate(() => {
-          this.tessel._rps.stderr.emit('data', new Buffer('No such wireless device'));
+          this.tessel._rps.stderr.emit('data', Buffer.from('No such wireless device'));
           this.tessel._rps.emit('close');
         });
       } else {
@@ -321,7 +321,7 @@ module.exports['Tessel.prototype.connectToNetwork'] = {
         // Write to stdout so it completes as expected
         // Wrap in setImmediate to make sure listener is set up before emitting
         setImmediate(() => {
-          this.tessel._rps.stdout.emit('data', new Buffer('signal'));
+          this.tessel._rps.stdout.emit('data', Buffer.from('signal'));
           this.tessel._rps.emit('close');
         });
       } else {
@@ -363,7 +363,7 @@ module.exports['Tessel.prototype.connectToNetwork'] = {
         // Write to stdout so it completes as expected
         // Wrap in setImmediate to make sure listener is set up before emitting
         setImmediate(() => {
-          this.tessel._rps.stdout.emit('data', new Buffer('signal'));
+          this.tessel._rps.stdout.emit('data', Buffer.from('signal'));
           this.tessel._rps.emit('close');
         });
       } else {
@@ -408,7 +408,7 @@ module.exports['Tessel.prototype.connectToNetwork'] = {
         // Write to stdout so it completes as expected
         // Wrap in setImmediate to make sure listener is set up before emitting
         setImmediate(() => {
-          this.tessel._rps.stdout.emit('data', new Buffer('signal'));
+          this.tessel._rps.stdout.emit('data', Buffer.from('signal'));
           this.tessel._rps.emit('close');
         });
       } else {
@@ -452,7 +452,7 @@ module.exports['Tessel.prototype.connectToNetwork'] = {
         // Wrap in setImmediate to make sure listener is set up before emitting
         setImmediate(() => {
           // Is missing the "signal" status key
-          this.tessel._rps.stderr.emit('data', new Buffer('Unable to connect to the network.'));
+          this.tessel._rps.stderr.emit('data', Buffer.from('Unable to connect to the network.'));
           this.tessel._rps.emit('close');
         });
       } else {
@@ -497,7 +497,7 @@ module.exports['Tessel.prototype.connectToNetwork'] = {
         // Wrap in setImmediate to make sure listener is set up before emitting
         setImmediate(() => {
           // Is missing the "signal" status key
-          this.tessel._rps.stdout.emit('data', new Buffer('{"frequency": 2422,"txpower": 20}'));
+          this.tessel._rps.stdout.emit('data', Buffer.from('{"frequency": 2422,"txpower": 20}'));
           this.tessel._rps.stdout.removeAllListeners();
           this.tessel._rps.stderr.removeAllListeners();
           this.tessel._rps.emit('close');
@@ -546,9 +546,9 @@ module.exports['Tessel.prototype.connectToNetwork'] = {
         // Wrap in setImmediate to make sure listener is set up before emitting
         setImmediate(() => {
           // First write some random data
-          this.tessel._rps.stdout.emit('data', new Buffer('do not have success yet'));
+          this.tessel._rps.stdout.emit('data', Buffer.from('do not have success yet'));
           // then write the keyword we're looking for for success
-          this.tessel._rps.stdout.emit('data', new Buffer('signal'));
+          this.tessel._rps.stdout.emit('data', Buffer.from('signal'));
           this.tessel._rps.emit('close');
         });
       } else {
@@ -636,7 +636,7 @@ module.exports['Tessel.prototype.setWifiState'] = {
         // Write to stdout so it completes as expected
         // Wrap in setImmediate to make sure listener is set up before emitting
         setImmediate(() => {
-          this.tessel._rps.stdout.emit('data', new Buffer('signal'));
+          this.tessel._rps.stdout.emit('data', Buffer.from('signal'));
           this.tessel._rps.emit('close');
         });
       } else {
@@ -677,7 +677,7 @@ module.exports['Tessel.prototype.setWifiState'] = {
         // Write to stdout so it completes as expected
         // Wrap in setImmediate to make sure listener is set up before emitting
         setImmediate(() => {
-          this.tessel._rps.stdout.emit('data', new Buffer('signal'));
+          this.tessel._rps.stdout.emit('data', Buffer.from('signal'));
           this.tessel._rps.emit('close');
         });
       } else {
@@ -718,12 +718,12 @@ module.exports['Tessel.prototype.setWifiState'] = {
         // Write to stdout so it completes as expected
         // Wrap in setImmediate to make sure listener is set up before emitting
         setImmediate(() => {
-          this.tessel._rps.stdout.emit('data', new Buffer('signal'));
+          this.tessel._rps.stdout.emit('data', Buffer.from('signal'));
           this.tessel._rps.emit('close');
         });
       } else if (command.toString() === 'wifi') {
         setImmediate(() => {
-          this.tessel._rps.stdout.emit('data', new Buffer(`'radio0' is disabled`));
+          this.tessel._rps.stdout.emit('data', Buffer.from(`'radio0' is disabled`));
           this.tessel._rps.emit('close');
         });
       } else {
@@ -765,12 +765,12 @@ module.exports['Tessel.prototype.setWifiState'] = {
         // Write to stdout so it completes as expected
         // Wrap in setImmediate to make sure listener is set up before emitting
         setImmediate(() => {
-          this.tessel._rps.stdout.emit('data', new Buffer('signal'));
+          this.tessel._rps.stdout.emit('data', Buffer.from('signal'));
           this.tessel._rps.emit('close');
         });
       } else if (command.toString() === 'wifi') {
         setImmediate(() => {
-          this.tessel._rps.stdout.emit('data', new Buffer(`Some other error`));
+          this.tessel._rps.stdout.emit('data', Buffer.from(`Some other error`));
           this.tessel._rps.emit('close');
         });
       } else {
@@ -809,7 +809,7 @@ module.exports['Tessel.prototype.setWifiState'] = {
         // Write to stderr so it completes as expected
         // Wrap in setImmediate to make sure listener is set up before emitting
         setImmediate(() => {
-          this.tessel._rps.stderr.emit('data', new Buffer('Not found'));
+          this.tessel._rps.stderr.emit('data', Buffer.from('Not found'));
           this.tessel._rps.stderr.removeAllListeners();
           this.tessel._rps.stdout.removeAllListeners();
           this.tessel._rps.emit('close');
@@ -914,7 +914,7 @@ module.exports['Tessel.getWifiInfo'] = {
         // Write to stdout so it completes as expected
         // Wrap in setImmediate to make sure listener is set up before emitting
         setImmediate(() => {
-          this.tessel._rps.stdout.emit('data', new Buffer(JSON.stringify({
+          this.tessel._rps.stdout.emit('data', Buffer.from(JSON.stringify({
             ssid: ssid
           })));
           this.tessel._rps.emit('close');
@@ -923,7 +923,7 @@ module.exports['Tessel.getWifiInfo'] = {
         // Write to stdout so it completes as expected
         // Wrap in setImmediate to make sure listener is set up before emitting
         setImmediate(() => {
-          this.tessel._rps.stdout.emit('data', new Buffer(ip));
+          this.tessel._rps.stdout.emit('data', Buffer.from(ip));
           this.tessel._rps.emit('close');
         });
       } else {
@@ -954,7 +954,7 @@ module.exports['Tessel.getWifiInfo'] = {
     this.tessel._rps.on('control', (command) => {
       if (command.toString() === commands.getWifiInfo().join(' ')) {
         setImmediate(() => {
-          this.tessel._rps.stdout.emit('data', new Buffer(JSON.stringify({
+          this.tessel._rps.stdout.emit('data', Buffer.from(JSON.stringify({
             noSSID: 'testing'
           })));
           this.tessel._rps.emit('close');
@@ -986,7 +986,7 @@ module.exports['Tessel.getWifiInfo'] = {
     this.tessel._rps.on('control', (command) => {
       if (command.toString() === commands.getWifiInfo().join(' ')) {
         setImmediate(() => {
-          this.tessel._rps.stdout.emit('data', new Buffer('Not JSON'));
+          this.tessel._rps.stdout.emit('data', Buffer.from('Not JSON'));
           this.tessel._rps.emit('close');
         });
       } else {
@@ -1019,7 +1019,7 @@ module.exports['Tessel.getWifiInfo'] = {
         // Write to stdout so it completes as expected
         // Wrap in setImmediate to make sure listener is set up before emitting
         setImmediate(() => {
-          this.tessel._rps.stderr.emit('data', new Buffer('Command: Not found.'));
+          this.tessel._rps.stderr.emit('data', Buffer.from('Command: Not found.'));
           this.tessel._rps.emit('close');
         });
       } else {
@@ -1052,7 +1052,7 @@ module.exports['Tessel.getWifiInfo'] = {
         // Write to stdout so it completes as expected
         // Wrap in setImmediate to make sure listener is set up before emitting
         setImmediate(() => {
-          this.tessel._rps.stderr.emit('data', new Buffer('Unknown error'));
+          this.tessel._rps.stderr.emit('data', Buffer.from('Unknown error'));
           this.tessel._rps.emit('close');
         });
       } else {


### PR DESCRIPTION
```
$ node -v
v10.13.0
...
$ t2 run index.js
INFO Looking for your Tessel...
(node:27867) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```

After migrating these warnings disappear. 